### PR TITLE
Configurable key-bindings for 'prompt submit with detialed output'. --submitPromptDetailedKeys

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -39,7 +39,9 @@ public sealed class Configuration
     public string? LoadScript { get; }
     public string[] LoadScriptArgs { get; }
     public string? OutputForEarlyExit { get; }
+
     public KeyBindings KeyBindings { get; }
+    public KeyPressPatterns SubmitPromptDetailedKeys { get; }
 
     public Configuration(
         string[]? references = null,
@@ -53,7 +55,8 @@ public sealed class Configuration
         string[]? commitCompletionKeyPatterns = null,
         string[]? triggerCompletionListKeyPatterns = null,
         string[]? newLineKeyPatterns = null,
-        string[]? submitPromptKeyPatterns = null)
+        string[]? submitPromptKeyPatterns = null,
+        string[]? submitPromptDetailedKeyPatterns = null)
     {
         References = references?.ToHashSet() ?? new HashSet<string>();
         Usings = usings?.ToHashSet() ?? new HashSet<string>();
@@ -83,7 +86,18 @@ public sealed class Configuration
             : new KeyPressPatterns(new(ConsoleModifiers.Control, ConsoleKey.Spacebar), new(ConsoleModifiers.Control, ConsoleKey.J));
 
         var newLine = newLineKeyPatterns?.Any() == true ? ParseKeyPressPatterns(newLineKeyPatterns) : default;
-        var submitPrompt = submitPromptKeyPatterns?.Any() == true ? ParseKeyPressPatterns(submitPromptKeyPatterns) : default;
+
+        if (submitPromptKeyPatterns?.Any() != true)
+        {
+            submitPromptKeyPatterns = new[] { "Enter" };
+        }
+        if (submitPromptDetailedKeyPatterns?.Any() != true)
+        {
+            submitPromptDetailedKeyPatterns = new[] { "Ctrl+Enter", "Ctrl+Alt+Enter" };
+        }
+
+        var submitPrompt = ParseKeyPressPatterns(submitPromptKeyPatterns.Concat(submitPromptDetailedKeyPatterns).ToArray());
+        SubmitPromptDetailedKeys = ParseKeyPressPatterns(submitPromptDetailedKeyPatterns);
 
         KeyBindings = new(commitCompletion, triggerCompletionList, newLine, submitPrompt);
     }

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -84,6 +84,11 @@ internal static class CommandLine
         description: "Set up key bindings for the submit of current prompt. Can be specified multiple times."
     );
 
+    private static readonly Option<string[]?> SubmitPromptDetailedKeyBindings = new(
+        aliases: new[] { "--submitPromptDetailedKeys" },
+        description: "Set up key bindings for the submit of current prompt with detailed output. Can be specified multiple times."
+    );
+
     public static Configuration Parse(string[] args)
     {
         var parseArgs = RemoveScriptArguments(args).ToArray();
@@ -103,7 +108,7 @@ internal static class CommandLine
                 new RootCommand("C# REPL") 
                 { 
                     References, Usings, Framework, Theme, Trace, Help, Version, 
-                    CommitCompletionKeyBindings, TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings
+                    CommitCompletionKeyBindings, TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings
                 }
             )
             .UseSuggestDirective() // support autocompletion via dotnet-suggest
@@ -130,7 +135,8 @@ internal static class CommandLine
             commitCompletionKeyPatterns: commandLine.ValueForOption(CommitCompletionKeyBindings),
             triggerCompletionListKeyPatterns: commandLine.ValueForOption(TriggerCompletionListKeyBindings),
             newLineKeyPatterns: commandLine.ValueForOption(NewLineKeyBindings),
-            submitPromptKeyPatterns: commandLine.ValueForOption(SubmitPromptKeyBindings)
+            submitPromptKeyPatterns: commandLine.ValueForOption(SubmitPromptKeyBindings),
+            submitPromptDetailedKeyPatterns: commandLine.ValueForOption(SubmitPromptDetailedKeyBindings)
         );
 
         return config;
@@ -222,6 +228,7 @@ internal static class CommandLine
         $"  --triggerCompletionListKeys:               {TriggerCompletionListKeyBindings.Description}" + NewLine +
         $"  --newLineKeys:                             {NewLineKeyBindings.Description}" + NewLine +
         $"  --submitPromptKeys:                        {SubmitPromptKeyBindings.Description}" + NewLine +
+        $"  --submitPromptDetailedKeys:                {SubmitPromptDetailedKeyBindings.Description}" + NewLine +
         $"  --trace:                                   {Trace.Description}" + NewLine + NewLine +
         "@response-file.rsp:" + NewLine +
         "  A file, with extension .rsp, containing the above command line [OPTIONS], one option per line." + NewLine + NewLine +

--- a/CSharpRepl/Properties/launchSettings.json
+++ b/CSharpRepl/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "CSharpRepl": {
       "commandName": "Project",
       "workingDirectory": "C:\\"
+    },
+    "CSharpRepl Custom Configuration": {
+      "commandName": "Project",
+      "commandLineArgs": "--newLineKeys Enter --submitPromptKeys Ctrl+Enter --submitPromptDetailedKeys Ctrl+Shift+Enter --submitPromptDetailedKeys Ctrl+Alt+Enter -t ..\\..\\..\\..\\CSharpRepl\\themes\\VisualStudio_Dark.json"
     }
   }
 }

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -28,10 +28,6 @@ internal sealed class ReadEvalPrintLoop
         this.console = console;
     }
 
-    private static readonly KeyPressPatterns submitWithDetailedOutputKeyPatterns = new(
-        new KeyPressPattern(ConsoleModifiers.Control, ConsoleKey.Enter),
-        new KeyPressPattern(ConsoleModifiers.Control | ConsoleModifiers.Alt, ConsoleKey.Enter));
-
     public async Task RunAsync(Configuration config)
     {
         console.WriteLine("Welcome to the C# REPL (Read Eval Print Loop)!");
@@ -77,7 +73,7 @@ internal sealed class ReadEvalPrintLoop
                     .EvaluateAsync(response.Text, config.LoadScriptArgs, response.CancellationToken)
                     .ConfigureAwait(false);
 
-                var displayDetails = submitWithDetailedOutputKeyPatterns.Matches(response.SubmitKeyInfo);
+                var displayDetails = config.SubmitPromptDetailedKeys.Matches(response.SubmitKeyInfo);
                 await PrintAsync(roslyn, console, result, displayDetails);
             }
         }


### PR DESCRIPTION
Alternative key-bindings example:
`--newLineKeys Enter --submitPromptKeys Ctrl+Enter --submitPromptDetailedKeys Ctrl+Shift+Enter --submitPromptDetailedKeys Ctrl+Alt+Enter`