### PR TITLE
Replace home-grown command line parser with System.CommandLine

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -14,19 +14,17 @@ namespace CSharpRepl.Services
     /// </summary>
     public sealed class Configuration
     {
-        public HashSet<string> References { get; } = new();
-        public HashSet<string> Usings { get; } = new();
+        public HashSet<string> References { get; init; } = new();
+        public HashSet<string> Usings { get; init; } = new();
 
         public const string FrameworkDefault = SharedFramework.NetCoreApp;
-        public string Framework { get; set; } = FrameworkDefault;
+        public string Framework { get; init; } = FrameworkDefault;
 
-        public string? Theme { get; set; }
-        public string? ResponseFile { get; set; }
-        public string? LoadScript { get; set; }
-        public string[] LoadScriptArgs { get; set; } = Array.Empty<string>();
+        public string? Theme { get; init; }
+        public string? LoadScript { get; init; }
+        public string[] LoadScriptArgs { get; init; } = Array.Empty<string>();
 
-        public bool ShowVersionAndExit { get; set; }
-        public bool ShowHelpAndExit { get; set; }
+        public string? OutputForEarlyExit { get; init; }
 
         public static string ApplicationDirectory => Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),

--- a/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
+++ b/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
@@ -270,7 +270,7 @@ namespace CSharpRepl.Services.Roslyn.References
             this.ImplementationAssemblies = ImplementationAssemblies;
         }
 
-        public static IReadOnlyCollection<string> SupportedFrameworks { get; } =
+        public static string[] SupportedFrameworks { get; } =
             Path.GetDirectoryName(typeof(object).Assembly.Location) is string frameworkDirectory
             ? Directory
                 .GetDirectories(Path.Combine(frameworkDirectory, "../../"))

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -52,7 +52,7 @@ namespace CSharpRepl.Services.SyntaxHighlighting
                 { nameof(AnsiColor.White), AnsiColor.White },
             };
 
-            var selectedTheme = themeName is null
+            var selectedTheme = string.IsNullOrEmpty(themeName)
                 ? new DefaultTheme()
                 : JsonSerializer.Deserialize<Theme>(
                     File.ReadAllText(themeName),

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -32,7 +32,7 @@ namespace CSharpRepl.Tests
         }
 
         [Theory]
-        [InlineData("-u"), InlineData("--usings"), InlineData("/u")]
+        [InlineData("-u"), InlineData("--using"), InlineData("/u")]
         public void ParseArguments_UsingArguments_ProducesUsings(string flag)
         {
             var result = Parse($"{flag} System.Linq System.Data Newtonsoft.Json");
@@ -44,7 +44,7 @@ namespace CSharpRepl.Tests
         }
 
         [Theory]
