### PR TITLE
Support running on preview versions of .NET

### DIFF
--- a/CSharpRepl.Services/Roslyn/ReferenceAssemblyService.cs
+++ b/CSharpRepl.Services/Roslyn/ReferenceAssemblyService.cs
@@ -150,7 +150,11 @@ namespace CSharpRepl.Services.Roslyn
             var configuredFramework = currentFrameworkPath.Replace(SharedFramework.NetCoreApp, framework);
             var configuredFrameworkAndVersion = Directory
                 .GetDirectories(configuredFramework, version + "*")
-                .OrderBy(path => new Version(Path.GetFileName(path)))
+                .OrderBy(path =>
+                {
+                    var versionString = Path.GetFileName(path).Split('-', 2).First(); // discard trailing preview versions, e.g. 6.0.0-preview.4.21253.7 
+                    return new Version(versionString);
+                })
                 .Last();
 
             return configuredFrameworkAndVersion;


### PR DESCRIPTION
When we're determining the shared framework implementation paths, we parse the version number to a `System.Diagnostics.CodeAnalysis.Version` so we can choose the latest point release (so e.g. 5.0.10 comes after 5.0.9, which wouldn't be the case for normal string sorting). However, for preview versions of .NET, the version string has a trailing identifier, e.g. `6.0.0-preview.4.21253.7`, which causes `System.Diagnostics.CodeAnalysis.Version` to throw.

Note, unit tests were failing when targeting `net6.0`; this fixes them all.

fixes #8