### PR TITLE
Configurability of  SelectedCompletionItemBackground / CompletionBoxBorderColor / CompletionItemDescriptionPaneBackground

### DIFF
--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -30,7 +30,7 @@ internal sealed class SyntaxHighlighter
     {
         this.cache = cache;
         this.theme = theme;
-        this.unhighlightedColor = theme.GetValueOrDefault("text") ?? AnsiColor.White;
+        this.unhighlightedColor = theme.GetSyntaxHighlightingColorOrDefault("text") ?? AnsiColor.White;
     }
 
     internal async Task<IReadOnlyCollection<HighlightedSpan>> HighlightAsync(Document document)
@@ -48,7 +48,7 @@ internal sealed class SyntaxHighlighter
             .Select(classifications =>
             {
                 var highlight = classifications
-                    .Select(classification => theme.GetValueOrDefault(classification.ClassificationType))
+                    .Select(classification => theme.GetSyntaxHighlightingColorOrDefault(classification.ClassificationType))
                     .FirstOrDefault(themeColor => themeColor is not null)
                     ?? unhighlightedColor;
                 return new HighlightedSpan(classifications.Key, highlight);
@@ -60,6 +60,6 @@ internal sealed class SyntaxHighlighter
         return highlighted;
     }
 
-    internal AnsiColor GetColor(string keyword) => theme.GetValueOrDefault(keyword, unhighlightedColor);
-    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetColor(keyword, out color);
+    internal AnsiColor GetColor(string keyword) => theme.GetSyntaxHighlightingColorOrDefault(keyword, unhighlightedColor);
+    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingColor(keyword, out color);
 }

--- a/CSharpRepl.Services/Theming/ExportVisualStudioTheme.csx
+++ b/CSharpRepl.Services/Theming/ExportVisualStudioTheme.csx
@@ -77,7 +77,7 @@ string GetVsColor(string name)
 }
 
 record Color(string name, string foreground);
-record Colors(Color[] colors);
+record Colors(Color[] syntaxHighlightingColors);
 
 var colors =
     typeof(ClassificationTypeNames)

--- a/CSharpRepl.Services/Theming/FormattedStringParser.cs
+++ b/CSharpRepl.Services/Theming/FormattedStringParser.cs
@@ -144,7 +144,7 @@ internal static class FormattedStringParser
                 else if (onKeywordActive)
                 {
                     if (background.HasValue ||
-                        !Color.TryParseAnsiColor(part, out var color))
+                        !ThemeColor.TryParseAnsiColor(part, out var color))
                     {
                         return false;
                     }
@@ -154,7 +154,7 @@ internal static class FormattedStringParser
                 else
                 {
                     if (foreground.HasValue ||
-                        !Color.TryParseAnsiColor(part, out var color))
+                        !ThemeColor.TryParseAnsiColor(part, out var color))
                     {
                         return false;
                     }

