### PR TITLE
Enable roll-forward to latest major .NET version

### DIFF
--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -4,6 +4,7 @@
     <Version>0.3.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
csharprepl targets .NET 5, but if .NET 5 is not installed, we should roll forward to .NET 6.

See https://docs.microsoft.com/en-us/dotnet/core/versions/selection for more info.

Fixes #25