### PR TITLE
Refactor logic out of Program.cs, fix some NDepend warnings

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.10.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="5.10.0" />
-    <PackageReference Include="PrettyPrompt" Version="0.9.6" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -14,7 +14,7 @@ namespace CSharpRepl.Services.Completion
 {
     public record CompletionItemWithDescription(CompletionItem Item, Lazy<Task<string>> DescriptionProvider);
 
-    class AutoCompleteService
+    internal sealed class AutoCompleteService
     {
         private const string CacheKeyPrefix = "AutoCompleteService_";
         private readonly IMemoryCache cache;

--- a/CSharpRepl.Services/Extensions/LinqExtensions.cs
+++ b/CSharpRepl.Services/Extensions/LinqExtensions.cs
@@ -1,0 +1,18 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CSharpRepl.Services.Extensions
+{
+    internal static class LinqExtensions
+    {
+        // purely for nullable reference type analysis
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
+        {
+            return source.Where(x => x != null)!;
+        }
+    }
+}

--- a/CSharpRepl.Services/Extensions/RoslynExtensions.cs
+++ b/CSharpRepl.Services/Extensions/RoslynExtensions.cs
@@ -4,12 +4,10 @@
 
 using Microsoft.CodeAnalysis;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
-namespace CSharpRepl.Services.Roslyn
+namespace CSharpRepl.Services.Extensions
 {
-    internal static class Extensions
+    internal static class RoslynExtensions
     {
         public static Solution ApplyChanges(this Solution edit, Workspace workspace)
         {
@@ -18,12 +16,6 @@ namespace CSharpRepl.Services.Roslyn
                 throw new InvalidOperationException("Failed to apply edit to workspace");
             }
             return workspace.CurrentSolution;
-        }
-
-        // purely for nullable reference type analysis
-        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
-        {
-            return source.Where(x => x != null)!;
         }
     }
 }

--- a/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
+++ b/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using CSharpRepl.Services.Extensions;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Concurrent;
@@ -21,7 +22,7 @@ namespace CSharpRepl.Services.Roslyn.References
     /// <remarks>
     /// Useful notes https://github.com/dotnet/roslyn/blob/main/docs/wiki/Runtime-code-generation-using-Roslyn-compilations-in-.NET-Core-App.md
     /// </remarks>
-    class AssemblyReferenceService
+    internal sealed class AssemblyReferenceService
     {
         private readonly ConcurrentDictionary<string, MetadataReference> cachedMetadataReferences;
         private readonly HashSet<MetadataReference> loadedReferenceAssemblies;

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using Microsoft.CodeAnalysis;

--- a/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
+++ b/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
@@ -33,7 +33,7 @@ namespace CSharpRepl.Services.SymbolExploration
             );
         }
 
-        public async Task<SymbolResult> GetSymbolAtPosition(Document document, int position)
+        public async Task<SymbolResult> GetSymbolAtPositionAsync(Document document, int position)
         {
             var semanticModel = await document.GetSemanticModelAsync();
             if (semanticModel is null) return SymbolResult.Unknown;

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="PrettyPrompt" Version="0.9.6" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CSharpRepl.Tests/CompleteStatementTests.cs
+++ b/CSharpRepl.Tests/CompleteStatementTests.cs
@@ -28,7 +28,7 @@ namespace CSharpRepl.Tests
         [InlineData("if you're happy and you know it, syntax error!", false)]
         public async Task IsCompleteStatement(string code, bool shouldBeCompleteStatement)
         {
-            bool isCompleteStatement = await services.IsTextCompleteStatement(code);
+            bool isCompleteStatement = await services.IsTextCompleteStatementAsync(code);
             Assert.Equal(shouldBeCompleteStatement, isCompleteStatement);
         }
     }