-        [InlineData("-r"), InlineData("--references"), InlineData("/r")]
+        [InlineData("-r"), InlineData("--reference"), InlineData("/r")]
         public void ParseArguments_ReferencesArguments_ProducesUsings(string flag)
         {
             var result = Parse($"{flag} Foo.dll Bar.dll");
@@ -70,7 +70,7 @@ namespace CSharpRepl.Tests
         {
             var result = Parse(flag);
             Assert.NotNull(result);
-            Assert.True(result.ShowVersionAndExit);
+            Assert.Contains("C# REPL ", result.OutputForEarlyExit);
         }
 
         [Theory]
@@ -79,7 +79,7 @@ namespace CSharpRepl.Tests
         {
             var result = Parse(flag);
             Assert.NotNull(result);
-            Assert.True(result.ShowHelpAndExit);
+            Assert.Contains("Usage: ", result.OutputForEarlyExit);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace CSharpRepl.Tests
             Assert.Equal(new[] { "System.Linq", "System.Data", "Newtonsoft.Json" }, result.Usings);
             Assert.Equal(new[] { "foo.dll", "bar.dll", "baz.dll" }, result.References);
             Assert.Equal("Microsoft.AspNetCore.App", result.Framework);
-            Assert.Equal(@"Console.WriteLine(""Hello World!"");", result.LoadScript);
+            Assert.Equal(@"Console.WriteLine(""Hello World!"");" + Environment.NewLine, result.LoadScript);
         }
 
         [Fact]
@@ -108,17 +108,38 @@ namespace CSharpRepl.Tests
         [Fact]
         public void ParseArguments_TrailingArgumentsAfterDoubleDash_SetAsLoadScriptArgs()
         {
-            var csxResult = CommandLine.ParseArguments(new[] { "Data/LoadScript.csx", "--", "Data/LoadScript.csx" });
+            var csxResult = CommandLine.Parse(new[] { "Data/LoadScript.csx", "--", "Data/LoadScript.csx" });
             // load script filename passed before "--" is a load script, after "--" we just pass it to the load script as an arg.
             Assert.Equal(new[] { "Data/LoadScript.csx" }, csxResult.LoadScriptArgs);
-            Assert.Equal(@"Console.WriteLine(""Hello World!"");", csxResult.LoadScript);
+            Assert.Equal(@"Console.WriteLine(""Hello World!"");" + Environment.NewLine, csxResult.LoadScript);
 
-            var quotedResult = CommandLine.ParseArguments(new[] { "-r", "Foo.dll", "--", @"""a b c""", @"""d e f""" });
+            var quotedResult = CommandLine.Parse(new[] { "-r", "Foo.dll", "--", @"""a b c""", @"""d e f""" });
             Assert.Equal(new[] { @"""a b c""", @"""d e f""" }, quotedResult.LoadScriptArgs);
             Assert.Equal(new[] { @"Foo.dll" }, quotedResult.References);
         }
 
+        [Fact]
+        public void ParseArguments_DotNetSuggestFrameworkParameter_IsAutocompleted()
+        {
+            var result = Parse("[suggest:3] --f");
+            Assert.Equal("--framework\r\n", result.OutputForEarlyExit);
+        }
+
+        [Fact]
+        public void ParseArguments_DotNetSuggestFrameworkValue_IsAutocompleted()
+        {
+            var result = CommandLine.Parse(new[] { "[suggest:12]", "--framework "});
+            Assert.Contains("Microsoft.NETCore.App", result.OutputForEarlyExit);
+        }
+
+        [Fact]
+        public void ParseArguments_DotNetSuggestUsingValue_IsAutocompleted()
+        {
+            var result = CommandLine.Parse(new[] { "[suggest:25]", "--using System.Collection"});
+            Assert.Contains("System.Collections.Immutable", result.OutputForEarlyExit);
+        }
+
         private static Configuration Parse(string commandline) =>
-            CommandLine.ParseArguments(commandline?.Split(' ') ?? Array.Empty<string>());
+            CommandLine.Parse(commandline?.Split(' ') ?? Array.Empty<string>());
     }
 }

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -122,7 +122,7 @@ namespace CSharpRepl.Tests
         public void ParseArguments_DotNetSuggestFrameworkParameter_IsAutocompleted()
         {
             var result = Parse("[suggest:3] --f");
-            Assert.Equal("--framework\r\n", result.OutputForEarlyExit);
+            Assert.Equal("--framework" + Environment.NewLine, result.OutputForEarlyExit);
         }
 
         [Fact]

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="PrettyPrompt" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -6,153 +6,168 @@ using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn.References;
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
 using static System.Environment;
 
 namespace CSharpRepl
 {
     /// <summary>
-    /// Parses command line arguments.
+    /// Parses command line arguments using System.CommandLine.
+    /// Includes support for dotnet-suggest.
     /// </summary>
-    /// <remarks>
-    /// Doing our own parsing, instead of using an existing library, is questionable. However, I wasn't able to find an
-    /// existing library that covers the following:
-    ///     - Supports response files (i.e. ".rsp" files) for compatibility with other interactive C# consoles (e.g. csi).
-    ///     - Supports windows-style forward slash arguments (e.g. /u), again for compatibility with other C# consoles.
-    /// </remarks>
     internal static class CommandLine
     {
-        public static Configuration ParseArguments(string[] args, Configuration? existingConfiguration = null)
+        private const string DisableFurtherOptionParsing = "--";
+
+        private static readonly Option<string[]> References = new(
+            aliases: new[] { "--reference", "-r", "/r" },
+            description: "Reference assemblies, nuget packages, and csproj files.",
+            getDefaultValue: Array.Empty<string>
+        );
+
+        private static readonly Option<string[]> Usings = new Option<string[]>(
+            aliases: new[] { "--using", "-u", "/u" },
+            description: "Add using statements.",
+            getDefaultValue: Array.Empty<string>
+        ).AddSuggestions(GetAvailableUsings);
+
+        private static readonly Option<string> Framework = new Option<string>(
+            aliases: new[] { "--framework", "-f", "/f" },
+            description: "Reference a shared framework.",
+            getDefaultValue: () => Configuration.FrameworkDefault
+        ).FromAmong(SharedFramework.SupportedFrameworks);
+
+        private static readonly Option<string> Theme = new(
+            aliases: new[] { "--theme", "-t", "/t" },
+            description: "Read a theme file for syntax highlighting. Respects the NO_COLOR standard.",
+            getDefaultValue: () => string.Empty
+        );
+
+        private static readonly Option<bool> Help = new(
+            aliases: new[] { "--help", "-h", "-?", "/h", "/?" },
+            description: "Show this help and exit."
+        );
+
+        private static readonly Option<bool> Version = new(
+            aliases: new[] { "--version", "-v", "/v" },
+            description: "Show version number and exit."
+        );
+
+        public static Configuration? Parse(string[] args)
         {
-            string currentSwitch = "";
-            List<string>? loadScriptArgs = null;
-            var config = args
-                .Aggregate(existingConfiguration ?? new Configuration(), (config, arg) =>
-                {
-                    // 
-                    // Process positional parameters
-                    // 
-                    if(arg == "--")
-                    {
-                        loadScriptArgs = new List<string>();
-                    }
-                    else if (loadScriptArgs is not null)
-                    {
-                        loadScriptArgs.Add(arg);
-                    }
-                    else if (arg.EndsWith(".csx"))
-                    {
-                        if (!File.Exists(arg)) throw new FileNotFoundException($@"Script file ""{arg}"" was not found");
-                        config.LoadScript = File.ReadAllText(arg);
-                    }
-                    else if (arg.EndsWith(".rsp"))
-                    {
-                        string path = arg.TrimStart('@'); // a common convention is to prefix rsp files with '@'
-                        if (!File.Exists(path)) throw new FileNotFoundException($@"RSP file ""{path}"" was not found");
-                        if (existingConfiguration is not null) throw new InvalidOperationException("Response files cannot be nested.");
-                        var responseFile = File
-                            .ReadAllLines(path)
-                            .SelectMany(line =>
-                                new string(line.TakeWhile(ch => ch != '#').ToArray()) // ignore comments
-                                .Split(new[] { ' ', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.None)
-                            )
-                            .ToArray();
-                        config = ParseArguments(responseFile, config);
-                    }
-                    //
-                    // process option flags
-                    //
-                    else if (arg == "-v" || arg == "--version" || arg == "/v")
-                        config.ShowVersionAndExit = true;
-                    else if (arg == "-h" || arg == "--help" || arg == "/h" || arg == "/?" || arg == "-?")
-                        config.ShowHelpAndExit = true;
-                    //
-                    // process option names, and optional values if they're provided like /r:Reference
-                    //
-                    else if (arg.StartsWith("-r") || arg.StartsWith("--reference") || arg.StartsWith("/r"))
-                    {
-                        currentSwitch = "--reference";
-                        if(TryGetConcatenatedValue(arg, out string? reference))
-                        {
-                            config.References.Add(reference);
-                        }
-                    }
-                    else if (arg.StartsWith("-u") || arg.StartsWith("--using") || arg.StartsWith("/u"))
-                    { 
-                        currentSwitch = "--using";
-                        if(TryGetConcatenatedValue(arg, out string? usingNamespace))
-                        {
-                            config.Usings.Add(usingNamespace);
-                        }
-                    }
-                    else if (arg.StartsWith("-f") || arg.StartsWith("--framework") || arg.StartsWith("/f"))
-                    { 
-                        currentSwitch = "--framework";
-                        if(TryGetConcatenatedValue(arg, out string? framework))
-                        {
-                             config.Framework = framework;
-                        }
-                    }
-                    else if (arg.StartsWith("-t") || arg.StartsWith("--theme") || arg.StartsWith("/t"))
-                    { 
-                        currentSwitch = "--theme";
-                        if(TryGetConcatenatedValue(arg, out string? theme))
-                        {
-                             config.Theme = theme;
-                        }
-                    }
-                    //
-                    // process option values
-                    //
-                    else if (currentSwitch == "--reference")
-                        config.References.Add(arg);
-                    else if (currentSwitch == "--using")
-                        config.Usings.Add(arg);
-                    else if (currentSwitch == "--framework")
-                        config.Framework = arg;
-                    else if (currentSwitch == "--theme")
-                        config.Theme = arg;
-                    else
-                        throw new InvalidOperationException("Unknown command line option: " + arg);
-                    return config;
-                });
+            var parseArgs = RemoveScriptArguments(args).ToArray();
 
-            if(loadScriptArgs is not null)
+            var commandLine =
+                new CommandLineBuilder(
+                    new RootCommand("C# REPL") { References, Usings, Framework, Theme, Help, Version }
+                )
+                .UseSuggestDirective() // support autocompletion via dotnet-suggest
+                .Build()
+                .Parse(parseArgs);
+
+            if (ShouldExitEarly(commandLine, out var text))
             {
-                config.LoadScriptArgs = loadScriptArgs.ToArray();
+                return new Configuration { OutputForEarlyExit = text };
+            }
+            if (commandLine.Errors.Count > 0)
+            {
+                throw new InvalidOperationException(string.Join(NewLine, commandLine.Errors));
             }
 
-            if (!SharedFramework.SupportedFrameworks.Contains(config.Framework.Split('/').First())) // allow trailing version numbers in framework name
+            var config = new Configuration
             {
-                throw new ArgumentException("Unknown Framework: " + config.Framework + ". Expected one of " + string.Join(", ", SharedFramework.SupportedFrameworks));
-            }
+                References = commandLine.ValueForOption(References)?.ToHashSet() ?? new HashSet<string>(),
+                Usings = commandLine.ValueForOption(Usings)?.ToHashSet() ?? new HashSet<string>(),
+                Framework = commandLine.ValueForOption(Framework) ?? Configuration.FrameworkDefault,
+                LoadScript = ProcessScriptArguments(args),
+                LoadScriptArgs = commandLine.UnparsedTokens.ToArray(),
+                Theme = commandLine.ValueForOption(Theme),
+            };
 
             return config;
         }
 
-        /// <summary>
-        /// Parse value in a string like "/u:foo"
-        /// </summary>
-        private static bool TryGetConcatenatedValue(string arg, [NotNullWhen(true)] out string? value)
+        private static bool ShouldExitEarly(ParseResult commandLine, [NotNullWhen(true)] out string? text)
         {
-            var referenceValue = arg.Split(new[] { ':', '=' }, 2);
-            if (referenceValue.Length == 2)
+            if(commandLine.Directives.Any())
             {
-                value = referenceValue[1];
+                // this is just for dotnet-suggest directive processing. Invoking should write to stdout
+                // and should not start the REPL. It's a feature of System.CommandLine.
+                var console = new TestConsole();
+                commandLine.Invoke(console);
+                text = console.Out.ToString() ?? string.Empty;
                 return true;
             }
-            value = null;
+            if (commandLine.ValueForOption<bool>("--help"))
+            {
+                text = GetHelp();
+                return true;
+            }
+            if (commandLine.ValueForOption<bool>("--version"))
+            {
+                text = GetVersion();
+                return true;
+            }
+
+            text = null;
             return false;
         }
 
-        public static string GetHelp() =>
+        /// <summary>
+        /// We allow csx files to be specified, sometimes in ambiguous scenarios that
+        /// System.CommandLine can't figure out. So we remove it from processing here,
+        /// and process it manually in <see cref="ProcessScriptArguments"/>.
+        /// </summary>
+        private static IEnumerable<string> RemoveScriptArguments(string[] args)
+        {
+            bool foundIgnore = false;
+            foreach (var arg in args)
+            {
+                foundIgnore |= arg == DisableFurtherOptionParsing;
+                if (foundIgnore || !arg.EndsWith(".csx"))
+                {
+                    yield return arg;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads the contents of any provided script (csx) files.
+        /// </summary>
+        private static string? ProcessScriptArguments(string[] args)
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (var arg in args)
+            {
+                if (arg == DisableFurtherOptionParsing) break;
+                if (!arg.EndsWith(".csx")) continue;
+                if (!File.Exists(arg)) throw new FileNotFoundException($@"Script file ""{arg}"" was not found");
+                stringBuilder.AppendLine(File.ReadAllText(arg));
+            }
+            return stringBuilder.Length == 0 ? null : stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Output of --help
+        /// </summary>
+        /// <remarks>
+        /// System.CommandLine can generate the help text for us, but I think it's less
+        /// readable, and the code to configure it ends up being longer than the below string.
+        /// </remarks>
+        private static string GetHelp() =>
             GetVersion() + NewLine +
-            "Usage: csharprepl [OPTIONS] [response-file.rsp] [script-file.csx] [-- <additional-arguments>]" + NewLine + NewLine +
+            "Usage: csharprepl [OPTIONS] [@response-file.rsp] [script-file.csx] [-- <additional-arguments>]" + NewLine + NewLine +
             "Starts a REPL (read eval print loop) according to the provided [OPTIONS]." + NewLine +
-            "These [OPTIONS] can be provided at the command line, or via a [response-file.rsp]." + NewLine +
+            "These [OPTIONS] can be provided at the command line, or via a [@response-file.rsp]." + NewLine +
             "A [script-file.csx], if provided, will be executed before the prompt starts." + NewLine + NewLine +
             "OPTIONS:" + NewLine +
             "  -r <dll> or --reference <dll>:             Reference assemblies, nuget packages, and csproj files." + NewLine +
@@ -163,13 +178,16 @@ namespace CSharpRepl
             "  -t <theme.json> or --theme <theme.json>:   Read a theme file for syntax highlighting. Respects the NO_COLOR standard." + NewLine +
             "  -v or --version:                           Show version number and exit." + NewLine +
             "  -h or --help:                              Show this help and exit." + NewLine + NewLine +
-            "response-file.rsp:" + NewLine +
+            "@response-file.rsp:" + NewLine +
             "  A file, with extension .rsp, containing the above command line [OPTIONS], one option per line." + NewLine + NewLine +
             "script-file.csx:" + NewLine +
             "  A file, with extension .csx, containing lines of C# to evaluate before starting the REPL." + NewLine +
             "  Arguments to this script can be passed as <additional-arguments> and will be available in a global `args` variable." + NewLine;
 
-        public static string GetVersion()
+        /// <summary>
+        /// Get assembly version for usage in --version
+        /// </summary>
+        private static string GetVersion()
         {
             var product = "C# REPL";
             var version = Assembly
@@ -179,12 +197,46 @@ namespace CSharpRepl
             return product + " " + version;
         }
 
+        /// <summary>
+        /// In the help text, lists the available frameworks and marks one as default.
+        /// </summary>
         private static string GetInstalledFrameworks(string leftPadding)
         {
             var frameworkList = SharedFramework
                 .SupportedFrameworks
                 .Select(fx => leftPadding + "- " + fx + (fx == Configuration.FrameworkDefault ? " (default)" : ""));
             return string.Join(NewLine, frameworkList);
+        }
+
+        /// <summary>
+        /// Autocompletions for --using.
+        /// </summary>
+        private static IEnumerable<string> GetAvailableUsings(ParseResult? parseResult, string? textToMatch)
+        {
+            if (string.IsNullOrEmpty(textToMatch) || "Syste".StartsWith(textToMatch, StringComparison.OrdinalIgnoreCase))
+                return new[] { "System" };
+
+            if (!textToMatch.StartsWith("System", StringComparison.OrdinalIgnoreCase))
+                return Array.Empty<string>();
+
+            var runtimeAssemblyPaths = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
+            using var mlc = new MetadataLoadContext(new PathAssemblyResolver(runtimeAssemblyPaths));
+
+            var namespaces =
+                from assembly in runtimeAssemblyPaths
+                from type in GetTypes(assembly)
+                where type.IsPublic
+                      && type.Namespace is not null
+                      && type.Namespace.StartsWith(textToMatch, StringComparison.OrdinalIgnoreCase)
+                select type.Namespace;
+
+            return namespaces.Distinct().Take(16).ToArray();
+
+            IEnumerable<Type> GetTypes(string assemblyPath)
+            {
+                try { return mlc.LoadFromAssemblyPath(assemblyPath).GetTypes(); }
+                catch (BadImageFormatException) { return Array.Empty<Type>(); } // handle native DLLs that have no managed metadata.
+            }
         }
     }
 }

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -23,18 +23,13 @@ namespace CSharpRepl
         {
             var console = new SystemConsole();
             Configuration? config = ParseArguments(args);
-            if (config is null)
+
+            if (config is null) // parsing error
                 return;
 
-            if (config.ShowHelpAndExit)
+            if (config.OutputForEarlyExit is not null)
             {
-                console.WriteLine(CommandLine.GetHelp());
-                return;
-            }
-
-            if (config.ShowVersionAndExit)
-            {
-                console.WriteLine(CommandLine.GetVersion());
+                console.WriteLine(config.OutputForEarlyExit);
                 return;
             }
 
@@ -51,28 +46,27 @@ namespace CSharpRepl
                 .ConfigureAwait(false);
         }
 
-        private static string CreateApplicationStorageDirectory()
-        {
-            var appStorage = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".csharprepl");
-            Directory.CreateDirectory(appStorage);
-            return appStorage;
-        }
-
         private static Configuration? ParseArguments(string[] args)
         {
             try
             {
-                return CommandLine.ParseArguments(args);
+                return CommandLine.Parse(args);
             }
             catch (Exception ex)
             {
-                Console.WriteLine(CommandLine.GetHelp());
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Error.WriteLine(ex.Message);
                 Console.ResetColor();
                 Console.WriteLine();
                 return null;
             }
+        }
+
+        private static string CreateApplicationStorageDirectory()
+        {
+            var appStorage = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".csharprepl");
+            Directory.CreateDirectory(appStorage);
+            return appStorage;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Supported options are:
 - `response-file.rsp`: A filepath of an .rsp file, containing any of the above command line options.
 - `script-file.csx`: A filepath of a .csx file, containing lines of C# to evaluate before starting the REPL. Arguments to this script can be passed as `<additional-arguments>`, after a double hyphen (`--`), and will be available in a global `args` variable.
 
+If you have [`dotnet-suggest`](https://github.com/dotnet/command-line-api/blob/main/docs/dotnet-suggest.md) enabled, all options can be tab-completed, including values provided to `--framework` and .NET namespaces provided to `--using`.
+
 ## Integrating with other software
 
 C# REPL is a standalone software application, but it can be useful to integrate it with other developer tools:


### PR DESCRIPTION
Replace complex command line parsing with simpler System.CommandLine usage. We get dotnet-suggest support which is pretty cool. This adds completions for frameworks and usings.