### PR TITLE
Shared framework loading from nuget store

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="5.11.0" />
     <PackageReference Include="PrettyPrompt" Version="2.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Services/Logging/ITraceLogger.cs
+++ b/CSharpRepl.Services/Logging/ITraceLogger.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System;
+using System.Collections.Generic;
 
 namespace CSharpRepl.Services.Logging
 {
@@ -10,5 +11,6 @@ namespace CSharpRepl.Services.Logging
     {
         void Log(string message);
         void Log(Func<string> message);
+        void LogPaths(string message, Func<IEnumerable<string?>> paths);
     }
 }

--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Logging;
-using Microsoft.CodeAnalysis;
 using System;
-using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace CSharpRepl.Services.Roslyn.References
@@ -23,33 +20,46 @@ namespace CSharpRepl.Services.Roslyn.References
     internal sealed class DotNetInstallationLocator
     {
         private readonly ITraceLogger logger;
+        private readonly IFileSystem io;
+        private readonly string dotnetRuntimePath;
+        private readonly string userProfilePath;
 
-        public DotNetInstallationLocator(ITraceLogger logger)
+        // used at runtime
+        public DotNetInstallationLocator(ITraceLogger logger) : this(
+           logger: logger,
+           io: new FileSystem(),
+           // a path like C:\Program Files\dotnet
+           dotnetRuntimePath: Path.GetFullPath(Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "../../../")),
+           // a path like C:\Users\username
+           userProfilePath: Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
+        ) { }
+
+        // used for unit testing, it will inject fake IO
+        internal DotNetInstallationLocator(ITraceLogger logger, IFileSystem io, string dotnetRuntimePath, string userProfilePath)
         {
             this.logger = logger;
+            this.io = io;
+            this.dotnetRuntimePath = dotnetRuntimePath;
+            this.userProfilePath = userProfilePath;
         }
 
         /// <summary>
-        /// Returns a SharedFramework that contains a list of reference and implementation assemblies in that framework.
-        /// It first tries to use a globally installed shared framework (e.g. in C:\Program Files\dotnet\) and falls back
-        /// to a shared framework installed in C:\Users\username\.nuget\packages\.
-        ///
-        /// Microsoft.NETCore.App is always returned, in addition to any other specified framework.
+        /// Finds the path to the specified framework's reference assemblies and implementation assemblies.
+        /// Usually, these are somewhere under the global dotnet installation, but they can also be in ~/.nuget.
         /// </summary>
-        /// <exception cref="InvalidOperationException">If no shared framework could be found</exception>
-        public SharedFramework[] GetSharedFrameworkConfiguration(string framework, Version version)
+        /// <param name="framework">A shared framework, like Microsoft.NETCore.App</param>
+        /// <param name="version">The desired shared framework version, like 5.0.4</param>
+        public (string referencePath, string implementationPath) FindInstallation(string framework, Version version)
         {
-            var dotnetRoot = GetDotNetRootPath();
-
             // first, try loading from the system-wide folders, e.g. in C:\Program Files\dotnet\
-            var referenceAssemblyRoot = Path.Combine(dotnetRoot, "packs", framework + ".Ref");
-            var implementationAssemblyRoot = Path.Combine(dotnetRoot, "shared", framework);
+            var referenceAssemblyRoot = Path.Combine(dotnetRuntimePath, "packs", framework + ".Ref");
+            var implementationAssemblyRoot = Path.Combine(dotnetRuntimePath, "shared", framework);
 
-            logger.LogPaths("Available Reference Assemblies", () => Directory.GetDirectories(referenceAssemblyRoot));
-            logger.LogPaths("Available Implementation Assemblies", () => Directory.GetDirectories(implementationAssemblyRoot));
+            logger.LogPaths("Available Reference Assemblies", () => ListDirectoriesIfExists(referenceAssemblyRoot));
+            logger.LogPaths("Available Implementation Assemblies", () => ListDirectoriesIfExists(implementationAssemblyRoot));
 
-            string? referencePath = GetGlobalReferenceAssemblyPath(referenceAssemblyRoot, version);
-            string? implementationPath = GetGlobalImplementationAssemblyPath(implementationAssemblyRoot, version);
+            var referencePath = GetGlobalReferenceAssemblyPath(referenceAssemblyRoot, version);
+            var implementationPath = GetGlobalImplementationAssemblyPath(implementationAssemblyRoot, version);
 
             // second, try loading from installed nuget packages, e.g. ~\.nuget\packages\microsoft.netcore.app.*
             if (referencePath is null)
@@ -70,41 +80,21 @@ namespace CSharpRepl.Services.Roslyn.References
                 );
             }
 
