### PR TITLE
Fix cache collision that results in an app crash

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.9.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="5.9.1" />
-    <PackageReference Include="PrettyPrompt" Version="0.9.3" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.4" />
   </ItemGroup>
 
 </Project>

--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -16,6 +16,7 @@ namespace CSharpRepl.Services.Completion
 
     class AutoCompleteService
     {
+        private const string CacheKeyPrefix = "AutoCompleteService_";
         private readonly IMemoryCache cache;
 
         public AutoCompleteService(IMemoryCache cache)
@@ -25,7 +26,8 @@ namespace CSharpRepl.Services.Completion
 
         public async Task<CompletionItemWithDescription[]> Complete(Document document, string text, int caret)
         {
-            if (text != string.Empty && cache.Get<CompletionItemWithDescription[]>(text + caret) is CompletionItemWithDescription[] cached)
+            var cacheKey = CacheKeyPrefix + text + caret;
+            if (text != string.Empty && cache.Get<CompletionItemWithDescription[]>(cacheKey) is CompletionItemWithDescription[] cached)
                 return cached;
 
             var completions = await CompletionService.GetService(document).GetCompletionsAsync(document, caret).ConfigureAwait(false);
@@ -45,7 +47,7 @@ namespace CSharpRepl.Services.Completion
                 ??
                 Array.Empty<CompletionItemWithDescription>();
 
-            cache.Set(text + caret, completionsWithDescriptions, DateTimeOffset.Now.AddMinutes(1));
+            cache.Set(cacheKey, completionsWithDescriptions, DateTimeOffset.Now.AddMinutes(1));
 
             return completionsWithDescriptions;
         }

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -23,6 +23,7 @@ namespace CSharpRepl.Services.SyntaxHighlighting
     /// </summary>
     class SyntaxHighlighter
     {
+        private const string CacheKeyPrefix = "SyntaxHighlighter_";
         private readonly IReadOnlyDictionary<string, AnsiColor> theme;
         private readonly AnsiColor unhighlightedColor;
         private readonly IReadOnlyDictionary<string, AnsiColor> ansiColorNames;
@@ -82,7 +83,8 @@ namespace CSharpRepl.Services.SyntaxHighlighting
         internal async Task<IReadOnlyCollection<HighlightedSpan>> HighlightAsync(Document document)
         {
             var text = (await document.GetTextAsync()).ToString().Trim();
-            if (this.cache.Get<IReadOnlyCollection<HighlightedSpan>>(text) is IReadOnlyCollection<HighlightedSpan> spans)
+            var cacheKey = CacheKeyPrefix + text;
+            if (this.cache.Get<IReadOnlyCollection<HighlightedSpan>>(cacheKey) is IReadOnlyCollection<HighlightedSpan> spans)
                 return spans;
 
             var classified = await Classifier.GetClassifiedSpansAsync(document, TextSpan.FromBounds(0, text.Length)).ConfigureAwait(false);
@@ -100,7 +102,7 @@ namespace CSharpRepl.Services.SyntaxHighlighting
                 })
                 .ToList();
 
-            this.cache.Set(text, highlighted, DateTimeOffset.Now.AddMinutes(1));
+            this.cache.Set(cacheKey, highlighted, DateTimeOffset.Now.AddMinutes(1));
 
             return highlighted;
         }

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="PrettyPrompt" Version="0.9.3" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -40,5 +40,20 @@ namespace CSharpRepl.Tests
             var writeLineDescription = await writelines[1].DescriptionProvider.Value;
             Assert.Contains("Writes the current line terminator to the standard output", writeLineDescription);
         }
+
+        /// <remarks>https://github.com/waf/CSharpRepl/issues/4</remarks>
+        [Fact]
+        public async Task Complete_SyntaxHighlight_CachesAreIsolated()
+        {
+            // type "c" which triggers completion at index 1, and is cached
+            var completions = await this.services.Complete("c", 1);
+
+            // next, type the number 1, which could collide with the previous cached value if the caches
+            // aren't isolated, resulting in an exception
+            var highlights = await this.services.SyntaxHighlightAsync("c1");
+
+            Assert.NotEmpty(completions);
+            Assert.NotEmpty(highlights);
+        }
     }
 }

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="0.9.3" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The AutoCompleteService and the SyntaxHighlighter both use the same cache, and it was possible that they'd generate the same cache key for certain inputs, but with different cached values.

This results in a fatal exception / app crash. The fix is to use a separate cache prefix to keep the values isolated.

closes #4