### PR TITLE
Configurable formatted prompt.

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -26,6 +26,8 @@ public sealed class Configuration
 
     public static readonly string DefaultThemeRelativePath = Path.Combine("themes", "VisualStudio_Dark.json");
 
+    public const string PromptDefault = "> ";
+
     public static readonly string ApplicationDirectory =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".csharprepl");
 
@@ -45,6 +47,7 @@ public sealed class Configuration
     public bool Trace { get; }
     public Theme Theme { get; }
     public bool UseTerminalPaletteTheme { get; }
+    public FormattedString Prompt { get; }
     public string? LoadScript { get; }
     public string[] LoadScriptArgs { get; }
     public string? OutputForEarlyExit { get; }
@@ -59,6 +62,7 @@ public sealed class Configuration
         bool trace = false,
         string? theme = null,
         bool useTerminalPaletteTheme = false,
+        string promptMarkup = PromptDefault,
         string? loadScript = null,
         string[]? loadScriptArgs = null,
         string? outputForEarlyExit = null,
@@ -103,6 +107,16 @@ public sealed class Configuration
                 Console.Error.WriteLine($"{AnsiColor.Red.GetEscapeSequence()}Unable to locate theme file '{theme}'. Defaut theme with terminal palette colors will be used.{AnsiEscapeCodes.Reset}");
                 Theme = Theme.DefaultTheme;
             }
+        }
+
+        if (FormattedStringParser.TryParse(promptMarkup, out var prompt))
+        {
+            Prompt = prompt;
+        }
+        else
+        {
+            Console.Error.WriteLine($"{AnsiColor.Red.GetEscapeSequence()}Unable to parse '{prompt}' markup. Defaut prompt '{PromptDefault}' will be used.{AnsiEscapeCodes.Reset}");
+            Prompt = PromptDefault;
         }
 
         LoadScript = loadScript;

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -55,6 +55,12 @@ internal static class CommandLine
         description: "Ignores theme loaded from file and uses default theme with terminal palette colors. Respects the NO_COLOR standard."
     );
 
+    private static readonly Option<string> Prompt = new(
+        aliases: new[] { "--prompt" },
+        description: "Formatted prompt string.",
+        getDefaultValue: () => Configuration.PromptDefault
+    );
+
     private static readonly Option<bool> Trace = new(
         aliases: new[] { "--trace" },
         description: "Produce a trace file in the current directory, for CSharpRepl bug reports."
@@ -113,7 +119,7 @@ internal static class CommandLine
             new CommandLineBuilder(
                 new RootCommand("C# REPL")
                 {
-                    References, Usings, Framework, Theme, UseTerminalPaletteTheme, Trace, Help, Version,
+                    References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, Trace, Help, Version,
                     CommitCompletionKeyBindings, TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings
                 }
             )
@@ -138,6 +144,7 @@ internal static class CommandLine
             loadScriptArgs: commandLine.UnparsedTokens.ToArray(),
             theme: commandLine.ValueForOption(Theme),
             useTerminalPaletteTheme: commandLine.ValueForOption(UseTerminalPaletteTheme),
+            promptMarkup: commandLine.ValueForOption(Prompt) ?? Configuration.PromptDefault,
             trace: commandLine.ValueForOption(Trace),
             commitCompletionKeyPatterns: commandLine.ValueForOption(CommitCompletionKeyBindings),
             triggerCompletionListKeyPatterns: commandLine.ValueForOption(TriggerCompletionListKeyBindings),
@@ -232,6 +239,7 @@ internal static class CommandLine
         $"                                              Available default themes: " + NewLine + GetDefaultThemes(
         $"                                               ") + NewLine +
         $"  --useTerminalPaletteTheme:                  {UseTerminalPaletteTheme.Description}" + NewLine +
+        $"  --prompt:                                   {Prompt.Description}" + NewLine +
         $"  -v or --version:                            {Version.Description}" + NewLine +
         $"  -h or --help:                               {Help.Description}" + NewLine +
         $"  --commitCompletionKeys <key-binding>:       {CommitCompletionKeyBindings.Description}" + NewLine +

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -100,7 +100,9 @@ static class Program
             var prompt = new Prompt(
                persistentHistoryFilepath: Path.Combine(appStorage, "prompt-history"),
                callbacks: new CSharpReplPromptCallbacks(console, roslyn, config),
-               configuration: new PromptConfiguration(keyBindings: config.KeyBindings));
+               configuration: new PromptConfiguration(
+                   keyBindings: config.KeyBindings,
+                   prompt: config.Prompt));
             return (prompt, ExitCodes.Success);
         }
         catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 87", StringComparison.Ordinal))

--- a/CSharpRepl/Properties/launchSettings.json
+++ b/CSharpRepl/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "CSharpRepl Custom Configuration": {
       "commandName": "Project",
-      "commandLineArgs": "--newLineKeys Enter --submitPromptKeys Ctrl+Enter --submitPromptDetailedKeys Ctrl+Shift+Enter --submitPromptDetailedKeys Ctrl+Alt+Enter"
+      "commandLineArgs": "--newLineKeys Enter --submitPromptKeys Ctrl+Enter --submitPromptDetailedKeys Ctrl+Shift+Enter --submitPromptDetailedKeys Ctrl+Alt+Enter --prompt \"[#B9FF51]>[/] \""
     }
   }
 }


### PR DESCRIPTION
E.g.: `csharprepl --prompt "[red]-[/][#FF7B00]-[/][#C7FF00]-[/][green]>[/] "`

![image](https://user-images.githubusercontent.com/11704036/156931716-a5c15a69-f540-4b0a-a5da-4053e2efd859.png)

or `csharprepl --prompt "[#B9FF51]|>[/] "` (when font support ligatures)
![image](https://user-images.githubusercontent.com/11704036/156932238-452caa77-136c-429e-b601-de16224605f8.png)

Resolves #24.