-            var referenceDlls = CreateDefaultReferences(
-                referencePath,
-                Directory.GetFiles(referencePath, "*.dll", SearchOption.TopDirectoryOnly)
-            );
-            var implementationDlls = CreateDefaultReferences(
-                implementationPath,
-                Directory.GetFiles(implementationPath, "*.dll", SearchOption.TopDirectoryOnly)
-            );
-
-            // Microsoft.NETCore.App is always loaded.
-            // e.g. if we're loading Microsoft.AspNetCore.App, load it alongside Microsoft.NETCore.App.
-            return framework switch
-            {
-                SharedFramework.NetCoreApp => new[] {
-                    new SharedFramework(referencePath, referenceDlls, implementationPath, implementationDlls)
-                },
-                _ => GetSharedFrameworkConfiguration(SharedFramework.NetCoreApp, version)
-                    .Append(new SharedFramework(referencePath, referenceDlls, implementationPath, implementationDlls))
-                    .ToArray()
-            };
+            return (referencePath, implementationPath);
         }
 
         /// <summary>
         /// Returns path to globally installed Reference Assemblies like C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0\ref\net5.0
         /// </summary>
-        private static string? GetGlobalReferenceAssemblyPath(string referenceAssemblyRoot, Version version)
+        private string? GetGlobalReferenceAssemblyPath(string referenceAssemblyRoot, Version version)
         {
-            var referenceAssemblyPath = Directory
+            if (!io.Directory.Exists(referenceAssemblyRoot)) return null;
+
+            var referenceAssemblyPath = io.Directory
                 .GetDirectories(referenceAssemblyRoot, "net*" + version.Major + "." + version.Minor + "*", SearchOption.AllDirectories)
                 .LastOrDefault();
 
-            if (referenceAssemblyPath is null)
-            {
-                return null;
-            }
+            if (referenceAssemblyPath is null) return null;
 
             return Path.GetFullPath(referenceAssemblyPath);
         }
@@ -112,16 +102,18 @@ namespace CSharpRepl.Services.Roslyn.References
         /// <summary>
         /// Returns the path to globally installed Implementation Assemblies like C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.10
         /// </summary>
-        private static string? GetGlobalImplementationAssemblyPath(string implementationAssemblyRoot, Version version)
+        private string? GetGlobalImplementationAssemblyPath(string implementationAssemblyRoot, Version version)
         {
-            var configuredFrameworkAndVersion = Directory
+            if (!io.Directory.Exists(implementationAssemblyRoot)) return null;
+
+            var configuredFrameworkAndVersion = io.Directory
                 .GetDirectories(implementationAssemblyRoot, version.Major + "." + version.Minor + "*")
                 .OrderBy(path => ParseDotNetVersion(path))
                 .LastOrDefault();
 
             return configuredFrameworkAndVersion;
 
-            static Version ParseDotNetVersion(string path)
+            Version ParseDotNetVersion(string path)
             {
                 var versionString = Path.GetFileName(path).Split('-', 2).First(); // discard trailing preview versions, e.g. 6.0.0-preview.4.21253.7 
                 return new Version(versionString);
@@ -135,12 +127,13 @@ namespace CSharpRepl.Services.Roslyn.References
         private string? FallbackToNugetReferencePath(string framework, Version version)
         {
             string nugetReferenceAssemblyRoot = Path.Combine(
-                Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
-                @".nuget\packages\",
+                userProfilePath,
+                ".nuget",
+                "packages",
                 framework.ToLowerInvariant() + ".ref"
             );
 
-            logger.LogPaths("NuGet Reference Assemblies", () => Directory.GetDirectories(nugetReferenceAssemblyRoot));
+            logger.LogPaths("NuGet Reference Assemblies", () => ListDirectoriesIfExists(nugetReferenceAssemblyRoot));
 
             return GetGlobalReferenceAssemblyPath(nugetReferenceAssemblyRoot, version);
         }
@@ -159,58 +152,26 @@ namespace CSharpRepl.Services.Roslyn.References
             if (platform is null) return null;
 
             var nugetImplementationAssemblyRoot = Path.Combine(
-                Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
-                @".nuget\packages\",
+                userProfilePath,
+                ".nuget",
+                "packages",
                 (framework + ".runtime." + platform + "-" + RuntimeInformation.ProcessArchitecture).ToLowerInvariant()
             );
 
-            logger.LogPaths("NuGet Implementation Assemblies", () => Directory.GetDirectories(nugetImplementationAssemblyRoot));
+            logger.LogPaths("NuGet Implementation Assemblies", () => ListDirectoriesIfExists(nugetImplementationAssemblyRoot));
 
             var implementationPath = GetGlobalImplementationAssemblyPath(nugetImplementationAssemblyRoot, version);
 
             if (implementationPath is null) return null;
 
-            return Directory
+            return io.Directory
                 .GetDirectories(implementationPath, "net*", SearchOption.AllDirectories)
                 .LastOrDefault();
         }
 
-        private static string GetDotNetRootPath()
-        {
-            var dotnetRuntimePath = RuntimeEnvironment.GetRuntimeDirectory();
-            var dotnetRoot = Path.GetFullPath(Path.Combine(dotnetRuntimePath, "../../../"));
-            return dotnetRoot;
-        }
-
-        private static IReadOnlyCollection<MetadataReference> CreateDefaultReferences(string assemblyPath, IReadOnlyCollection<string> assemblies)
-        {
-            return assemblies
-                .AsParallel()
-                .Select(dll =>
-                {
-                    string fullReferencePath = Path.Combine(assemblyPath, dll);
-                    string fullDocumentationPath = Path.ChangeExtension(fullReferencePath, ".xml");
-
-                    if (!IsManagedAssembly(fullReferencePath))
-                        return null;
-
-                    return File.Exists(fullDocumentationPath)
-                        ? MetadataReference.CreateFromFile(fullReferencePath, documentation: XmlDocumentationProvider.CreateFromFile(fullDocumentationPath))
-                        : MetadataReference.CreateFromFile(fullReferencePath);
-                })
-                .WhereNotNull()
-                .ToList();
-        }
-
-        private static bool IsManagedAssembly(string assemblyPath)
-        {
-            try
-            {
-                _ = AssemblyName.GetAssemblyName(assemblyPath);
-                return true;
-            }
-            catch (FileNotFoundException) { return false; }
-            catch (BadImageFormatException) { return false; }
-        }
+        private string[] ListDirectoriesIfExists(string referenceAssemblyRoot) =>
+            io.Directory.Exists(referenceAssemblyRoot)
+            ? io.Directory.GetDirectories(referenceAssemblyRoot)
+            : Array.Empty<string>();
     }
 }

