### PR TITLE
Syntax highlighting in completion items and its descriptions.

### DIFF
--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -2,28 +2,33 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CSharpRepl.Services.Extensions;
+using CSharpRepl.Services.SyntaxHighlighting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.Extensions.Caching.Memory;
 using PrettyPrompt.Highlighting;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 using PrettyPromptCompletionItem = PrettyPrompt.Completion.CompletionItem;
 
 namespace CSharpRepl.Services.Completion;
 
-public record CompletionItemWithDescription(CompletionItem Item, PrettyPromptCompletionItem.GetExtendedDescriptionHandler GetDescriptionAsync);
+public record CompletionItemWithDescription(CompletionItem Item, FormattedString DisplayText, PrettyPromptCompletionItem.GetExtendedDescriptionHandler GetDescriptionAsync);
 
 internal sealed class AutoCompleteService
 {
     private const string CacheKeyPrefix = "AutoCompleteService_";
+
+    private readonly SyntaxHighlighter highlighter;
     private readonly IMemoryCache cache;
 
-    public AutoCompleteService(IMemoryCache cache)
+    public AutoCompleteService(SyntaxHighlighter highlighter, IMemoryCache cache)
     {
+        this.highlighter = highlighter;
         this.cache = cache;
     }
 
@@ -39,15 +44,30 @@ internal sealed class AutoCompleteService
             .ConfigureAwait(false);
 
         var completionsWithDescriptions = completions?.Items
-            .Select(item => new CompletionItemWithDescription(item, cancellationToken => GetExtendedDescription(document, item)))
+            .Select(item => new CompletionItemWithDescription(item, GetDisplayText(item), cancellationToken => GetExtendedDescriptionAsync(document, item, highlighter)))
             .ToArray() ?? Array.Empty<CompletionItemWithDescription>();
 
         cache.Set(cacheKey, completionsWithDescriptions, DateTimeOffset.Now.AddMinutes(1));
 
         return completionsWithDescriptions;
+
+        FormattedString GetDisplayText(CompletionItem item)
+        {
+            var text = item.DisplayTextPrefix + item.DisplayText + item.DisplayTextSuffix;
+            if (item.Tags.Length > 0)
+            {
+                var classification = RoslynExtensions.TextTagToClassificationTypeName(item.Tags.First());
+                if (classification is not null &&
+                    highlighter.TryGetColor(classification, out var color))
+                {
+                    return new FormattedString(text, new FormatSpan(0, text.Length, new ConsoleFormat(Foreground: color)));
+                }
+            }
+            return text;
+        }
     }
 
-    private static async Task<FormattedString> GetExtendedDescription(Document document, CompletionItem item)
+    private static async Task<FormattedString> GetExtendedDescriptionAsync(Document document, CompletionItem item, SyntaxHighlighter highlighter)
     {
         var currentText = await document.GetTextAsync().ConfigureAwait(false);
         var completedText = currentText.Replace(item.Span, item.DisplayText);
@@ -57,8 +77,28 @@ internal sealed class AutoCompleteService
         if (infoService is null) return string.Empty;
 
         var info = await infoService.GetQuickInfoAsync(completedDocument, item.Span.End).ConfigureAwait(false);
-        return info is null
-            ? string.Empty
-            : string.Join(Environment.NewLine, info.Sections.Select(s => s.Text));
+        if (info is null) return FormattedString.Empty;
+
+        var stringBuilder = new FormattedStringBuilder();
+
+        for (int sectionIndex = 0; sectionIndex < info.Sections.Length; sectionIndex++)
+        {
+            var section = info.Sections[sectionIndex];
+            foreach (var taggedText in section.TaggedParts)
+            {
+                var classification = RoslynExtensions.TextTagToClassificationTypeName(taggedText.Tag);
+                if (classification is not null &&
+                    highlighter.TryGetColor(classification, out var color))
+                {
+                    stringBuilder.Append(taggedText.Text, new FormatSpan(0, taggedText.Text.Length, new ConsoleFormat(Foreground: color)));
+                }
+                else
+                {
+                    stringBuilder.Append(taggedText.Text);
+                }
+            }
+            if (sectionIndex + 1 < info.Sections.Length) stringBuilder.Append(Environment.NewLine);
+        }
+        return stringBuilder.ToFormattedString();
     }
 }

--- a/CSharpRepl.Services/Extensions/RoslynExtensions.cs
+++ b/CSharpRepl.Services/Extensions/RoslynExtensions.cs
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
 
 namespace CSharpRepl.Services.Extensions;
 
@@ -16,5 +17,43 @@ internal static class RoslynExtensions
             throw new InvalidOperationException("Failed to apply edit to workspace");
         }
         return workspace.CurrentSolution;