--- a/CSharpRepl.Services/Theming/SyntaxHighlightingColor.cs
+++ b/CSharpRepl.Services/Theming/SyntaxHighlightingColor.cs
@@ -1,0 +1,23 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace CSharpRepl.Services.Theming;
+
+public readonly struct SyntaxHighlightingColor
+{
+    [JsonConstructor]
+    public SyntaxHighlightingColor(string name, string foreground)
+    {
+        Debug.Assert(!string.IsNullOrEmpty(name));
+
+        Name = name;
+        Foreground = foreground;
+    }
+
+    public string Name { get; }
+    public string Foreground { get; }
+}

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -15,65 +15,66 @@ public sealed class Theme
 {
     private static readonly Lazy<Theme> defaultTheme = new(
         () =>
-        new(new[]
-        {
-            new Color(name: ClassificationTypeNames.ClassName, foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.StructName, foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.DelegateName, foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.InterfaceName, foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.ModuleName, foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.RecordClassName, foreground: "BrightCyan"),
-            new Color(name: "record struct name", foreground: "BrightCyan"),
-            new Color(name: ClassificationTypeNames.EnumName, foreground: "Green"),
-            new Color(name: ClassificationTypeNames.Text, foreground: "White"),
-            new Color(name: ClassificationTypeNames.ConstantName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.EnumMemberName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.EventName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.ExtensionMethodName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.Identifier, foreground: "White"),
-            new Color(name: ClassificationTypeNames.LabelName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.LocalName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.MethodName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.PropertyName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.NamespaceName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.ParameterName, foreground: "White"),
-            new Color(name: ClassificationTypeNames.NumericLiteral, foreground: "Blue"),
-            new Color(name: ClassificationTypeNames.ControlKeyword, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.Keyword, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.Operator, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.OperatorOverloaded, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.PreprocessorKeyword, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.StringEscapeCharacter, foreground: "BrightMagenta"),
-            new Color(name: ClassificationTypeNames.VerbatimStringLiteral, foreground: "BrightYellow"),
-            new Color(name: ClassificationTypeNames.StringLiteral, foreground: "BrightYellow"),
-            new Color(name: ClassificationTypeNames.TypeParameterName, foreground: "Yellow"),
-            new Color(name: ClassificationTypeNames.Comment, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentAttributeQuotes, foreground: "Green"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentAttributeValue, foreground: "Green"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentAttributeName, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentCDataSection, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentComment, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentDelimiter, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentEntityReference, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentName, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentProcessingInstruction, foreground: "Cyan"),
-            new Color(name: ClassificationTypeNames.XmlDocCommentText, foreground: "Cyan")
-        }));
+        new(
+            syntaxHighlightingColors: new[]
+            {
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ClassName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.StructName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.DelegateName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.InterfaceName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ModuleName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.RecordClassName, foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: "record struct name", foreground: "BrightCyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.EnumName, foreground: "Green"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.Text, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ConstantName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.EnumMemberName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.EventName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ExtensionMethodName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.Identifier, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.LabelName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.LocalName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.MethodName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.PropertyName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.NamespaceName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ParameterName, foreground: "White"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.NumericLiteral, foreground: "Blue"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.ControlKeyword, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.Keyword, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.Operator, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.OperatorOverloaded, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.PreprocessorKeyword, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.StringEscapeCharacter, foreground: "BrightMagenta"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.VerbatimStringLiteral, foreground: "BrightYellow"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.StringLiteral, foreground: "BrightYellow"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.TypeParameterName, foreground: "Yellow"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.Comment, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentAttributeQuotes, foreground: "Green"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentAttributeValue, foreground: "Green"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentAttributeName, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentCDataSection, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentComment, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentDelimiter, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentEntityReference, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentName, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentProcessingInstruction, foreground: "Cyan"),
+                new SyntaxHighlightingColor(name: ClassificationTypeNames.XmlDocCommentText, foreground: "Cyan")
+            }));
 
     public static Theme DefaultTheme => defaultTheme.Value;
 
-    public Color[] Colors { get; }
+    public SyntaxHighlightingColor[] SyntaxHighlightingColors { get; }
 
     [JsonIgnore]
-    private readonly Dictionary<string, AnsiColor> values;
+    private readonly Dictionary<string, AnsiColor> syntaxHighlightingColorsDictionary;
 
-    public Theme(Color[] colors)
+    public Theme(SyntaxHighlightingColor[] syntaxHighlightingColors)
     {
-        Colors = colors;
-        values = colors.ToDictionary(c => c.Name, c => c.ToAnsiColor());
+        SyntaxHighlightingColors = syntaxHighlightingColors;
+        syntaxHighlightingColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToAnsiColor());
     }
 