--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -1,0 +1,216 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Extensions;
+using CSharpRepl.Services.Logging;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace CSharpRepl.Services.Roslyn.References
+{
+    /// <summary>
+    /// Determines locations of Reference Assemblies and Implementation Assemblies.
+    /// We need the Reference Assemblies for the Workspace API, and Implementation Assemblies for the CSharpScript APIs.
+    /// Sets of assemblies are per-shared-framework, e.g. Microsoft.NETCore.App or Microsoft.AspNetCore.App.
+    /// </summary>
+    /// <remarks>https://github.com/dotnet/designs/blob/main/accepted/2019/targeting-packs-and-runtime-packs.md</remarks>
+    internal sealed class DotNetInstallationLocator
+    {
+        private readonly ITraceLogger logger;
+
+        public DotNetInstallationLocator(ITraceLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Returns a SharedFramework that contains a list of reference and implementation assemblies in that framework.
+        /// It first tries to use a globally installed shared framework (e.g. in C:\Program Files\dotnet\) and falls back
+        /// to a shared framework installed in C:\Users\username\.nuget\packages\.
+        ///
+        /// Microsoft.NETCore.App is always returned, in addition to any other specified framework.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If no shared framework could be found</exception>
+        public SharedFramework[] GetSharedFrameworkConfiguration(string framework, Version version)
+        {
+            var dotnetRoot = GetDotNetRootPath();
+
+            // first, try loading from the system-wide folders, e.g. in C:\Program Files\dotnet\
+            var referenceAssemblyRoot = Path.Combine(dotnetRoot, "packs", framework + ".Ref");
+            var implementationAssemblyRoot = Path.Combine(dotnetRoot, "shared", framework);
+
+            logger.LogPaths("Available Reference Assemblies", () => Directory.GetDirectories(referenceAssemblyRoot));
+            logger.LogPaths("Available Implementation Assemblies", () => Directory.GetDirectories(implementationAssemblyRoot));
+
+            string? referencePath = GetGlobalReferenceAssemblyPath(referenceAssemblyRoot, version);
+            string? implementationPath = GetGlobalImplementationAssemblyPath(implementationAssemblyRoot, version);
+
+            // second, try loading from installed nuget packages, e.g. ~\.nuget\packages\microsoft.netcore.app.*
+            if (referencePath is null)
+            {
+                referencePath = FallbackToNugetReferencePath(framework, version);
+            }
+            if (implementationPath is null)
+            {
+                implementationPath = FallbackToNugetImplementationPath(framework, version);
+            }
+
+            if (referencePath is null || implementationPath is null)
+            {
+                throw new InvalidOperationException(
+                    "Could not determine the .NET SDK to use. Please install the latest .NET SDK installer from https://dotnet.microsoft.com/download" + Environment.NewLine
+                    + $@"Tried to find {version} with reference assemblies in ""{referenceAssemblyRoot}"" and implementation assemblies in ""{implementationAssemblyRoot}""." + Environment.NewLine
+                    + $@"Also tried falling back to ""{referencePath}"" and ""{implementationPath}"""
+                );
+            }
+
+            var referenceDlls = CreateDefaultReferences(
+                referencePath,
+                Directory.GetFiles(referencePath, "*.dll", SearchOption.TopDirectoryOnly)
+            );
+            var implementationDlls = CreateDefaultReferences(
+                implementationPath,
+                Directory.GetFiles(implementationPath, "*.dll", SearchOption.TopDirectoryOnly)
+            );
+
+            // Microsoft.NETCore.App is always loaded.
+            // e.g. if we're loading Microsoft.AspNetCore.App, load it alongside Microsoft.NETCore.App.
+            return framework switch
+            {
+                SharedFramework.NetCoreApp => new[] {
+                    new SharedFramework(referencePath, referenceDlls, implementationPath, implementationDlls)
+                },
+                _ => GetSharedFrameworkConfiguration(SharedFramework.NetCoreApp, version)
+                    .Append(new SharedFramework(referencePath, referenceDlls, implementationPath, implementationDlls))
+                    .ToArray()
+            };
+        }
+
+        /// <summary>
+        /// Returns path to globally installed Reference Assemblies like C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0\ref\net5.0
+        /// </summary>
+        private static string? GetGlobalReferenceAssemblyPath(string referenceAssemblyRoot, Version version)
+        {
+            var referenceAssemblyPath = Directory
+                .GetDirectories(referenceAssemblyRoot, "net*" + version.Major + "." + version.Minor + "*", SearchOption.AllDirectories)
+                .LastOrDefault();
+
+            if (referenceAssemblyPath is null)
+            {
+                return null;
+            }
+
+            return Path.GetFullPath(referenceAssemblyPath);
+        }
+
+        /// <summary>
+        /// Returns the path to globally installed Implementation Assemblies like C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.10
+        /// </summary>
+        private static string? GetGlobalImplementationAssemblyPath(string implementationAssemblyRoot, Version version)
+        {
+            var configuredFrameworkAndVersion = Directory
+                .GetDirectories(implementationAssemblyRoot, version.Major + "." + version.Minor + "*")
+                .OrderBy(path => ParseDotNetVersion(path))
+                .LastOrDefault();
+
+            return configuredFrameworkAndVersion;
+
+            static Version ParseDotNetVersion(string path)
+            {
+                var versionString = Path.GetFileName(path).Split('-', 2).First(); // discard trailing preview versions, e.g. 6.0.0-preview.4.21253.7 
+                return new Version(versionString);
+            }
+        }
+
+        /// <summary>
+        /// Returns a path like C:\Users\username\.nuget\packages\microsoft.aspnetcore.app.ref\5.0.0\ref\net5.0
+        /// or equivalent on mac os / linux.
+        /// </summary>
+        private string? FallbackToNugetReferencePath(string framework, Version version)
+        {
+            string nugetReferenceAssemblyRoot = Path.Combine(
+                Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
+                @".nuget\packages\",
+                framework.ToLowerInvariant() + ".ref"
+            );
+
+            logger.LogPaths("NuGet Reference Assemblies", () => Directory.GetDirectories(nugetReferenceAssemblyRoot));
+
+            return GetGlobalReferenceAssemblyPath(nugetReferenceAssemblyRoot, version);
+        }
+
+        /// <summary>
+        /// Returns a path like C:\Users\username\.nuget\packages\microsoft.aspnetcore.app.runtime.win-x86\5.0.8\runtimes\win-x86\lib\net5.0
+        /// or equivalent on mac os / linux.
+        /// </summary>
+        private string? FallbackToNugetImplementationPath(string framework, Version version)
+        {
+            string? platform = OperatingSystem.IsWindows() ? "win"
+                : OperatingSystem.IsLinux() ? "linux"
+                : OperatingSystem.IsMacOS() ? "osx"
+                : null;
+
+            if (platform is null) return null;
+
+            var nugetImplementationAssemblyRoot = Path.Combine(
+                Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
+                @".nuget\packages\",
+                (framework + ".runtime." + platform + "-" + RuntimeInformation.ProcessArchitecture).ToLowerInvariant()
+            );
+
+            logger.LogPaths("NuGet Implementation Assemblies", () => Directory.GetDirectories(nugetImplementationAssemblyRoot));
+
+            var implementationPath = GetGlobalImplementationAssemblyPath(nugetImplementationAssemblyRoot, version);
+
+            if (implementationPath is null) return null;
+
+            return Directory
+                .GetDirectories(implementationPath, "net*", SearchOption.AllDirectories)
+                .LastOrDefault();
+        }
+
+        private static string GetDotNetRootPath()
+        {
+            var dotnetRuntimePath = RuntimeEnvironment.GetRuntimeDirectory();
+            var dotnetRoot = Path.GetFullPath(Path.Combine(dotnetRuntimePath, "../../../"));
+            return dotnetRoot;
+        }
+
+        private static IReadOnlyCollection<MetadataReference> CreateDefaultReferences(string assemblyPath, IReadOnlyCollection<string> assemblies)
+        {
+            return assemblies
+                .AsParallel()
+                .Select(dll =>
+                {
+                    string fullReferencePath = Path.Combine(assemblyPath, dll);
+                    string fullDocumentationPath = Path.ChangeExtension(fullReferencePath, ".xml");
+
+                    if (!IsManagedAssembly(fullReferencePath))
+                        return null;
+
+                    return File.Exists(fullDocumentationPath)
+                        ? MetadataReference.CreateFromFile(fullReferencePath, documentation: XmlDocumentationProvider.CreateFromFile(fullDocumentationPath))
+                        : MetadataReference.CreateFromFile(fullReferencePath);
+                })
+                .WhereNotNull()
+                .ToList();
+        }
+
+        private static bool IsManagedAssembly(string assemblyPath)
+        {
+            try
+            {
+                _ = AssemblyName.GetAssemblyName(assemblyPath);
+                return true;
+            }
+            catch (FileNotFoundException) { return false; }
+            catch (BadImageFormatException) { return false; }
+        }
+    }
+}

--- a/CSharpRepl.Services/Roslyn/References/SharedFramework.cs
+++ b/CSharpRepl.Services/Roslyn/References/SharedFramework.cs
@@ -1,0 +1,43 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CSharpRepl.Services.Roslyn.References
+{
+    /// <summary>
+    /// Represents an installed Shared Framework. Can be a base framework (Microsoft.NETCore.App), ASP.NET, Windows Desktop, etc.
+    /// https://docs.microsoft.com/en-us/aspnet/core/fundamentals/metapackage-app?view=aspnetcore-5.0
+    /// </summary>
+    public class SharedFramework
+    {
+        public const string NetCoreApp = "Microsoft.NETCore.App";
+        public string ReferencePath { get; }
+        public string ImplementationPath { get; }
+        public IReadOnlyCollection<MetadataReference> ReferenceAssemblies { get; }
+        public IReadOnlyCollection<MetadataReference> ImplementationAssemblies { get; }
+
+        public SharedFramework(
+            string referencePath, IReadOnlyCollection<MetadataReference> ReferenceAssemblies,
+            string ImplementationPath, IReadOnlyCollection<MetadataReference> ImplementationAssemblies)
+        {
+            this.ReferencePath = referencePath;
+            this.ImplementationPath = ImplementationPath;
+            this.ReferenceAssemblies = ReferenceAssemblies;
+            this.ImplementationAssemblies = ImplementationAssemblies;
+        }
+
+        public static string[] SupportedFrameworks { get; } =
+            Path.GetDirectoryName(typeof(object).Assembly.Location) is string frameworkDirectory
+            ? Directory
+                .GetDirectories(Path.Combine(frameworkDirectory, "../../"))
+                .Select(dir => Path.GetFileName(dir))
+                .ToArray()
+            : Array.Empty<string>();
+    }
+}

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -68,7 +68,7 @@ namespace CSharpRepl.Services.Roslyn
                 // the script runner is used to actually execute the scripts, and the workspace manager
                 // is updated alongside. The workspace is a datamodel used in "editor services" like
                 // syntax highlighting, autocompletion, and roslyn symbol queries.
-                this.scriptRunner = new ScriptRunner(console, compilationOptions, referenceService);
+                this.scriptRunner = new ScriptRunner(compilationOptions, referenceService, console);
                 this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger);
 
                 this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -30,7 +30,7 @@ namespace CSharpRepl.Services.Roslyn.Scripting
         private ScriptOptions scriptOptions;
         private ScriptState<object>? state;
 
