### PR TITLE
Allow graceful exit in more scenarios

### DIFF
--- a/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -43,6 +43,8 @@ namespace CSharpRepl.Tests
             yield return new object[] { (ConsoleModifiers.Control, ConsoleKey.F1) };
             yield return new object[] { ConsoleKey.F9 };
             yield return new object[] { (ConsoleModifiers.Control, ConsoleKey.F9) };
+            yield return new object[] { ConsoleKey.F12 };
+            yield return new object[] { (ConsoleModifiers.Control, ConsoleKey.D) };
         }
     }
 }

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -1,4 +1,5 @@
-﻿using CSharpRepl.Services;
+﻿using CSharpRepl.PrettyPromptConfig;
+using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using NSubstitute;
 using NSubstitute.ClearExtensions;
@@ -126,6 +127,20 @@ namespace CSharpRepl.Tests
             await repl.RunAsync(new Configuration());
 
             console.Received().WriteErrorLine(Arg.Is<string>(message => message.Contains("bonk")));
+        }
+
+        [Fact]
+        public async Task RunAsync_ExitCommand_ExitsRepl()
+        {
+            prompt
+                .ReadLineAsync("> ")
+                .Returns(
+                    new ExitApplicationKeyPress()
+                );
+
+            await repl.RunAsync(new Configuration());
+
+            // by reaching here, the application correctly exited.
         }
     }
 }

--- a/CSharpRepl/PrettyPromptConfig/PromptConfiguration.cs
+++ b/CSharpRepl/PrettyPromptConfig/PromptConfiguration.cs
@@ -38,6 +38,7 @@ namespace CSharpRepl.PrettyPromptConfig
                     [ConsoleKey.F9] = DisassembleDebug,
                     [(ConsoleModifiers.Control, ConsoleKey.F9)] = DisassembleRelease,
                     [ConsoleKey.F12] = LaunchSourceForSymbol,
+                    [(ConsoleModifiers.Control, ConsoleKey.D)] = ExitApplication,
                 }
             };
 
@@ -61,6 +62,9 @@ namespace CSharpRepl.PrettyPromptConfig
 
             Task<KeyPressCallbackResult?> DisassembleRelease(string text, int caret) =>
                 Disassemble(roslyn, text, console, debugMode: false);
+
+            Task<KeyPressCallbackResult?> ExitApplication(string text, int caret) =>
+                Task.FromResult<KeyPressCallbackResult?>(new ExitApplicationKeyPress());
         }
 
         private static async Task<KeyPressCallbackResult?> Disassemble(RoslynServices roslyn, string text, IConsole console, bool debugMode)
@@ -134,4 +138,9 @@ namespace CSharpRepl.PrettyPromptConfig
                 })
                 .ToArray();
     }
+
+    /// <summary>
+    /// Used when the user presses an "exit application" key combo (ctrl-d) to instruct the main REPL loop to end.
+    /// </summary>
+    sealed record ExitApplicationKeyPress() : KeyPressCallbackResult(null, null);
 }

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -1,4 +1,5 @@
-﻿using CSharpRepl.Services;
+﻿using CSharpRepl.PrettyPromptConfig;
+using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
 using PrettyPrompt;
@@ -40,6 +41,11 @@ namespace CSharpRepl
             {
                 var response = await prompt.ReadLineAsync("> ").ConfigureAwait(false);
 
+                if (response is ExitApplicationKeyPress)
+                {
+                    break;
+                }
+
                 if (response.IsSuccess)
                 {
                     var commandText = response.Text.Trim().ToLowerInvariant();
@@ -59,6 +65,8 @@ namespace CSharpRepl
                         console.WriteLine(Environment.NewLine + callbackOutput.Output);
                         continue;
                     }
+
+                    response.CancellationToken.Register(() => Environment.Exit(1));
 
                     // evaluate C# code and directives
                     var result = await roslyn


### PR DESCRIPTION
- Exit when user presses ctrl-d; this is pretty typical behavior for command line applications
- If the user presses ctrl-c when there's a long running (or infinite!) evaluation, exit the application. Ideally we'd be able to abort the evaluation and keep the application running, but that's not really possible or supported by Roslyn. It's better than completely ignoring the user's keypress, which is what currently happens.