### PR TITLE
Fix of soft-enter for non-complete statements.

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="3.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.1" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />
   </ItemGroup>
 

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="PrettyPrompt" Version="3.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.1" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.47" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -34,7 +34,7 @@ public class PromptConfigurationTests : IAsyncLifetime
     [MemberData(nameof(KeyPresses))]
     public void PromptConfiguration_CanCreate(ConsoleKeyInfo keyInfo)
     {
-        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services);
+        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
         Assert.True(configuration.TryGetKeyPressCallbacks(keyInfo, out var callback));
         callback.Invoke("Console.WriteLine(\"Hi!\");", 0, default);
     }
@@ -42,10 +42,10 @@ public class PromptConfigurationTests : IAsyncLifetime
     public static IEnumerable<object[]> KeyPresses()
     {
         yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F1, shift: false, alt: false, control: false) };
-        yield return new object[] { new ConsoleKeyInfo('\0',  ConsoleKey.F1, shift: false, alt: false, control: true) };
+        yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F1, shift: false, alt: false, control: true) };
         yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F9, shift: false, alt: false, control: false) };
-        yield return new object[] { new ConsoleKeyInfo('\0',  ConsoleKey.F9, shift: false, alt: false, control: true) };
+        yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F9, shift: false, alt: false, control: true) };
         yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F12, shift: false, alt: false, control: false) };
-        yield return new object[] { new ConsoleKeyInfo('\0',  ConsoleKey.D, shift: false, alt: false, control: true) };
+        yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.D, shift: false, alt: false, control: true) };
     }
 }

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="3.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
   </ItemGroup>

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -99,7 +99,7 @@ static class Program
         {
             var prompt = new Prompt(
                persistentHistoryFilepath: Path.Combine(appStorage, "prompt-history"),
-               callbacks: new CSharpReplPromptCallbacks(console, roslyn),
+               callbacks: new CSharpReplPromptCallbacks(console, roslyn, config),
                configuration: new PromptConfiguration(keyBindings: config.KeyBindings));
             return (prompt, ExitCodes.Success);
         }


### PR DESCRIPTION
This is a fix of soft-enter issue (#68) which needs PrettyPrompt 3.0.1.