-        public ScriptRunner(IConsole console, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService)
+        public ScriptRunner(CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsole console)
         {
             this.console = console;
             this.referenceAssemblyService = referenceAssemblyService;

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="PrettyPrompt" Version="2.0.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.47" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -29,7 +29,7 @@ namespace CSharpRepl.Tests
             var console = Substitute.For<IConsole>();
             console.BufferWidth.Returns(200);
             var referenceService = new AssemblyReferenceService(new Configuration(), new TestTraceLogger());
-            var scriptRunner = new ScriptRunner(console, options, referenceService);
+            var scriptRunner = new ScriptRunner(options, referenceService, console);
 
             this.disassembler = new Disassembler(options, referenceService, scriptRunner);
             this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());

--- a/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
+++ b/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
@@ -1,0 +1,152 @@
+﻿using CSharpRepl.Services.Roslyn.References;
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+using System.IO;
+
+namespace CSharpRepl.Tests
+{
+    public class DotNetInstallationLocatorTest
+    {
+        [Fact]
+        public void GetSharedFrameworkConfiguration_Net5GlobalInstallation_IsLocated()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", MockFileData.NullObject }
+            });
+
+            var locator = new DotNetInstallationLocator(
+                logger: new TestTraceLogger(), io: fileSystem,
+                dotnetRuntimePath: @"/Program Files/dotnet/",
+                userProfilePath: @"/Users/bob/"
+            );
+
+            // system under test
+            var (refPath, implPath) = locator.FindInstallation("Microsoft.NETCore.App", new Version(5, 0, 14));
+
+            Assert.Equal(
+                CrossPlatform(@"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/ref/net5.0"),
+                CrossPlatform(refPath)
+            );
+            Assert.Equal(
+                CrossPlatform(@"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10"),
+                CrossPlatform(implPath)
+            );
+        }
+
+        [Fact]
+        public void GetSharedFrameworkConfiguration_NoGlobalNet5ReferenceAssemblies_UsesNuGetInstallation()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                // no net5.0 reference assemblies
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", MockFileData.NullObject },
+
+                // reference assemblies in .nuget installation
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+
+                // implement assemblies in .nuget installation
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+            });
+
+            var locator = new DotNetInstallationLocator(
+                logger: new TestTraceLogger(), io: fileSystem,
+                dotnetRuntimePath: @"/Program Files/dotnet/",
+                userProfilePath: @"/Users/bob/"
+            );
+
+            // system under test
+            var (refPath, implPath) = locator.FindInstallation("Microsoft.NETCore.App", new Version(5, 0, 10));
+
+            Assert.Equal(
+                CrossPlatform("/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0"),
+                CrossPlatform(refPath)
+            );
+            // it's possible that this could also be the implementation assemblies in ~/.nuget
+            Assert.Equal(
+                CrossPlatform(@"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10"),
+                CrossPlatform(implPath)
+            );
+        }
+
+        [Fact]
+        public void GetSharedFrameworkConfiguration_NoGlobalNet5Assemblies_UsesNuGetInstallation()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                // no global net5.0 assemblies
+                //
+
+                // reference assemblies in .nuget installation
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+
+                // implement assemblies in .nuget installation
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+            });
+
+            var locator = new DotNetInstallationLocator(
+                logger: new TestTraceLogger(), io: fileSystem,
+                dotnetRuntimePath: @"/Program Files/dotnet/",
+                userProfilePath: @"/Users/bob/"
+            );
+
+            // system under test
+            var (refPath, implPath) = locator.FindInstallation("Microsoft.NETCore.App", new Version(5, 0, 10));
+
+            Assert.Equal(
+                CrossPlatform(@"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0"),
+                CrossPlatform(refPath)
+            );
+
+            string platform = OperatingSystem.IsWindows() ? "win"
+                : OperatingSystem.IsLinux() ? "linux"
+                : OperatingSystem.IsMacOS() ? "osx"
+                : null;
+            // it's possible that this could also be the implementation assemblies in ~/.nuget
+            Assert.Equal(
+                CrossPlatform($@"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.{platform}-x64/5.0.8/runtimes/{platform}-x64/lib/net5.0"),
+                CrossPlatform(implPath)
+            );
+        }
+
+        /// <summary>
+        /// Converts a path to the operating system path. e.g. "/" vs "\", remove drive letters ("C:"), etc.
+        /// This is needed so the tests assert correctly when they're running under Windows, Linux, and Mac OS.
+        /// </summary>
+        private static string CrossPlatform(string path)
+        {
+            string fullPath = Path.GetFullPath(path);
+            return OperatingSystem.IsWindows()
+                ? fullPath.Split(Path.VolumeSeparatorChar, 2)[1]
+                : fullPath;
+        }
+    }
+}

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -1,32 +1,32 @@
 ﻿using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