--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -28,7 +28,7 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Complete_GivenCode_ReturnsCompletions()
         {
-            var completions = await this.services.Complete("Console.Writ", 12);
+            var completions = await this.services.CompleteAsync("Console.Writ", 12);
             var writelines = completions
                 .Where(c => c.Item.DisplayText.StartsWith("Write"))
                 .ToList();
@@ -46,7 +46,7 @@ namespace CSharpRepl.Tests
         public async Task Complete_GivenLinq_ReturnsCompletions()
         {
             // LINQ tends to be a good canary for whether or not our reference / implementation assemblies are correct.
-            var completions = await this.services.Complete("new[] { 1, 2, 3 }.Wher", 21);
+            var completions = await this.services.CompleteAsync("new[] { 1, 2, 3 }.Wher", 21);
 
             var whereCompletion = completions.SingleOrDefault(c => c.Item.DisplayText.StartsWith("Where"));
 
@@ -62,7 +62,7 @@ namespace CSharpRepl.Tests
         public async Task Complete_SyntaxHighlight_CachesAreIsolated()
         {
             // type "c" which triggers completion at index 1, and is cached
-            var completions = await this.services.Complete("c", 1);
+            var completions = await this.services.CompleteAsync("c", 1);
 
             // next, type the number 1, which could collide with the previous cached value if the caches
             // aren't isolated, resulting in an exception

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -33,7 +33,7 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_LiteralInteger_ReturnsInteger()
         {
-            var result = await services.Evaluate("5");
+            var result = await services.EvaluateAsync("5");
 
             var success = Assert.IsType<EvaluationResult.Success>(result);
             Assert.Equal("5", success.Input);
@@ -45,8 +45,8 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_Variable_ReturnsValue()
         {
-            var variableAssignment = await services.Evaluate(@"var x = ""Hello World"";");
-            var variableUsage = await services.Evaluate(@"x.Replace(""World"", ""Mundo"")");
+            var variableAssignment = await services.EvaluateAsync(@"var x = ""Hello World"";");
+            var variableUsage = await services.EvaluateAsync(@"x.Replace(""World"", ""Mundo"")");
 
             var assignment = Assert.IsType<EvaluationResult.Success>(variableAssignment);
             var usage = Assert.IsType<EvaluationResult.Success>(variableUsage);
@@ -57,8 +57,8 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_NugetPackage_InstallsPackage()
         {
-            var installation = await services.Evaluate(@"#r ""nuget:Newtonsoft.Json""");
-            var usage = await services.Evaluate(@"Newtonsoft.Json.JsonConvert.SerializeObject(new { Foo = ""bar"" })");
+            var installation = await services.EvaluateAsync(@"#r ""nuget:Newtonsoft.Json""");
+            var usage = await services.EvaluateAsync(@"Newtonsoft.Json.JsonConvert.SerializeObject(new { Foo = ""bar"" })");
 
             var installationResult = Assert.IsType<EvaluationResult.Success>(installation);
             var usageResult = Assert.IsType<EvaluationResult.Success>(usage);
@@ -72,8 +72,8 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_NugetPackageVersioned_InstallsPackageVersion()
         {
-            var installation = await services.Evaluate(@"#r ""nuget:Newtonsoft.Json, 12.0.1""");
-            var usage = await services.Evaluate(@"Newtonsoft.Json.JsonConvert.SerializeObject(new { Foo = ""bar"" })");
+            var installation = await services.EvaluateAsync(@"#r ""nuget:Newtonsoft.Json, 12.0.1""");
+            var usage = await services.EvaluateAsync(@"Newtonsoft.Json.JsonConvert.SerializeObject(new { Foo = ""bar"" })");
 
             var installationResult = Assert.IsType<EvaluationResult.Success>(installation);
             var usageResult = Assert.IsType<EvaluationResult.Success>(usage);
@@ -87,9 +87,9 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_RelativeAssemblyReference_CanReferenceAssembly()
         {
-            var referenceResult = await services.Evaluate(@"#r ""./Data/DemoLibrary.dll""");
-            var importResult = await services.Evaluate("using DemoLibrary;");
-            var multiplyResult = await services.Evaluate("DemoClass.Multiply(5, 6)");
+            var referenceResult = await services.EvaluateAsync(@"#r ""./Data/DemoLibrary.dll""");
+            var importResult = await services.EvaluateAsync("using DemoLibrary;");
+            var multiplyResult = await services.EvaluateAsync("DemoClass.Multiply(5, 6)");
 
             Assert.IsType<EvaluationResult.Success>(referenceResult);
             Assert.IsType<EvaluationResult.Success>(importResult);
@@ -101,9 +101,9 @@ namespace CSharpRepl.Tests
         public async Task Evaluate_AbsoluteAssemblyReference_CanReferenceAssembly()
         {
             var absolutePath = Path.GetFullPath("./Data/DemoLibrary.dll");
-            var referenceResult = await services.Evaluate(@$"#r ""{absolutePath}""");
-            var importResult = await services.Evaluate("using DemoLibrary;");
-            var multiplyResult = await services.Evaluate("DemoClass.Multiply(7, 6)");
+            var referenceResult = await services.EvaluateAsync(@$"#r ""{absolutePath}""");
+            var importResult = await services.EvaluateAsync("using DemoLibrary;");
+            var multiplyResult = await services.EvaluateAsync("DemoClass.Multiply(7, 6)");
 
             Assert.IsType<EvaluationResult.Success>(referenceResult);
             Assert.IsType<EvaluationResult.Success>(importResult);
@@ -114,7 +114,7 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_AssemblyReferenceInSearchPath_CanReferenceAssembly()
         {
-            var referenceResult = await services.Evaluate(@"#r ""System.Linq.dll""");
+            var referenceResult = await services.EvaluateAsync(@"#r ""System.Linq.dll""");
 
             Assert.IsType<EvaluationResult.Success>(referenceResult);
         }
@@ -122,23 +122,23 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task Evaluate_AssemblyReferenceWithSharedFramework_ReferencesSharedFramework()
         {
-            var referenceResult = await services.Evaluate(@"#r ""./Data/WebApplication1.dll""");
-            var sharedFrameworkResult = await services.Evaluate(@"using Microsoft.AspNetCore.Hosting;");
-            var applicationResult = await services.Evaluate(@"using WebApplication1;");
+            var referenceResult = await services.EvaluateAsync(@"#r ""./Data/WebApplication1.dll""");
+            var sharedFrameworkResult = await services.EvaluateAsync(@"using Microsoft.AspNetCore.Hosting;");
+            var applicationResult = await services.EvaluateAsync(@"using WebApplication1;");
 
             Assert.IsType<EvaluationResult.Success>(referenceResult);
             Assert.IsType<EvaluationResult.Success>(sharedFrameworkResult);
             Assert.IsType<EvaluationResult.Success>(applicationResult);
 
-            var completions = await services.Complete(@"using WebApplicat", 17);
+            var completions = await services.CompleteAsync(@"using WebApplicat", 17);
             Assert.Contains("WebApplication1", completions.Select(c => c.Item.DisplayText).First(text => text.StartsWith("WebApplicat")));
         }
 
         [Fact]
         public async Task Evaluate_ProjectReference_ReferencesProject()
         {
-            var referenceResult = await services.Evaluate(@"#r ""./../../../../CSharpRepl.Services/CSharpRepl.Services.csproj""");
-            var importResult = await services.Evaluate(@"using CSharpRepl.Services;");
+            var referenceResult = await services.EvaluateAsync(@"#r ""./../../../../CSharpRepl.Services/CSharpRepl.Services.csproj""");
+            var importResult = await services.EvaluateAsync(@"using CSharpRepl.Services;");
 
             Assert.IsType<EvaluationResult.Success>(referenceResult);
             Assert.IsType<EvaluationResult.Success>(importResult);

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -1,0 +1,135 @@
+﻿using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using NSubstitute;
+using PrettyPrompt;
+using PrettyPrompt.Consoles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpRepl.Tests
+{
+    [Collection(nameof(RoslynServices))]
+    public class ReadEvalPrintLoopTests : IAsyncLifetime
+    {
+        private readonly ReadEvalPrintLoop repl;
+        private readonly IConsole console;
+        private readonly IPrompt prompt;
+        private readonly RoslynServices services;
+
+        public ReadEvalPrintLoopTests()
+        {
+            this.console = Substitute.For<IConsole>();
+            this.prompt = Substitute.For<IPrompt>();
+            this.services = new RoslynServices(console, new Configuration());
+            this.repl = new ReadEvalPrintLoop(services, prompt, console);
+        }
+
+        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        [Theory]
+        [InlineData("help")]
+        [InlineData("#help")]
+        [InlineData("?")]
+        public async Task RunAsync_HelpCommand_ShowsHelp(string help)
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, help, false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration());
+
+            console.Received().WriteLine(Arg.Is<string>(str => str.Contains("Welcome to the C# REPL")));
+            console.Received().WriteLine(Arg.Is<string>(str => str.Contains("Type C# at the prompt and press Enter to run it.")));
+        }
+
+        [Fact]
+        public async Task RunAsync_ClearCommand_ClearsScreen()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, @"""foobar""", false),
+                    new PromptResult(true, "clear", false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration());
+
+            console.Received().Clear();
+        }
+
+        [Fact]
+        public async Task RunAsync_EvaluateCode_ReturnsResult()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, "5 + 3", false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration());
+
+            console.Received().WriteLine("8");
+        }
+
+        [Fact]
+        public async Task RunAsync_LoadScript_RunsScript()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, "x", false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration
+            {
+                LoadScript = @"var x = ""Hello World"";"
+            });
+
+            console.Received().WriteLine(@"""Hello World""");
+        }
+
+        [Fact]
+        public async Task RunAsync_Reference_AddsReference()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, "DemoLibrary.DemoClass.Multiply(5, 6)", false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration
+            {
+                References = { "Data/DemoLibrary.dll" }
+            });
+
+            console.Received().WriteLine("30");
+        }
+
+        [Fact]
+        public async Task RunAsync_Exception_ShowsMessage()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new PromptResult(true, @"throw new InvalidOperationException(""bonk!"");", false),
+                    new PromptResult(true, "exit", false)
+                );
+
+            await repl.RunAsync(new Configuration());
+
+            console.Received().WriteErrorLine(Arg.Is<string>(message => message.Contains("bonk")));
+        }
+    }
+}

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -20,8 +20,8 @@ namespace CSharpRepl.Tests
             var args = new[] { "Howdy" };
 
             await services.WarmUpAsync(args);
