### PR TITLE
Fix project/solution references on non-windows platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,17 @@ jobs:
       run: dotnet --info
       
     - name: Install Codecov
+      if: matrix.platform == 'windows-latest' # only generate and upload code coverage once
       run: dotnet tool install --global Codecov.Tool
       
     - name: Build
       run: dotnet build
       
     - name: Test
-      run: dotnet test --collect:"XPlat Code Coverage" --settings CSharpRepl.Tests\TestCoverageRunSettings.xml
+      run: dotnet test --collect:"XPlat Code Coverage" --settings CSharpRepl.Tests/TestCoverageRunSettings.xml
 
     - name: Code Coverage
+      if: matrix.platform == 'windows-latest' # only generate and upload code coverage once
       shell: pwsh
       run: |
         $testCoverage = Get-ChildItem CSharpRepl.Tests\TestResults\*\*.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/CSharpRepl/bin/Debug/net5.0/CSharpRepl.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/CSharpRepl",
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/CSharpRepl/CSharpRepl.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/CSharpRepl/CSharpRepl.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/CSharpRepl/CSharpRepl.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
@@ -75,7 +75,7 @@ namespace CSharpRepl.Services.Roslyn.MetadataResolvers
             {
                 StartInfo =
                 {
-                    FileName = "dotnet.exe",
+                    FileName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet",
                     ArgumentList = { "build", reference },
                     RedirectStandardOutput = true
                 }

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -35,6 +35,8 @@ namespace CSharpRepl.Tests
             var services = new RoslynServices(console, new Configuration());
 
             await services.WarmUpAsync(Array.Empty<string>());
+            _ = await services.EvaluateAsync("using System.Globalization;");
+            _ = await services.EvaluateAsync("CultureInfo.DefaultThreadCurrentCulture = new System.Globalization.CultureInfo(\"en-US\");");
             var printStatement = await services.EvaluateAsync("Print(DateTime.MinValue)");
 
             Assert.IsType<EvaluationResult.Success>(printStatement);


### PR DESCRIPTION
We had a windows-only "dotnet.exe" command. This PR changes it so we call either "dotnet.exe" or "dotnet" depending on the platform.

Additionally, this was covered by an integration test that was failing on Ubuntu, so this PR additionally enables Ubuntu in the CI tests.

Just for good measure, I also added a `.vscode` directory for easier development on Ubuntu. 🚀

Fixes #27