-using System;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpRepl.Tests
 {
     [Collection(nameof(RoslynServices))]
-    public class ReadEvalPrintLoopTests : IAsyncLifetime
+    public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
     {
         private readonly ReadEvalPrintLoop repl;
         private readonly IConsole console;
         private readonly IPrompt prompt;
         private readonly RoslynServices services;
 
-        public ReadEvalPrintLoopTests()
+        public ReadEvalPrintLoopTests(RoslynServicesFixture fixture)
         {
-            this.console = Substitute.For<IConsole>();
-            this.prompt = Substitute.For<IPrompt>();
-            this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());
+            this.console = fixture.ConsoleStub;
+            this.prompt = fixture.PromptStub;
+            this.services = fixture.RoslynServices;
             this.repl = new ReadEvalPrintLoop(services, prompt, console);
-        }
 
-        public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
-        public Task DisposeAsync() => Task.CompletedTask;
+            this.console.ClearSubstitute();
+            this.prompt.ClearSubstitute();
+        }
 
         [Theory]
         [InlineData("help")]

--- a/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -1,0 +1,29 @@
+﻿using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using NSubstitute;
+using PrettyPrompt;
+using PrettyPrompt.Consoles;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpRepl.Tests
+{
+    public sealed class RoslynServicesFixture : IAsyncLifetime
+    {
+        public IConsole ConsoleStub { get; }
+        public IPrompt PromptStub { get; }
+        public RoslynServices RoslynServices { get; }
+
+        public RoslynServicesFixture()
+        {
+            this.ConsoleStub = Substitute.For<IConsole>();
+            this.PromptStub = Substitute.For<IPrompt>();
+            this.RoslynServices = new RoslynServices(ConsoleStub, new Configuration(), new TestTraceLogger());
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        public Task InitializeAsync() => RoslynServices.WarmUpAsync(Array.Empty<string>());
+    }
+}

--- a/CSharpRepl.Tests/TraceLoggerTests.cs
+++ b/CSharpRepl.Tests/TraceLoggerTests.cs
@@ -7,29 +7,43 @@ using Xunit;
 
 namespace CSharpRepl.Tests
 {
+    /// <summary>
+    /// more of an integration test than anything; we want to make sure the logger actually does log to a file.
+    /// </summary>
     public class TraceLoggerTests
     {
         [Fact]
-        public void Test()
+        public void Create_ThenLog_WritesToFile()
         {
-            // more of an integration test than anything; we want to
-            // make sure the logger actually does log to a file.
-
             var path = Path.GetTempFileName();
             var logger = TraceLogger.Create(path);
+
             logger.Log("Hello World, I'm a hopeful and optimistic REPL.");
-            logger.Log("Arrgghh an error");
+            logger.Log(() => "Arrgghh an error");
 
             var loggedLines = File.ReadAllLines(path);
-
             Assert.Contains("Trace session starting", loggedLines[0]);
             Assert.Contains("Hello World, I'm a hopeful and optimistic REPL.", loggedLines[1]);
             Assert.Contains("Arrgghh an error", loggedLines[2]);
         }
+
+        [Fact]
+        public void LogPaths_GivenPaths_GroupsByPrefix()
+        {
+            var path = Path.GetTempFileName();
+            var logger = TraceLogger.Create(path);
+
+            logger.LogPaths("Some Files", () => new[] { @"/Foo/Bar.txt", @"/Foo/Baz.txt" });
+
+            var loggedLines = File.ReadAllLines(path);
+            Assert.Contains("Trace session starting", loggedLines[0]);
+            Assert.Contains(@"Some Files: ", loggedLines[1]); 
+            Assert.EndsWith(@"[""Bar.txt"", ""Baz.txt""]", loggedLines[1]);
+        }
     }
 
     /// <summary>
-    /// Executes the delayed evaluation Funcs for testing purposes (to make sure they don't throw).
+    /// Executes the delayed evaluation Funcs for testing purposes (to make sure they don't throw exceptions).
     /// </summary>
     public class TestTraceLogger : ITraceLogger
     {

--- a/CSharpRepl.Tests/TraceLoggerTests.cs
+++ b/CSharpRepl.Tests/TraceLoggerTests.cs
@@ -1,6 +1,7 @@
 ﻿using CSharpRepl.Logging;
 using CSharpRepl.Services.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -27,10 +28,15 @@ namespace CSharpRepl.Tests
         }
     }
 
+    /// <summary>
+    /// Executes the delayed evaluation Funcs for testing purposes (to make sure they don't throw).
+    /// </summary>
     public class TestTraceLogger : ITraceLogger
     {
-        public void Log(string message) => Console.WriteLine(message);
+        public void Log(string message) { }
 
-        public void Log(Func<string> message) => Console.WriteLine(message());
+        public void Log(Func<string> message) { message(); }
+
+        public void LogPaths(string message, Func<IEnumerable<string>> paths) => paths();
     }
 }

