### PR TITLE
Theme refactoring

### DIFF
--- a/CSharpRepl.Services/Theming/Color.cs
+++ b/CSharpRepl.Services/Theming/Color.cs
@@ -1,0 +1,55 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using PrettyPrompt.Highlighting;
+
+namespace CSharpRepl.Services.Theming;
+
+internal readonly struct Color
+{
+    private static readonly Dictionary<string, AnsiColor> ansiColorNames =
+        typeof(AnsiColor)
+        .GetFields(BindingFlags.Static | BindingFlags.Public)
+        .Where(f => f.FieldType == typeof(AnsiColor))
+        .ToDictionary(f => f.Name, f => (AnsiColor)f.GetValue(null)!);
+
+    [JsonConstructor]
+    public Color(string name, string foreground)
+    {
+        Debug.Assert(!string.IsNullOrEmpty(name));
+        Debug.Assert(!string.IsNullOrEmpty(foreground));
+
+        Name = name;
+        Foreground = foreground;
+    }
+
+    public string Name { get; }
+    public string Foreground { get; }
+
+    public AnsiColor ToAnsiColor()
+    {
+        var span = Foreground.AsSpan();
+        if (Foreground.StartsWith('#') && Foreground.Length == 7 &&
+            byte.TryParse(span.Slice(1, 2), NumberStyles.AllowHexSpecifier, null, out byte r) &&
+            byte.TryParse(span.Slice(3, 2), NumberStyles.AllowHexSpecifier, null, out byte g) &&
+            byte.TryParse(span.Slice(5, 2), NumberStyles.AllowHexSpecifier, null, out byte b))
+        {
+            return AnsiColor.RGB(r, g, b);
+        }
+
+        if (ansiColorNames.TryGetValue(Foreground, out AnsiColor? color))
+        {
+            return color;
+        }
+
+        throw new ArgumentException($"Unknown recognized color '{Foreground}'. Expecting either a hexadecimal color of the format #RRGGBB or a standard ANSI color name");
+    }
+}

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -2,14 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.Classification;
+using Newtonsoft.Json;
+using PrettyPrompt.Highlighting;
 
-namespace CSharpRepl.Services.SyntaxHighlighting;
+namespace CSharpRepl.Services.Theming;
 
-internal sealed class DefaultTheme : Theme
+internal sealed class Theme
 {
-    public DefaultTheme() : base(new[]
-    {
+    private static readonly Lazy<Theme> defaultTheme = new(
+        () =>
+        new(new[]
+        {
             new Color(name: ClassificationTypeNames.ClassName, foreground: "BrightCyan"),
             new Color(name: ClassificationTypeNames.StructName, foreground: "BrightCyan"),
             new Color(name: ClassificationTypeNames.DelegateName, foreground: "BrightCyan"),
@@ -51,28 +58,21 @@ internal sealed class DefaultTheme : Theme
             new Color(name: ClassificationTypeNames.XmlDocCommentName, foreground: "Cyan"),
             new Color(name: ClassificationTypeNames.XmlDocCommentProcessingInstruction, foreground: "Cyan"),
             new Color(name: ClassificationTypeNames.XmlDocCommentText, foreground: "Cyan")
-        })
-    { }
-}
+        }));
 
-internal class Theme
-{
-    public Theme(Color[] colors)
-    {
-        this.Colors = colors;
-    }
+    public static Theme DefaultTheme => defaultTheme.Value;
 
     public Color[] Colors { get; }
-}
 
-internal sealed class Color
-{
-    public Color(string name, string foreground)
+    [JsonIgnore]
+    private readonly Dictionary<string, AnsiColor> values;
+
+    public Theme(Color[] colors)
     {
-        this.Name = name;
-        this.Foreground = foreground;
+        Colors = colors;
+        values = colors.ToDictionary(c => c.Name, c => c.ToAnsiColor());
     }
 
-    public string Name { get; }
-    public string Foreground { get; }
+    public AnsiColor? GetValueOrDefault(string name) => values.GetValueOrDefault(name);
+    public AnsiColor GetValueOrDefault(string name, AnsiColor defaultValue) => values.GetValueOrDefault(name, defaultValue);
 }

--- a/CSharpRepl.Tests/Data/theme.json
+++ b/CSharpRepl.Tests/Data/theme.json
@@ -1,7 +1,7 @@
 {
     "colors": [
-        { "name": "class name", "foreground": "#8BE9FD" },
-        { "name": "struct name", "foreground": "#8BE9FD" },
+        { "name": "class name", "foreground": "BrightMagenta" },
+        { "name": "struct name", "foreground": "Yellow" },
         { "name": "delegate name", "foreground": "#8BE9FD" },
         { "name": "interface name", "foreground": "#8BE9FD" },
         { "name": "module name", "foreground": "#8BE9FD" },


### PR DESCRIPTION
Elimination of ```DefaultTheme```. Move to ```Theming``` namespace. Simplified usage.