+    }
+
+    //Source: https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/Common/TaggedText.cs
+    //Unfortunately this method is internal, so here is copy.
+    public static string? TextTagToClassificationTypeName(string taggedTextTag)
+    {
+        return taggedTextTag switch
+        {
+            TextTags.Keyword => ClassificationTypeNames.Keyword,
+            TextTags.Class => ClassificationTypeNames.ClassName,
+            TextTags.Delegate => ClassificationTypeNames.DelegateName,
+            TextTags.Enum => ClassificationTypeNames.EnumName,
+            TextTags.Interface => ClassificationTypeNames.InterfaceName,
+            TextTags.Module => ClassificationTypeNames.ModuleName,
+            TextTags.Struct or "Structure" => ClassificationTypeNames.StructName,
+            TextTags.TypeParameter => ClassificationTypeNames.TypeParameterName,
+            TextTags.Field => ClassificationTypeNames.FieldName,
+            TextTags.Event => ClassificationTypeNames.EventName,
+            TextTags.Label => ClassificationTypeNames.LabelName,
+            TextTags.Local => ClassificationTypeNames.LocalName,
+            TextTags.Method => ClassificationTypeNames.MethodName,
+            TextTags.Namespace => ClassificationTypeNames.NamespaceName,
+            TextTags.Parameter => ClassificationTypeNames.ParameterName,
+            TextTags.Property => ClassificationTypeNames.PropertyName,
+            TextTags.ExtensionMethod => ClassificationTypeNames.ExtensionMethodName,
+            TextTags.EnumMember => ClassificationTypeNames.EnumMemberName,
+            TextTags.Constant => ClassificationTypeNames.ConstantName,
+            TextTags.Alias or TextTags.Assembly or TextTags.ErrorType or TextTags.RangeVariable => ClassificationTypeNames.Identifier,
+            TextTags.NumericLiteral => ClassificationTypeNames.NumericLiteral,
+            TextTags.StringLiteral => ClassificationTypeNames.StringLiteral,
+            TextTags.Space or TextTags.LineBreak => ClassificationTypeNames.WhiteSpace,
+            TextTags.Operator => ClassificationTypeNames.Operator,
+            TextTags.Punctuation => ClassificationTypeNames.Punctuation,
+            TextTags.AnonymousTypeIndicator or TextTags.Text => ClassificationTypeNames.Text,
+            TextTags.Record => ClassificationTypeNames.RecordClassName,
+            TextTags.RecordStruct => ClassificationTypeNames.RecordStructName,
+            _ => null,
+        };
     }
 }

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -72,14 +72,14 @@ public sealed class RoslynServices
             this.scriptRunner = new ScriptRunner(compilationOptions, referenceService, console);
             this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger);
 
-            this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);
-            this.prettyPrinter = new PrettyPrinter();
-            this.symbolExplorer = new SymbolExplorer(referenceService, scriptRunner);
-            this.autocompleteService = new AutoCompleteService(cache);
-            logger.Log("Background initialization complete");
-        });
-        Initialization.ContinueWith(task => console.WriteErrorLine(task.Exception?.Message ?? "Unknown error"), TaskContinuationOptions.OnlyOnFaulted);
-    }
+                this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);
+                this.prettyPrinter = new PrettyPrinter();
+                this.symbolExplorer = new SymbolExplorer(referenceService, scriptRunner);
+                this.autocompleteService = new AutoCompleteService(highlighter, cache);
+                logger.Log("Background initialization complete");
+            });
+            Initialization.ContinueWith(task => console.WriteErrorLine(task.Exception?.Message ?? "Unknown error"), TaskContinuationOptions.OnlyOnFaulted);
+        }
 
     public async Task<EvaluationResult> EvaluateAsync(string input, string[]? args = null, CancellationToken cancellationToken = default)
     {

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -38,7 +38,7 @@ internal sealed class SyntaxHighlighter
                 File.ReadAllText(themeName),
                 new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
               ) ?? Theme.DefaultTheme;
-        this.unhighlightedColor = theme.GetValueOrDefault("text") ?? AnsiColor.Black;
+        this.unhighlightedColor = theme.GetValueOrDefault("text") ?? AnsiColor.White;
     }
 
     internal async Task<IReadOnlyCollection<HighlightedSpan>> HighlightAsync(Document document)
@@ -69,4 +69,5 @@ internal sealed class SyntaxHighlighter
     }
 
     internal AnsiColor GetColor(string keyword) => theme.GetValueOrDefault(keyword, unhighlightedColor);
+    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetColor(keyword, out color);
 }

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -75,4 +75,5 @@ internal sealed class Theme
 
     public AnsiColor? GetValueOrDefault(string name) => values.GetValueOrDefault(name);
     public AnsiColor GetValueOrDefault(string name, AnsiColor defaultValue) => values.GetValueOrDefault(name, defaultValue);
+    public bool TryGetColor(string name, out AnsiColor color) => values.TryGetValue(name, out color);
 }

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -66,7 +66,7 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
               .ThenBy(i => i.Item.SortText)
               .Select(r => new CompletionItem(
                   replacementText: r.Item.DisplayText,
-                  displayText: r.Item.DisplayTextPrefix + r.Item.DisplayText + r.Item.DisplayTextSuffix,
+                  displayText: r.DisplayText,
                   getExtendedDescription: r.GetDescriptionAsync,
                   filterText: r.Item.FilterText
               ))


### PR DESCRIPTION
Hi!

This builds upon changes made in PR https://github.com/waf/PrettyPrompt/pull/17.

This change adds semantic highlighting to completion items and to its descriptions. Examples:
![image](https://user-images.githubusercontent.com/11704036/154780095-8de6f715-f2a8-43b4-8cf8-7411eafa1850.png)
![image](https://user-images.githubusercontent.com/11704036/154780135-a556a1e1-1739-4eee-9ac4-81d274c758e9.png)

With things built in PrettyPromt PR it was quite simple. Only inconvenience was translation of ```TextTag``` to ```ClassificationTypeName``` (both are of ```string``` type). I found translation inside Roslyn repo but it is internal, so I copied it. Even though I had to manually add "Structure".

Thanks for great tool and I hope you will like these PRs.