--- a/CSharpRepl/Logging/NullLogger.cs
+++ b/CSharpRepl/Logging/NullLogger.cs
@@ -4,12 +4,17 @@
 
 using CSharpRepl.Services.Logging;
 using System;
+using System.Collections.Generic;
 
 namespace CSharpRepl.Logging
 {
+    /// <summary>
+    /// NullLogger is used by default. <see cref="TraceLogger"/> is used when the --trace flag is provided.
+    /// </summary>
     internal sealed class NullLogger : ITraceLogger
     {
         public void Log(string message) { /* null logger does not log */ }
         public void Log(Func<string> message) { /* null logger does not log */ }
+        public void LogPaths(string message, Func<IEnumerable<string?>> paths) { /* null logger does not log */ }
     }
 }

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -22,30 +22,34 @@ namespace CSharpRepl
     /// </summary>
     static class Program
     {
+
         internal static async Task<int> Main(string[] args)
         {
             var console = new SystemConsole();
 
             if (!TryParseArguments(args, out var config))
-                return 1;
+                return ExitCodes.ErrorParseArguments;
 
             if (config.OutputForEarlyExit is not null)
             {
                 console.WriteLine(config.OutputForEarlyExit);
-                return 0;
+                return ExitCodes.Success;
             }
 
             var appStorage = CreateApplicationStorageDirectory();
 
             var logger = InitializeLogging(config.Trace);
             var roslyn = new RoslynServices(console, config, logger);
-            var prompt = InitializePrompt(console, appStorage, roslyn);
+            var (prompt, exitCode) = InitializePrompt(console, appStorage, roslyn);
 
-            await new ReadEvalPrintLoop(roslyn, prompt, console)
-                .RunAsync(config)
-                .ConfigureAwait(false);
+            if (prompt is not null)
+            {
+                await new ReadEvalPrintLoop(roslyn, prompt, console)
+                    .RunAsync(config)
+                    .ConfigureAwait(false);
+            }
 
-            return 0;
+            return exitCode;
         }
 
 
@@ -91,24 +95,39 @@ namespace CSharpRepl
             return TraceLogger.Create($"csharprepl-tracelog-{DateTime.UtcNow:yyyy-MM-dd}.txt");
         }
 