-            var variableAssignment = await services.Evaluate($@"var x = {argsAccessor};");
-            var variableUsage = await services.Evaluate(@"x");
+            var variableAssignment = await services.EvaluateAsync($@"var x = {argsAccessor};");
+            var variableUsage = await services.EvaluateAsync(@"x");
 
             Assert.IsType<EvaluationResult.Success>(variableAssignment);
             var usage = Assert.IsType<EvaluationResult.Success>(variableUsage);
@@ -35,7 +35,7 @@ namespace CSharpRepl.Tests
             var services = new RoslynServices(console, new Configuration());
 
             await services.WarmUpAsync(Array.Empty<string>());
-            var printStatement = await services.Evaluate("Print(DateTime.MinValue)");
+            var printStatement = await services.EvaluateAsync("Print(DateTime.MinValue)");
 
             Assert.IsType<EvaluationResult.Success>(printStatement);
             Assert.Equal("[1/1/0001 12:00:00 AM]" + Environment.NewLine, stdOut.ToString());

--- a/CSharpRepl.Tests/SymbolExplorerTests.cs
+++ b/CSharpRepl.Tests/SymbolExplorerTests.cs
@@ -27,7 +27,7 @@ namespace CSharpRepl.Tests
         [Fact]
         public async Task GetSymbolAtIndex_ReturnsFullyQualifiedName()
         {
-            var symbol = await services.GetSymbolAtIndex(@"Console.WriteLine(""howdy"")", "Console.Wri".Length);
+            var symbol = await services.GetSymbolAtIndexAsync(@"Console.WriteLine(""howdy"")", "Console.Wri".Length);
             Assert.Equal("System.Console.WriteLine", symbol.SymbolDisplay);
         }
     }

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="0.9.6" />
+    <PackageReference Include="PrettyPrompt" Version="0.9.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -4,22 +4,19 @@
 
 using System;
 using System.Threading.Tasks;