-    public AnsiColor? GetValueOrDefault(string name) => values.GetValueOrDefault(name);
-    public AnsiColor GetValueOrDefault(string name, AnsiColor defaultValue) => values.GetValueOrDefault(name, defaultValue);
-    public bool TryGetColor(string name, out AnsiColor color) => values.TryGetValue(name, out color);
+    public AnsiColor? GetSyntaxHighlightingColorOrDefault(string name) => syntaxHighlightingColorsDictionary.GetValueOrDefault(name);
+    public AnsiColor GetSyntaxHighlightingColorOrDefault(string name, AnsiColor defaultValue) => syntaxHighlightingColorsDictionary.GetValueOrDefault(name, defaultValue);
+    public bool TryGetSyntaxHighlightingColor(string name, out AnsiColor color) => syntaxHighlightingColorsDictionary.TryGetValue(name, out color);
 }

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -16,6 +16,9 @@ public sealed class Theme
     private static readonly Lazy<Theme> defaultTheme = new(
         () =>
         new(
+            selectedCompletionItemBackground: null,
+            completionBoxBorderColor: null,
+            completionItemDescriptionPaneBackground: null,
             syntaxHighlightingColors: new[]
             {
                 new SyntaxHighlightingColor(name: ClassificationTypeNames.ClassName, foreground: "BrightCyan"),
@@ -63,13 +66,33 @@ public sealed class Theme
 
     public static Theme DefaultTheme => defaultTheme.Value;
 
+    public string? SelectedCompletionItemBackground { get; }
+    public AnsiColor? GetSelectedCompletionItemBackgroundColor()
+        => SelectedCompletionItemBackground is null ? null : new ThemeColor(SelectedCompletionItemBackground).ToAnsiColor();
+
+    public string? CompletionBoxBorderColor { get; }
+    public ConsoleFormat? GetCompletionBoxBorderFormat()
+        => CompletionBoxBorderColor is null ? null : new ConsoleFormat(Foreground: new ThemeColor(CompletionBoxBorderColor).ToAnsiColor());
+
+    public string? CompletionItemDescriptionPaneBackground { get; }
+    public AnsiColor? GetCompletionItemDescriptionPaneBackground()
+        => CompletionItemDescriptionPaneBackground is null ? null : new ThemeColor(CompletionItemDescriptionPaneBackground).ToAnsiColor();
+
     public SyntaxHighlightingColor[] SyntaxHighlightingColors { get; }
 
     [JsonIgnore]
     private readonly Dictionary<string, AnsiColor> syntaxHighlightingColorsDictionary;
 
-    public Theme(SyntaxHighlightingColor[] syntaxHighlightingColors)
+    public Theme(
+        string? selectedCompletionItemBackground,
+        string? completionBoxBorderColor,
+        string? completionItemDescriptionPaneBackground,
+        SyntaxHighlightingColor[] syntaxHighlightingColors)
     {
+        SelectedCompletionItemBackground = selectedCompletionItemBackground;
+        CompletionBoxBorderColor = completionBoxBorderColor;
+        CompletionItemDescriptionPaneBackground = completionItemDescriptionPaneBackground;
+
         SyntaxHighlightingColors = syntaxHighlightingColors;
         syntaxHighlightingColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToAnsiColor());
     }

--- a/CSharpRepl.Services/Theming/ThemeColor.cs
+++ b/CSharpRepl.Services/Theming/ThemeColor.cs
@@ -8,12 +8,11 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Text.Json.Serialization;
 using PrettyPrompt.Highlighting;
 
 namespace CSharpRepl.Services.Theming;
 
-public readonly struct Color
+public readonly struct ThemeColor
 {
     private static readonly Dictionary<string, AnsiColor> ansiColorNames =
         typeof(AnsiColor)
@@ -21,27 +20,23 @@ public readonly struct Color
         .Where(f => f.FieldType == typeof(AnsiColor))
         .ToDictionary(f => f.Name, f => (AnsiColor)f.GetValue(null)!, StringComparer.OrdinalIgnoreCase);
 
-    [JsonConstructor]
-    public Color(string name, string foreground)
+    public ThemeColor(string color)
     {
-        Debug.Assert(!string.IsNullOrEmpty(name));
-        Debug.Assert(!string.IsNullOrEmpty(foreground));
+        Debug.Assert(!string.IsNullOrEmpty(color));
 
-        Name = name;
-        Foreground = foreground;
+        Value = color;
     }
 
-    public string Name { get; }
-    public string Foreground { get; }
+    public string Value { get; }
 
     public AnsiColor ToAnsiColor()
     {
-        if (TryParseAnsiColor(Foreground, out var color))
+        if (TryParseAnsiColor(Value, out var color))
         {
             return color;
         }
 
-        throw new ArgumentException($"Unknown recognized color '{Foreground}'. Expecting either a hexadecimal color of the format #RRGGBB or a standard ANSI color name");
+        throw new ArgumentException($"Unknown recognized color '{Value}'. Expecting either a hexadecimal color of the format #RRGGBB or a standard ANSI color name");
     }
 
     public static bool TryParseAnsiColor(string input, out AnsiColor result)
@@ -58,7 +53,7 @@ public readonly struct Color
 
         if (ansiColorNames.TryGetValue(input, out var color))
         {
-            result= color;
+            result = color;
             return true;
         }
 

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -61,8 +61,8 @@ public class CommandLineTests
     {
         var result = Parse($"{flag} Data/theme.json");
         Assert.NotNull(result);
-        Assert.Equal(41, result.Theme.Colors.Length);
-        Assert.True(result.Theme.TryGetColor("struct name", out var color));
+        Assert.Equal(41, result.Theme.SyntaxHighlightingColors.Length);
+        Assert.True(result.Theme.TryGetSyntaxHighlightingColor("struct name", out var color));
         Assert.Equal("Yellow", color.ToString());
     }
 
@@ -90,8 +90,8 @@ public class CommandLineTests
         var result = Parse("-t Data/theme.json -u System.Linq System.Data -u Newtonsoft.Json --reference foo.dll -f Microsoft.AspNetCore.App --reference bar.dll baz.dll Data/LoadScript.csx");
         Assert.NotNull(result);
 
-        Assert.Equal(41, result.Theme.Colors.Length);
-        Assert.True(result.Theme.TryGetColor("struct name", out var color));
+        Assert.Equal(41, result.Theme.SyntaxHighlightingColors.Length);
+        Assert.True(result.Theme.TryGetSyntaxHighlightingColor("struct name", out var color));
         Assert.Equal("Yellow", color.ToString());
 
         Assert.Equal(new[] { "System.Linq", "System.Data", "Newtonsoft.Json" }, result.Usings);

--- a/CSharpRepl.Tests/Data/theme.json
+++ b/CSharpRepl.Tests/Data/theme.json
@@ -1,45 +1,168 @@
 {
-    "colors": [
-        { "name": "class name", "foreground": "BrightMagenta" },
-        { "name": "struct name", "foreground": "Yellow" },
-        { "name": "delegate name", "foreground": "#8BE9FD" },
-        { "name": "interface name", "foreground": "#8BE9FD" },
-        { "name": "module name", "foreground": "#8BE9FD" },
-        { "name": "record class name", "foreground": "#8BE9FD" },
-        { "name": "record struct name", "foreground": "#8BE9FD" },
-        { "name": "enum name", "foreground": "#50FA7B" },
-        { "name": "constant name", "foreground": "#F8F8F2" },
-        { "name": "enum member name", "foreground": "#F8F8F2" },
-        { "name": "event name", "foreground": "#F8F8F2" },
-        { "name": "extension method name", "foreground": "#F8F8F2" },
-        { "name": "text", "foreground": "#F8F8F2" },
-        { "name": "identifier", "foreground": "#F8F8F2" },
-        { "name": "label name", "foreground": "#F8F8F2" },
-        { "name": "local name", "foreground": "#F8F8F2" },
-        { "name": "method name", "foreground": "#F8F8F2" },
-        { "name": "property name", "foreground": "#F8F8F2" },
-        { "name": "namespace name", "foreground": "#F8F8F2" },
-        { "name": "parameter name", "foreground": "#F8F8F2" },
-        { "name": "number", "foreground": "#BD93F9" },
-        { "name": "keyword - control", "foreground": "#FF79C6" },
-        { "name": "keyword", "foreground": "#FF79C6" },
-        { "name": "operator", "foreground": "#FF79C6" },
-        { "name": "operator - overloaded", "foreground": "#FF79C6" },
-        { "name": "preprocessor keyword", "foreground": "#FF79C6" },
-        { "name": "string - escape character", "foreground": "#FF79C6" },
-        { "name": "string - verbatim", "foreground": "#F1FA8C" },
-        { "name": "string", "foreground": "#F1FA8C" },
-        { "name": "type parameter name", "foreground": "#FFB86C" },
-        { "name": "comment", "foreground": "#6272A4" },
-        { "name": "xml doc comment - attribute quotes", "foreground": "#50FA7B" },
-        { "name": "xml doc comment - attribute value", "foreground": "#50FA7B" },
-        { "name": "xml doc comment - attribute name", "foreground": "#6272A4" },
-        { "name": "xml doc comment - cdata section", "foreground": "#6272A4" },
-        { "name": "xml doc comment - comment", "foreground": "#6272A4" },
-        { "name": "xml doc comment - delimiter", "foreground": "#6272A4" },
-        { "name": "xml doc comment - entity reference", "foreground": "#6272A4" },
-        { "name": "xml doc comment - name", "foreground": "#6272A4" },
-        { "name": "xml doc comment - processing instruction", "foreground": "#6272A4" },
-        { "name": "xml doc comment - text", "foreground": "#6272A4" }
-    ]
+  "syntaxHighlightingColors": [
+    {
+      "name": "class name",
+      "foreground": "BrightMagenta"
+    },
+    {
+      "name": "struct name",
+      "foreground": "Yellow"
+    },
+    {
+      "name": "delegate name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "interface name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "module name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "record class name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "record struct name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "enum name",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "constant name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "enum member name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "event name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "extension method name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "text",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "identifier",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "label name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "local name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "method name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "property name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "namespace name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "parameter name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "number",
+      "foreground": "#BD93F9"
+    },
+    {
+      "name": "keyword - control",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "keyword",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "operator",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "operator - overloaded",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "preprocessor keyword",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "string - escape character",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "string - verbatim",
+      "foreground": "#F1FA8C"
+    },
+    {
+      "name": "string",
+      "foreground": "#F1FA8C"
+    },
+    {
+      "name": "type parameter name",
+      "foreground": "#FFB86C"
+    },
+    {
+      "name": "comment",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - attribute quotes",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "xml doc comment - attribute value",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "xml doc comment - attribute name",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - cdata section",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - comment",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - delimiter",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - entity reference",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - name",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - processing instruction",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - text",
+      "foreground": "#6272A4"
+    }
+  ]
 }

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -13,6 +13,7 @@ using CSharpRepl.Services.Logging;
 using CSharpRepl.Services.Roslyn;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
 
 namespace CSharpRepl;
 
@@ -102,7 +103,10 @@ internal static class Program
                callbacks: new CSharpReplPromptCallbacks(console, roslyn, config),
                configuration: new PromptConfiguration(
                    keyBindings: config.KeyBindings,
-                   prompt: config.Prompt));
+                   prompt: config.Prompt,
+                   completionBoxBorderFormat: config.Theme.GetCompletionBoxBorderFormat(),
+                   completionItemDescriptionPaneBackground: config.Theme.GetCompletionItemDescriptionPaneBackground(),
+                   selectedCompletionItemBackground: config.Theme.GetSelectedCompletionItemBackgroundColor()));
             return (prompt, ExitCodes.Success);
         }
         catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 87", StringComparison.Ordinal))