-        private static Prompt InitializePrompt(SystemConsole console, string appStorage, RoslynServices roslyn)
+        private static (Prompt? prompt, int exitCode) InitializePrompt(SystemConsole console, string appStorage, RoslynServices roslyn)
         {
             try
             {
-                return new Prompt(
+                var prompt = new Prompt(
                     persistentHistoryFilepath: Path.Combine(appStorage, "prompt-history"),
                     callbacks: PromptConfiguration.Configure(console, roslyn)
                 );
+                return (prompt, ExitCodes.Success);
             }
-            catch (InvalidOperationException ex) when (ex.Message.Contains("error code: 87"))
+            catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 87", StringComparison.Ordinal))
             {
                 Console.Error.WriteLine(
-                    "Failed to initialize prompt. Please make sure that:" + Environment.NewLine
-                    + " - The OS is Windows 10 version 1511 (build number 10586) or greater." + Environment.NewLine
-                    + " - The current terminal supports ANSI escape sequences. For Command Prompt, make sure \"Use legacy console\" is disabled." + Environment.NewLine
+                    "Failed to initialize prompt. Please make sure that the current terminal supports ANSI escape sequences." + Environment.NewLine
+                    + (OperatingSystem.IsWindows()
+                        ? @"This requires at least Windows 10 version 1511 (build number 10586) and ""Use legacy console"" to be disabled in the Command Prompt." + Environment.NewLine
+                        : string.Empty)
                 );
-                throw;
+                return (null, ExitCodes.ErrorAnsiEscapeSequencesNotSupported);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 6", StringComparison.Ordinal))
+            {
+                Console.Error.WriteLine("Failed to initialize prompt. Invalid output mode -- is output redirected?");
+                return (null, ExitCodes.ErrorInvalidConsoleHandle);
             }
         }
+    }
+
+    internal static class ExitCodes
+    {
+        public const int Success = 0;
+        public const int ErrorParseArguments = 1;
+        public const int ErrorAnsiEscapeSequencesNotSupported = 2;
+        public const int ErrorInvalidConsoleHandle = 3;
     }
 }

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -39,11 +39,12 @@ namespace CSharpRepl
             while (true)
             {
                 var response = await prompt.ReadLineAsync("> ").ConfigureAwait(false);
+
                 if (response.IsSuccess)
                 {
                     var commandText = response.Text.Trim().ToLowerInvariant();
 
-                    // process built in commands
+                    // evaluate built in commands
                     if (commandText == "exit") { break; }
                     if (commandText == "clear") { console.Clear(); continue; }
                     if (new[] { "help", "#help", "?" }.Contains(commandText))
@@ -52,14 +53,14 @@ namespace CSharpRepl
                         continue;
                     }
 
-                    // process results returned by special keybindings (configured in the PromptConfiguration.cs)
+                    // evaluate results returned by special keybindings (configured in the PromptConfiguration.cs)
                     if(response is KeyPressCallbackResult callbackOutput)
                     {
                         console.WriteLine(Environment.NewLine + callbackOutput.Output);
                         continue;
                     }
 
-                    // process C# code and directives
+                    // evaluate C# code and directives
                     var result = await roslyn
                         .EvaluateAsync(response.Text, config.LoadScriptArgs, response.CancellationToken)
                         .ConfigureAwait(false);
@@ -124,9 +125,9 @@ https://github.com/waf/CSharpRepl/blob/main/README.md
 
 Evaluating Code
 ===============
-Type C# at the prompt and press {Blue("Enter")} to run it. The result will be printed.
-{Blue("Ctrl+Enter")} will also run the code, but show detailed member info / stack traces.
-{Blue("Shift+Enter")} will insert a newline, to support multiple lines of input.
+Type C# at the prompt and press {Underline("Enter")} to run it. The result will be printed.
+{Underline("Ctrl+Enter")} will also run the code, but show detailed member info / stack traces.
+{Underline("Shift+Enter")} will insert a newline, to support multiple lines of input.
 If the code isn't a complete statement, pressing Enter will insert a newline.
 
 Adding References
@@ -142,9 +143,9 @@ to load.
 
 Exploring Code
 ==============
-{Blue("F1")}: when the caret is in a type or member, open the corresponding MSDN documentation.
-{Blue("F9")}: show the IL (intermediate language) for the current statement.
-{Blue("F12")}: open the type's source code in the browser, if the assembly supports Source Link.
+{Underline("F1")}: when the caret is in a type or member, open the corresponding MSDN documentation.
+{Underline("F9")}: show the IL (intermediate language) for the current statement.
+{Underline("F12")}: open the type's source code in the browser, if the assembly supports Source Link.
 
 Configuration Options
 =====================
@@ -168,17 +169,12 @@ Run --help at the command line to view these options
             return highlightedKeyword + highlightedArgument;
         }
 
