### PR TITLE
Support for passing global "args" from the command line

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
 using System.Collections.Generic;
 
 namespace CSharpRepl.Services
@@ -20,6 +21,7 @@ namespace CSharpRepl.Services
         public string Theme { get; set; }
         public string ResponseFile { get; set; }
         public string LoadScript { get; set; }
+        public string[] LoadScriptArgs { get; set; } = Array.Empty<string>();
 
         public bool ShowVersionAndExit { get; set; }
         public bool ShowHelpAndExit { get; set; }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Nuget;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using PrettyPrompt.Consoles;

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -57,12 +57,12 @@ namespace CSharpRepl.Services.Roslyn
             initialization.ContinueWith(task => console.WriteErrorLine(task.Exception.Message), TaskContinuationOptions.OnlyOnFaulted);
         }
 
-        public async Task<EvaluationResult> Evaluate(string input, CancellationToken cancellationToken = default)
+        public async Task<EvaluationResult> Evaluate(string input, string[] args = null, CancellationToken cancellationToken = default)
         {
             await initialization.ConfigureAwait(false);
 
             var result = await scriptRunner
-                .RunCompilation(input.Trim(), cancellationToken)
+                .RunCompilation(input.Trim(), args, cancellationToken)
                 .ConfigureAwait(false);
 
             if (result is EvaluationResult.Success success)
@@ -124,12 +124,12 @@ namespace CSharpRepl.Services.Roslyn
         /// Roslyn services can be a bit slow to initialize the first time they're executed.
         /// Warm them up in the background so it doesn't affect the user.
         /// </summary>
-        public Task WarmUpAsync() =>
+        public Task WarmUpAsync(string[] args) =>
             Task.Run(async () =>
             {
                 await initialization.ConfigureAwait(false);
                 await Task.WhenAll(
-                    Evaluate(@"_ = ""REPL Warmup""", CancellationToken.None),
+                    Evaluate(@"_ = ""REPL Warmup""", args),
                     SyntaxHighlightAsync(@"_ = ""REPL Warmup"""),
                     Task.WhenAny((await Complete(@"C", 1)).Select(completion => completion.DescriptionProvider.Value))
                 ).ConfigureAwait(false);

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -105,6 +105,19 @@ namespace CSharpRepl.Tests
             Assert.Equal(new[] { "System", "System.ValueTuple.dll", "Foo.Main.Logic.dll", "lib.dll" }, result.References);
         }
 
+        [Fact]
+        public void ParseArguments_TrailingArgumentsAfterDoubleDash_SetAsLoadScriptArgs()
+        {
+            var csxResult = CommandLine.ParseArguments(new[] { "Data/LoadScript.csx", "--", "Data/LoadScript.csx" });
+            // load script filename passed before "--" is a load script, after "--" we just pass it to the load script as an arg.
+            Assert.Equal(new[] { "Data/LoadScript.csx" }, csxResult.LoadScriptArgs);
+            Assert.Equal(@"Console.WriteLine(""Hello World!"");", csxResult.LoadScript);
+
+            var quotedResult = CommandLine.ParseArguments(new[] { "-r", "Foo.dll", "--", @"""a b c""", @"""d e f""" });
+            Assert.Equal(new[] { @"""a b c""", @"""d e f""" }, quotedResult.LoadScriptArgs);
+            Assert.Equal(new[] { @"Foo.dll" }, quotedResult.References);
+        }
+
         private static Configuration Parse(string commandline) =>
             CommandLine.ParseArguments(commandline?.Split(' ') ?? Array.Empty<string>());
     }

--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -4,6 +4,7 @@
 
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,7 +22,7 @@ namespace CSharpRepl.Tests
             this.services = new RoslynServices(console, new Configuration());
         }
 
-        public Task InitializeAsync() => services.WarmUpAsync();
+        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -4,6 +4,7 @@
 
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace CSharpRepl.Tests
             this.stdout = stdout;
         }
 
-        public Task InitializeAsync() => services.WarmUpAsync();
+        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -1,0 +1,27 @@
+﻿using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpRepl.Tests
+{
+    [Collection(nameof(RoslynServices))]
+    public class ScriptArgumentTests
+    {
+        [Fact]
+        public async Task Evaluate_WithArguments_ArgumentsAvailable()
+        {
+            var (console, _) = FakeConsole.CreateStubbedOutput();
+            var services = new RoslynServices(console, new Configuration());
+            var args = new[] { "Howdy" };
+
+            await services.WarmUpAsync(args);
+            var variableAssignment = await services.Evaluate(@"var x = args[0];");
+            var variableUsage = await services.Evaluate(@"x");
+
+            Assert.IsType<EvaluationResult.Success>(variableAssignment);
+            var usage = Assert.IsType<EvaluationResult.Success>(variableUsage);
+            Assert.Equal("Howdy", usage.ReturnValue);
+        }
+    }
+}

--- a/CSharpRepl.Tests/SymbolExplorerTests.cs
+++ b/CSharpRepl.Tests/SymbolExplorerTests.cs
@@ -4,6 +4,7 @@
 
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace CSharpRepl.Tests
             this.services = new RoslynServices(console, new Configuration());
         }
 
-        public Task InitializeAsync() => this.services.WarmUpAsync();
+        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/CSharpRepl.Tests/SyntaxHighlightingTests.cs
+++ b/CSharpRepl.Tests/SyntaxHighlightingTests.cs
@@ -8,6 +8,7 @@ using CSharpRepl.Services.Roslyn;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using System;
 
 namespace CSharpRepl.Tests
 {
@@ -25,7 +26,7 @@ namespace CSharpRepl.Tests
             });
         }
 
-        public Task InitializeAsync() => this.services.WarmUpAsync();
+        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]


### PR DESCRIPTION
This adds support for passing command line arguments to CSX files and the scripting session. Arguments are provided after a double dash (e.g. "--"), and these arguments are available in a global `string[] args` variable.

Example usage:

```
csharprepl my-file.csx -- argA argB argC
```

Fixes #12