--- a/CSharpRepl/themes/VisualStudio_BlueExtraContrast.json
+++ b/CSharpRepl/themes/VisualStudio_BlueExtraContrast.json
@@ -1,4 +1,7 @@
 {
+  "selectedCompletionItemBackground": "#D7D7D7",
+  "completionBoxBorderColor": "#777777",
+  "completionItemDescriptionPaneBackground": "#EBEBEB",
   "syntaxHighlightingColors": [
     {
       "name": "comment",

--- a/CSharpRepl/themes/VisualStudio_BlueExtraContrast.json
+++ b/CSharpRepl/themes/VisualStudio_BlueExtraContrast.json
@@ -1,5 +1,5 @@
 {
-  "colors": [
+  "syntaxHighlightingColors": [
     {
       "name": "comment",
       "foreground": "#066555"

--- a/CSharpRepl/themes/VisualStudio_Dark.json
+++ b/CSharpRepl/themes/VisualStudio_Dark.json
@@ -1,5 +1,5 @@
 {
-  "colors": [
+  "syntaxHighlightingColors": [
     {
       "name": "comment",
       "foreground": "#57A64A"

--- a/CSharpRepl/themes/VisualStudio_Dark.json
+++ b/CSharpRepl/themes/VisualStudio_Dark.json
@@ -1,4 +1,7 @@
 {
+  "selectedCompletionItemBackground": "#3C3C3C",
+  "completionBoxBorderColor": "#909090",
+  "completionItemDescriptionPaneBackground": "#282828",
   "syntaxHighlightingColors": [
     {
       "name": "comment",

--- a/CSharpRepl/themes/VisualStudio_Light.json
+++ b/CSharpRepl/themes/VisualStudio_Light.json
@@ -1,5 +1,5 @@
 {
-  "colors": [
+  "syntaxHighlightingColors": [
     {
       "name": "comment",
       "foreground": "#008000"

--- a/CSharpRepl/themes/VisualStudio_Light.json
+++ b/CSharpRepl/themes/VisualStudio_Light.json
@@ -1,4 +1,7 @@
 {
+  "selectedCompletionItemBackground": "#D7D7D7",
+  "completionBoxBorderColor": "#777777",
+  "completionItemDescriptionPaneBackground": "#EBEBEB",
   "syntaxHighlightingColors": [
     {
       "name": "comment",

--- a/CSharpRepl/themes/dracula.json
+++ b/CSharpRepl/themes/dracula.json
@@ -1,45 +1,168 @@
 {
-    "colors": [
-        { "name": "class name", "foreground": "#8BE9FD" },
-        { "name": "struct name", "foreground": "#8BE9FD" },
-        { "name": "delegate name", "foreground": "#8BE9FD" },
-        { "name": "interface name", "foreground": "#8BE9FD" },
-        { "name": "module name", "foreground": "#8BE9FD" },
-        { "name": "record class name", "foreground": "#8BE9FD" },
-        { "name": "record struct name", "foreground": "#8BE9FD" },
-        { "name": "enum name", "foreground": "#50FA7B" },
-        { "name": "constant name", "foreground": "#F8F8F2" },
-        { "name": "enum member name", "foreground": "#F8F8F2" },
-        { "name": "event name", "foreground": "#F8F8F2" },
-        { "name": "extension method name", "foreground": "#F8F8F2" },
-        { "name": "text", "foreground": "#F8F8F2" },
-        { "name": "identifier", "foreground": "#F8F8F2" },
-        { "name": "label name", "foreground": "#F8F8F2" },
-        { "name": "local name", "foreground": "#F8F8F2" },
-        { "name": "method name", "foreground": "#F8F8F2" },
-        { "name": "property name", "foreground": "#F8F8F2" },
-        { "name": "namespace name", "foreground": "#F8F8F2" },
-        { "name": "parameter name", "foreground": "#F8F8F2" },
-        { "name": "number", "foreground": "#BD93F9" },
-        { "name": "keyword - control", "foreground": "#FF79C6" },
-        { "name": "keyword", "foreground": "#FF79C6" },
-        { "name": "operator", "foreground": "#FF79C6" },
-        { "name": "operator - overloaded", "foreground": "#FF79C6" },
-        { "name": "preprocessor keyword", "foreground": "#FF79C6" },
-        { "name": "string - escape character", "foreground": "#FF79C6" },
-        { "name": "string - verbatim", "foreground": "#F1FA8C" },
-        { "name": "string", "foreground": "#F1FA8C" },
-        { "name": "type parameter name", "foreground": "#FFB86C" },
-        { "name": "comment", "foreground": "#6272A4" },
-        { "name": "xml doc comment - attribute quotes", "foreground": "#50FA7B" },
-        { "name": "xml doc comment - attribute value", "foreground": "#50FA7B" },
-        { "name": "xml doc comment - attribute name", "foreground": "#6272A4" },
-        { "name": "xml doc comment - cdata section", "foreground": "#6272A4" },
-        { "name": "xml doc comment - comment", "foreground": "#6272A4" },
-        { "name": "xml doc comment - delimiter", "foreground": "#6272A4" },
-        { "name": "xml doc comment - entity reference", "foreground": "#6272A4" },
-        { "name": "xml doc comment - name", "foreground": "#6272A4" },
-        { "name": "xml doc comment - processing instruction", "foreground": "#6272A4" },
-        { "name": "xml doc comment - text", "foreground": "#6272A4" }
-    ]
+  "syntaxHighlightingColors": [
+    {
+      "name": "class name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "struct name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "delegate name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "interface name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "module name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "record class name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "record struct name",
+      "foreground": "#8BE9FD"
+    },
+    {
+      "name": "enum name",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "constant name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "enum member name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "event name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "extension method name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "text",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "identifier",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "label name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "local name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "method name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "property name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "namespace name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "parameter name",
+      "foreground": "#F8F8F2"
+    },
+    {
+      "name": "number",
+      "foreground": "#BD93F9"
+    },
+    {
+      "name": "keyword - control",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "keyword",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "operator",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "operator - overloaded",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "preprocessor keyword",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "string - escape character",
+      "foreground": "#FF79C6"
+    },
+    {
+      "name": "string - verbatim",
+      "foreground": "#F1FA8C"
+    },
+    {
+      "name": "string",
+      "foreground": "#F1FA8C"
+    },
+    {
+      "name": "type parameter name",
+      "foreground": "#FFB86C"
+    },
+    {
+      "name": "comment",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - attribute quotes",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "xml doc comment - attribute value",
+      "foreground": "#50FA7B"
+    },
+    {
+      "name": "xml doc comment - attribute name",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - cdata section",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - comment",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - delimiter",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - entity reference",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - name",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - processing instruction",
+      "foreground": "#6272A4"
+    },
+    {
+      "name": "xml doc comment - text",
+      "foreground": "#6272A4"
+    }
+  ]
 }

--- a/CSharpRepl/themes/dracula.json
+++ b/CSharpRepl/themes/dracula.json
@@ -1,4 +1,7 @@
 {
+  "selectedCompletionItemBackground": "#3C3C3C",
+  "completionBoxBorderColor": "#909090",
+  "completionItemDescriptionPaneBackground": "#282828",
   "syntaxHighlightingColors": [
     {
       "name": "class name",


### PR DESCRIPTION
Theme files are extendend. They can contains following:
![image](https://user-images.githubusercontent.com/11704036/158025593-60dd4924-597a-484f-aa59-510a83383916.png)

VS dark:
![image](https://user-images.githubusercontent.com/11704036/158025557-513904a8-94cb-4726-8783-40a786067848.png)

VS Light:
![image](https://user-images.githubusercontent.com/11704036/158025568-9d0340cb-b6f3-41a8-8f8b-2a62e79f0dcb.png)