-        private string VariableDeclaration =>
-            prompt.HasUserOptedOutFromColor
-            ? "var x ="
-            : (Color("keyword") + "var" + AnsiEscapeCodes.Reset + " " +
-               Color("field name") + "x" + AnsiEscapeCodes.Reset + " " +
-               Color("operator") + "=" + AnsiEscapeCodes.Reset);
-
         private string Color(string reference) =>
-            AnsiEscapeCodes.ToAnsiEscapeSequence(new ConsoleFormat(roslyn!.ToColor(reference)));
+            prompt.HasUserOptedOutFromColor
+            ? string.Empty
+            : AnsiEscapeCodes.ToAnsiEscapeSequence(new ConsoleFormat(roslyn!.ToColor(reference)));
 
-        private string Blue(string word) =>
+        private static string Underline(string word) =>
             AnsiEscapeCodes.ToAnsiEscapeSequence(new ConsoleFormat(Underline: true))
             + word + AnsiEscapeCodes.Reset;
 


### PR DESCRIPTION
Preliminary fix for #40 -- support scenarios where shared frameworks are installed to the ~/.nuget directory, rather than "C:/Program Files/dotnet" (or Linux / Mac OS equivalent). See https://github.com/dotnet/designs/blob/main/accepted/2019/targeting-packs-and-runtime-packs.md