-using CSharpRepl.Services.Roslyn;
-using PrettyPrompt.Highlighting;
 using PrettyPrompt.Consoles;
-using CSharpRepl.Prompt;
 using CSharpRepl.Services;
-using PrettyPrompt;
-using System.Linq;
-using CSharpRepl.Services.Roslyn.Scripting;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Prompt;
 
 namespace CSharpRepl
 {
+    /// <summary>
+    /// Main entry point; parses command line args and starts the <see cref="ReadEvalPrintLoop"/>.
+    /// Check out ARCHITECTURE.md in the root of the repo for some design documentation.
+    /// </summary>
     static class Program
     {
-        private static RoslynServices? roslyn;
-        private static IPrompt? prompt;
-
         internal static async Task Main(string[] args)
         {
             var console = new SystemConsole();
@@ -39,7 +36,12 @@ namespace CSharpRepl
                 return;
             }
 
-            await ReadEvalPrintLoop(console, config).ConfigureAwait(false);
+            var roslyn = new RoslynServices(console, config);
+            var prompt = PromptConfiguration.Create(roslyn);
+
+            await new ReadEvalPrintLoop(roslyn, prompt, console)
+                .RunAsync(config)
+                .ConfigureAwait(false);
         }
 
         private static Configuration? ParseArguments(string[] args)
@@ -58,160 +60,5 @@ namespace CSharpRepl
                 return null;
             }
         }
