### PR TITLE
Completion item symbols + '--useUnicode' argument

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -48,6 +48,7 @@ public sealed class Configuration
     public Theme Theme { get; }
     public bool UseTerminalPaletteTheme { get; }
     public FormattedString Prompt { get; }
+    public bool UseUnicode { get; }
     public string? LoadScript { get; }
     public string[] LoadScriptArgs { get; }
     public string? OutputForEarlyExit { get; }
@@ -63,6 +64,7 @@ public sealed class Configuration
         string? theme = null,
         bool useTerminalPaletteTheme = false,
         string promptMarkup = PromptDefault,
+        bool useUnicode = false,
         string? loadScript = null,
         string[]? loadScriptArgs = null,
         string? outputForEarlyExit = null,
@@ -119,6 +121,7 @@ public sealed class Configuration
             Prompt = PromptDefault;
         }
 
+        UseUnicode = useUnicode;
         LoadScript = loadScript;
         LoadScriptArgs = loadScriptArgs ?? Array.Empty<string>();
         OutputForEarlyExit = outputForEarlyExit;

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -75,7 +75,7 @@ public sealed class RoslynServices
                 this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);
                 this.prettyPrinter = new PrettyPrinter();
                 this.symbolExplorer = new SymbolExplorer(referenceService, scriptRunner);
-                this.autocompleteService = new AutoCompleteService(highlighter, cache);
+                this.autocompleteService = new AutoCompleteService(highlighter, cache, config);
                 logger.Log("Background initialization complete");
             });
             Initialization.ContinueWith(task => console.WriteErrorLine(task.Exception?.Message ?? "Unknown error"), TaskContinuationOptions.OnlyOnFaulted);

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -61,6 +61,11 @@ internal static class CommandLine
         getDefaultValue: () => Configuration.PromptDefault
     );
 
+    private static readonly Option<bool> UseUnicode = new(
+        aliases: new[] { "--useUnicode" },
+        description: "UTF8 output encoding will be enabled and unicode character will be used (requires terminal support)."
+    );
+
     private static readonly Option<bool> Trace = new(
         aliases: new[] { "--trace" },
         description: "Produce a trace file in the current directory, for CSharpRepl bug reports."
@@ -119,7 +124,7 @@ internal static class CommandLine
             new CommandLineBuilder(
                 new RootCommand("C# REPL")
                 {
-                    References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, Trace, Help, Version,
+                    References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, UseUnicode, Trace, Help, Version,
                     CommitCompletionKeyBindings, TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings
                 }
             )
@@ -145,6 +150,7 @@ internal static class CommandLine
             theme: commandLine.ValueForOption(Theme),
             useTerminalPaletteTheme: commandLine.ValueForOption(UseTerminalPaletteTheme),
             promptMarkup: commandLine.ValueForOption(Prompt) ?? Configuration.PromptDefault,
+            useUnicode: commandLine.ValueForOption(UseUnicode),
             trace: commandLine.ValueForOption(Trace),
             commitCompletionKeyPatterns: commandLine.ValueForOption(CommitCompletionKeyBindings),
             triggerCompletionListKeyPatterns: commandLine.ValueForOption(TriggerCompletionListKeyBindings),
@@ -240,6 +246,7 @@ internal static class CommandLine
         $"                                               ") + NewLine +
         $"  --useTerminalPaletteTheme:                  {UseTerminalPaletteTheme.Description}" + NewLine +
         $"  --prompt:                                   {Prompt.Description}" + NewLine +
+        $"  --useUnicode:                               {UseUnicode.Description}" + NewLine +
         $"  -v or --version:                            {Version.Description}" + NewLine +
         $"  -h or --help:                               {Help.Description}" + NewLine +
         $"  --commitCompletionKeys <key-binding>:       {CommitCompletionKeyBindings.Description}" + NewLine +

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using CSharpRepl.Logging;
 using CSharpRepl.PrettyPromptConfig;
@@ -13,7 +14,6 @@ using CSharpRepl.Services.Logging;
 using CSharpRepl.Services.Roslyn;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
-using PrettyPrompt.Highlighting;
 
 namespace CSharpRepl;
 
@@ -29,6 +29,9 @@ internal static class Program
 
         if (!TryParseArguments(args, out var config))
             return ExitCodes.ErrorParseArguments;
+
+        if (config.UseUnicode)
+            Console.OutputEncoding = Encoding.UTF8;
 
         if (config.OutputForEarlyExit is not null)
         {


### PR DESCRIPTION
When '--useUnicode' is used, console output encoding is set to UTF8 and CSharpRepl will start to use Unicode characters (this requires the support of terminal).

This is utilized in the completion list where every item kind has its own symbol (similarly to VS completion list).
![WindowsTerminal_bccW52BQkY](https://user-images.githubusercontent.com/11704036/158030436-4123ac6f-e37d-48c9-a51b-4e78acfc18f9.gif)

