### PR TITLE
Add support for IList<string> args and Print function

### DIFF
--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Caching.Memory;
 using PrettyPrompt.Consoles;
 using System.Diagnostics.CodeAnalysis;
 using CSharpRepl.Services.Roslyn.References;
+using CSharpRepl.Services.Roslyn.Scripting;
 
 namespace CSharpRepl.Services.Roslyn
 {

--- a/CSharpRepl.Services/Roslyn/Scripting/EvaluationResult.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/EvaluationResult.cs
@@ -1,0 +1,18 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+
+namespace CSharpRepl.Services.Roslyn.Scripting
+{
+    /// <remarks>about as close to a discriminated union as I can get</remarks>
+    public abstract record EvaluationResult
+    {
+        public sealed record Success(string Input, object ReturnValue, IReadOnlyCollection<MetadataReference> References) : EvaluationResult;
+        public sealed record Error(Exception Exception) : EvaluationResult;
+        public sealed record Cancelled() : EvaluationResult;
+    }
+}

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
@@ -1,0 +1,47 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using PrettyPrompt.Consoles;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
+
+namespace CSharpRepl.Services.Roslyn.Scripting
+{
+    /// <summary>
+    /// Defines variables that are available in the C# Script environment.
+    /// </summary>
+    /// <remarks>Must be public so it can be referenced by the script</remarks>
+    public sealed class ScriptGlobals
+    {
+        private readonly IConsole console;
+
+        public ScriptGlobals(IConsole console, string[] args)
+        {
+            this.console = console;
+            this.args = args;
+            this.Args = new List<string>(args);
+        }
+
+        #pragma warning disable IDE1006 // Naming Styles
+        /// <summary>
+        /// Arguments provided at the command line after a double dash.
+        /// This naming convention matches top-level programs and Main method conventions.
+        /// </summary>
+        public string[] args { get; set; }
+        #pragma warning restore IDE1006 // Naming Styles
+
+        /// <summary>
+        /// Arguments provided at the command line after a double dash.
+        /// This naming convention matches csi, dotnet-script, etc.
+        /// </summary>
+        public IList<string> Args { get; set; }
+
+        /// <summary>
+        /// Pretty-print a c# object. While not so useful in a REPL, where results
+        /// are pretty-printed by default, it's useful in CSX scripts.
+        /// </summary>
+        public void Print(object value) =>
+            console.WriteLine(CSharpObjectFormatter.Instance.FormatObject(value));
+    }
+}

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using CSharpRepl.Services.Roslyn.References;
+using CSharpRepl.Services.Roslyn.Scripting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -4,6 +4,7 @@
 
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
 using System;
 using System.IO;
 using System.Linq;

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -1,5 +1,7 @@
 ﻿using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -8,20 +10,35 @@ namespace CSharpRepl.Tests
     [Collection(nameof(RoslynServices))]
     public class ScriptArgumentTests
     {
-        [Fact]
-        public async Task Evaluate_WithArguments_ArgumentsAvailable()
+        [Theory]
+        [InlineData("args[0]")] // array accessor
+        [InlineData("Args[0]")] // IList<string> accessor
+        public async Task Evaluate_WithArguments_ArgumentsAvailable(string argsAccessor)
         {
             var (console, _) = FakeConsole.CreateStubbedOutput();
             var services = new RoslynServices(console, new Configuration());
             var args = new[] { "Howdy" };
 
             await services.WarmUpAsync(args);
-            var variableAssignment = await services.Evaluate(@"var x = args[0];");
+            var variableAssignment = await services.Evaluate($@"var x = {argsAccessor};");
             var variableUsage = await services.Evaluate(@"x");
 
             Assert.IsType<EvaluationResult.Success>(variableAssignment);
             var usage = Assert.IsType<EvaluationResult.Success>(variableUsage);
             Assert.Equal("Howdy", usage.ReturnValue);
+        }
+
+        [Fact]
+        public async Task Evaluate_PrettyPrint_PrintsPrettily()
+        {
+            var (console, stdOut) = FakeConsole.CreateStubbedOutput();
+            var services = new RoslynServices(console, new Configuration());
+
+            await services.WarmUpAsync(Array.Empty<string>());
+            var printStatement = await services.Evaluate("Print(DateTime.MinValue)");
+
+            Assert.IsType<EvaluationResult.Success>(printStatement);
+            Assert.Equal("[1/1/0001 12:00:00 AM]" + Environment.NewLine, stdOut.ToString());
         }
     }
 }

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -11,6 +11,7 @@ using CSharpRepl.Prompt;
 using CSharpRepl.Services;
 using PrettyPrompt;
 using System.Linq;
+using CSharpRepl.Services.Roslyn.Scripting;
 
 namespace CSharpRepl
 {
@@ -38,7 +39,7 @@ namespace CSharpRepl
                 return;
             }
 
-            await RunPrompt(console, config).ConfigureAwait(false);
+            await ReadEvalPrintLoop(console, config).ConfigureAwait(false);
         }
 
         private static Configuration? ParseArguments(string[] args)
@@ -58,7 +59,7 @@ namespace CSharpRepl
             }
         }
 
-        private static async Task RunPrompt(IConsole console, Configuration config)
+        private static async Task ReadEvalPrintLoop(IConsole console, Configuration config)
         {
             // these are required to run before displaying the welcome text.
             // `roslyn` is required for the syntax highlighting in the text,
@@ -79,7 +80,12 @@ namespace CSharpRepl
                 if (response.IsSuccess)
                 {
                     if (response.Text == "exit") { break; }
-                    if (response.Text == "help" || response.Text == "?") { PrintHelp(console); continue; }
+
+                    if (new[] { "help", "#help", "?" }.Contains(response.Text.ToLowerInvariant()))
+                    {
+                        PrintHelp(console);
+                        continue;
+                    }
 
                     var result = await roslyn
                         .Evaluate(response.Text, config.LoadScriptArgs, response.CancellationToken)


### PR DESCRIPTION
Makes csharprepl more compatible with csi and dotnet-script, while still maintaining compatibility with top-level programs and Main methods.

Adds an `IList<string> Args` property and a `void Print(object)` method, to match other script host implementations. We still have the `string[] args` as well.