-
-        private static async Task ReadEvalPrintLoop(IConsole console, Configuration config)
-        {
-            // these are required to run before displaying the welcome text.
-            // `roslyn` is required for the syntax highlighting in the text,
-            // and `prompt` is required because it enables escape sequences.
-            roslyn = new RoslynServices(console, config);
-            prompt = PromptConfiguration.Create(roslyn);
-
-            console.WriteLine("Welcome to the C# REPL (Read Eval Print Loop)!");
-            console.WriteLine("Type C# expressions and statements at the prompt and press Enter to evaluate them.");
-            console.WriteLine($"Type {Help} to learn more, and type {Exit} to quit.");
-            console.WriteLine(string.Empty);
-
-            await Preload(roslyn, console, config).ConfigureAwait(false);
-
-            while (true)
-            {
-                var response = await prompt.ReadLineAsync("> ").ConfigureAwait(false);
-                if (response.IsSuccess)
-                {
-                    if (response.Text == "exit") { break; }
-                    if (response.Text == "clear") { console.Clear(); continue; }
-                    if (new[] { "help", "#help", "?" }.Contains(response.Text.ToLowerInvariant()))
-                    {
-                        PrintHelp(console);
-                        continue;
-                    }
-
-                    var result = await roslyn
-                        .Evaluate(response.Text, config.LoadScriptArgs, response.CancellationToken)
-                        .ConfigureAwait(false);
-
-                    bool shouldVerbosePrint = response.IsHardEnter;
-                    await Print(roslyn, console, result, shouldVerbosePrint);
-                }
-            }
-        }
-
-        private static async Task Preload(RoslynServices roslyn, IConsole console, Configuration config)
-        {
-            bool hasReferences = config.References.Count > 0;
-            bool hasLoadScript = config.LoadScript is not null;
-            if (!hasReferences && !hasLoadScript)
-            {
-                _ = roslyn.WarmUpAsync(config.LoadScriptArgs); // don't await; we don't want to block the console while warmup happens.
-                return;
-            }
-
-            if(hasReferences)
-            {
-                console.WriteLine("Adding supplied references...");
-                var loadReferenceScript = string.Join("\r\n", config.References.Select(reference => $@"#r ""{reference}"""));
-                var loadReferenceScriptResult = await roslyn.Evaluate(loadReferenceScript).ConfigureAwait(false);
-                await Print(roslyn, console, loadReferenceScriptResult, displayDetails: false).ConfigureAwait(false);
-            }
-
-            if (hasLoadScript)
-            {
-                console.WriteLine("Running supplied CSX file...");
-                var loadScriptResult = await roslyn.Evaluate(config.LoadScript!, config.LoadScriptArgs).ConfigureAwait(false);
-                await Print(roslyn, console, loadScriptResult, displayDetails: false).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task Print(RoslynServices roslyn, IConsole console, EvaluationResult result, bool displayDetails)
-        {
-            switch (result)
-            {
-                case EvaluationResult.Success ok:
-                    var formatted = await roslyn.PrettyPrint(ok?.ReturnValue, displayDetails);
-                    console.WriteLine(formatted);
-                    break;
-                case EvaluationResult.Error err:
-                    var formattedError = await roslyn.PrettyPrint(err.Exception, displayDetails);
-                    console.WriteErrorLine(AnsiEscapeCodes.Red + formattedError + AnsiEscapeCodes.Reset);
-                    break;
-                case EvaluationResult.Cancelled:
-                    console.WriteErrorLine(
-                        AnsiEscapeCodes.Yellow + "Operation cancelled." + AnsiEscapeCodes.Reset
-                    );
-                    break;
-            }
-        }
-
-        private static void PrintHelp(IConsole console)
-        {
-            console.WriteLine(
-$@"
-Welcome to the C# REPL.
-This tool is for rapid experimentation and exploration of code.
-
-Evaluating Code
-===============
-Type C# at the prompt and press Enter to run it. Its result will be printed.
-Shift+Enter will insert a newline instead, to support multiple lines of input.
-Ctrl+Enter will evaluate the code, but show detailed member info / stack traces.
-If the code isn't complete (e.g. ""{VariableDeclaration}"") pressing Enter will insert a newline.
-
-Adding References
-=================
-Use the {Reference()} command to add assembly or nuget references.
-For assembly references, run {Reference("AssemblyName")} or {Reference("path/to/assembly.dll")}
-For nuget packages, run {Reference("nuget: PackageName")} or {Reference("nuget: PackageName, version")}
-
-Use {Preprocessor("#load", "path-to-file")} to evaluate C# stored in files (e.g. csx files). This can
-be useful, for example, to build a "".profile.csx"" that includes libraries you want
-to load.
-
-Exploring Code
-==============
-F1, when the caret is in a type or member, will open its MSDN documentation.
-Ctrl+F1 will open the type or member's source code on https://source.dot.net/
-
-Configuration Options
-=====================
-All configuration, including theming, is done at startup via command line flags.
-Run --help at the command line to view these options
-" 
-            );
-        }
-
-        private static string Reference(string? argument = null) =>
-            Preprocessor("#r", argument);
-
-        /// <summary>
-        /// Produce syntax-highlighted strings like "#r reference" for the provided <paramref name="argument"/> string.
-        /// </summary>
-        private static string Preprocessor(string keyword, string? argument = null)
-        {
-            var highlightedKeyword = Color("preprocessor keyword") + keyword + AnsiEscapeCodes.Reset;
-            var highlightedArgument = argument is null ? "" : Color("string") + @" """ + argument + @"""" + AnsiEscapeCodes.Reset;
-
-            return highlightedKeyword + highlightedArgument;
-        }
-
-        private static string VariableDeclaration =>
-            prompt!.HasUserOptedOutFromColor
-            ? "var x ="
-            : (Color("keyword") + "var" + AnsiEscapeCodes.Reset + " " +
-               Color("field name") + "x" + AnsiEscapeCodes.Reset + " " +
-               Color("operator") + "=" + AnsiEscapeCodes.Reset);
-
-        private static string Color(string reference) =>
-            AnsiEscapeCodes.ToAnsiEscapeSequence(new ConsoleFormat(roslyn!.ToColor(reference)));
-
-        private static string Help =>
-            prompt!.HasUserOptedOutFromColor
-            ? @"""help"""
-            : AnsiEscapeCodes.Green + "help" + AnsiEscapeCodes.Reset;
-
-        private static string Exit =>
-            prompt!.HasUserOptedOutFromColor
-            ? @"""exit"""
-            : AnsiEscapeCodes.BrightRed + @"exit" + AnsiEscapeCodes.Reset;
     }
 }

--- a/CSharpRepl/Prompt/PromptConfiguration.cs
+++ b/CSharpRepl/Prompt/PromptConfiguration.cs
@@ -39,19 +39,19 @@ namespace CSharpRepl.Prompt
             });
 
             async Task<IReadOnlyList<PrettyPrompt.Completion.CompletionItem>> completionHandler(string text, int caret) =>
-                adapter.AdaptCompletions(await roslyn.Complete(text, caret).ConfigureAwait(false));
+                adapter.AdaptCompletions(await roslyn.CompleteAsync(text, caret).ConfigureAwait(false));
 
             async Task<IReadOnlyCollection<FormatSpan>> highlightHandler(string text) =>
                 adapter.AdaptSyntaxClassification(await roslyn.SyntaxHighlightAsync(text).ConfigureAwait(false));
 
             async Task<bool> forceSoftEnterHandler(string text) =>
-                !await roslyn.IsTextCompleteStatement(text).ConfigureAwait(false);
+                !await roslyn.IsTextCompleteStatementAsync(text).ConfigureAwait(false);
 
             async Task LaunchHelpForSymbol(string text, int caret) =>
-                LaunchDocumentation(await roslyn.GetSymbolAtIndex(text, caret));
+                LaunchDocumentation(await roslyn.GetSymbolAtIndexAsync(text, caret));
 
             async Task LaunchSourceForSymbol(string text, int caret) =>
-                LaunchSource(await roslyn.GetSymbolAtIndex(text, caret));
+                LaunchSource(await roslyn.GetSymbolAtIndexAsync(text, caret));
         }
 
         private static void LaunchDocumentation(SymbolResult type)

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -1,0 +1,182 @@
+﻿using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+using PrettyPrompt;
+using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CSharpRepl
+{
+    /// <summary>
+    /// The core REPL; prints the welcome message, collects input with the <see cref="PrettyPrompt"/> library and
+    /// processes that input with <see cref="RoslynServices" />.
+    /// </summary>
+    internal sealed class ReadEvalPrintLoop
+    {
+        private readonly RoslynServices roslyn;
+        private readonly IPrompt prompt;
+        private readonly IConsole console;
+
+        public ReadEvalPrintLoop(RoslynServices roslyn, IPrompt prompt, IConsole console)
+        {
+            this.roslyn = roslyn;
+            this.prompt = prompt;
+            this.console = console;
+        }
+
+        public async Task RunAsync(Configuration config)
+        {
+            console.WriteLine("Welcome to the C# REPL (Read Eval Print Loop)!");
+            console.WriteLine("Type C# expressions and statements at the prompt and press Enter to evaluate them.");
+            console.WriteLine($"Type {Help} to learn more, and type {Exit} to quit.");
+            console.WriteLine(string.Empty);
+
+            await Preload(roslyn, console, config).ConfigureAwait(false);
+
+            while (true)
+            {
+                var response = await prompt.ReadLineAsync("> ").ConfigureAwait(false);
+                if (response.IsSuccess)
+                {
+                    if (response.Text == "exit") { break; }
+
+                    if (response.Text == "clear") { console.Clear(); continue; }
+
+                    if (new[] { "help", "#help", "?" }.Contains(response.Text.ToLowerInvariant()))
+                    {
+                        PrintHelp();
+                        continue;
+                    }
+
+                    var result = await roslyn
+                        .EvaluateAsync(response.Text, config.LoadScriptArgs, response.CancellationToken)
+                        .ConfigureAwait(false);
+
+                    bool shouldVerbosePrint = response.IsHardEnter;
+                    await PrintAsync(roslyn, console, result, shouldVerbosePrint);
+                }
+            }
+        }
+
+        private static async Task Preload(RoslynServices roslyn, IConsole console, Configuration config)
+        {
+            bool hasReferences = config.References.Count > 0;
+            bool hasLoadScript = config.LoadScript is not null;
+            if (!hasReferences && !hasLoadScript)
+            {
+                _ = roslyn.WarmUpAsync(config.LoadScriptArgs); // don't await; we don't want to block the console while warmup happens.
+                return;
+            }
+
+            if(hasReferences)
+            {
+                console.WriteLine("Adding supplied references...");
+                var loadReferenceScript = string.Join("\r\n", config.References.Select(reference => $@"#r ""{reference}"""));
+                var loadReferenceScriptResult = await roslyn.EvaluateAsync(loadReferenceScript).ConfigureAwait(false);
+                await PrintAsync(roslyn, console, loadReferenceScriptResult, displayDetails: false).ConfigureAwait(false);
+            }
+
+            if (hasLoadScript)
+            {
+                console.WriteLine("Running supplied CSX file...");
+                var loadScriptResult = await roslyn.EvaluateAsync(config.LoadScript!, config.LoadScriptArgs).ConfigureAwait(false);
+                await PrintAsync(roslyn, console, loadScriptResult, displayDetails: false).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task PrintAsync(RoslynServices roslyn, IConsole console, EvaluationResult result, bool displayDetails)
+        {
+            switch (result)
+            {
+                case EvaluationResult.Success ok:
+                    var formatted = await roslyn.PrettyPrintAsync(ok?.ReturnValue, displayDetails);
+                    console.WriteLine(formatted);
+                    break;
+                case EvaluationResult.Error err:
+                    var formattedError = await roslyn.PrettyPrintAsync(err.Exception, displayDetails);
+                    console.WriteErrorLine(AnsiEscapeCodes.Red + formattedError + AnsiEscapeCodes.Reset);
+                    break;
+                case EvaluationResult.Cancelled:
+                    console.WriteErrorLine(
+                        AnsiEscapeCodes.Yellow + "Operation cancelled." + AnsiEscapeCodes.Reset
+                    );
+                    break;
+            }
+        }
+
+        private void PrintHelp()
+        {
+            console.WriteLine(
+$@"
+More details and screenshots are available at
+https://github.com/waf/CSharpRepl/blob/main/README.md
+
+Evaluating Code
+===============
+Type C# at the prompt and press Enter to run it. The result will be printed.
+Ctrl+Enter will also run the code, but show detailed member info / stack traces.
+Shift+Enter will insert a newline, to support multiple lines of input.
+If the code isn't complete (e.g. ""{VariableDeclaration}"") pressing Enter will insert a newline.
+
+Adding References
+=================
+Use the {Reference()} command to add assembly or nuget references.
+For assembly references, run {Reference("AssemblyName")} or {Reference("path/to/assembly.dll")}
+For nuget packages, run {Reference("nuget: PackageName")} or {Reference("nuget: PackageName, version")}
+For project references, run {Reference("path/to/my.csproj")} or {Reference("path/to/my.sln")} 
+
+Use {Preprocessor("#load", "path-to-file")} to evaluate C# stored in files (e.g. csx files). This can
+be useful, for example, to build a "".profile.csx"" that includes libraries you want
+to load.
+
+Exploring Code
+==============
+F1, when the caret is in a type or member, will open its MSDN documentation.
+Ctrl+F1 will open the type or member's source code on https://source.dot.net/
+
+Configuration Options
+=====================
+All configuration, including theming, is done at startup via command line flags.
+Run --help at the command line to view these options
+" 
+            );
+        }
+
+        private string Reference(string? argument = null) =>
+            Preprocessor("#r", argument);
+
+        /// <summary>
+        /// Produce syntax-highlighted strings like "#r reference" for the provided <paramref name="argument"/> string.
+        /// </summary>
+        private string Preprocessor(string keyword, string? argument = null)
+        {
+            var highlightedKeyword = Color("preprocessor keyword") + keyword + AnsiEscapeCodes.Reset;
+            var highlightedArgument = argument is null ? "" : Color("string") + @" """ + argument + @"""" + AnsiEscapeCodes.Reset;
+
+            return highlightedKeyword + highlightedArgument;
+        }
+
+        private string VariableDeclaration =>
+            prompt.HasUserOptedOutFromColor
+            ? "var x ="
+            : (Color("keyword") + "var" + AnsiEscapeCodes.Reset + " " +
+               Color("field name") + "x" + AnsiEscapeCodes.Reset + " " +
+               Color("operator") + "=" + AnsiEscapeCodes.Reset);
+
+        private string Color(string reference) =>
+            AnsiEscapeCodes.ToAnsiEscapeSequence(new ConsoleFormat(roslyn!.ToColor(reference)));
+
+        private string Help =>
+            prompt.HasUserOptedOutFromColor
+            ? @"""help"""
+            : AnsiEscapeCodes.Green + "help" + AnsiEscapeCodes.Reset;
+
+        private string Exit =>
+            prompt.HasUserOptedOutFromColor
+            ? @"""exit"""
+            : AnsiEscapeCodes.BrightRed + "exit" + AnsiEscapeCodes.Reset;
+    }
+}


### PR DESCRIPTION
Clean up some code warnings from NDepend

- Pull logic out of Program.cs into ReadEvalPrintLoop.cs
   - Allows for more unit tests; also added a unit test for the new functionality in #20
- Clean up "-Async" method suffixes.