### PR TITLE
Usage of Roslyn's commit completion characters (#96).

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text.Json;
 using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Theming;
+using Microsoft.CodeAnalysis.Completion;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Highlighting;
@@ -68,7 +69,6 @@ public sealed class Configuration
         string? loadScript = null,
         string[]? loadScriptArgs = null,
         FormattedString outputForEarlyExit = default,
-        string[]? commitCompletionKeyPatterns = null,
         string[]? triggerCompletionListKeyPatterns = null,
         string[]? newLineKeyPatterns = null,
         string[]? submitPromptKeyPatterns = null,
@@ -126,11 +126,6 @@ public sealed class Configuration
         LoadScriptArgs = loadScriptArgs ?? Array.Empty<string>();
         OutputForEarlyExit = outputForEarlyExit;
 
-        var commitCompletion =
-            commitCompletionKeyPatterns?.Any() == true
-            ? ParseKeyPressPatterns(commitCompletionKeyPatterns)
-            : new KeyPressPatterns(new(ConsoleKey.Enter), new(ConsoleKey.Tab), new(' '), new('.'), new('('));
-
         var triggerCompletionList =
             triggerCompletionListKeyPatterns?.Any() == true
             ? ParseKeyPressPatterns(triggerCompletionListKeyPatterns)
@@ -149,6 +144,11 @@ public sealed class Configuration
 
         var submitPrompt = ParseKeyPressPatterns(submitPromptKeyPatterns.Concat(submitPromptDetailedKeyPatterns).ToArray());
         SubmitPromptDetailedKeys = ParseKeyPressPatterns(submitPromptDetailedKeyPatterns);
+        
+        var commitCompletion = new KeyPressPatterns(
+            CompletionRules.Default.DefaultCommitCharacters.Select(c => new KeyPressPattern(c))
+            .Concat(new KeyPressPattern[] { new(ConsoleKey.Enter), new(ConsoleKey.Tab) })
+            .ToArray());
 
         KeyBindings = new(commitCompletion, triggerCompletionList, newLine, submitPrompt);
     }

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -182,7 +182,7 @@ public sealed class RoslynServices
     {
         var keyChar = keyPress.ConsoleKeyInfo.KeyChar;
         var keyModifiers = keyPress.ConsoleKeyInfo.Modifiers;
-        if (keyChar is '\0' or ' ' or '{' ||
+        if (keyChar is '\0' or ' ' or '{' or '(' or '[' or '<' ||
             (keyModifiers & ConsoleModifiers.Control) != 0 ||
             (keyModifiers & ConsoleModifiers.Alt) != 0)
         {

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -78,7 +79,8 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
                   replacementText: r.Item.DisplayText,
                   displayText: r.DisplayText,
                   getExtendedDescription: r.GetDescriptionAsync,
-                  filterText: r.Item.FilterText
+                  filterText: r.Item.FilterText,
+                  commitCharacterRules: r.Item.Rules.CommitCharacterRules.Select(r => new CharacterSetModificationRule((CharacterSetModificationKind)r.Kind, r.Characters)).ToImmutableArray()
               ))
               .ToArray();
     }

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -84,11 +84,6 @@ internal static class CommandLine
         description: "Show version number and exit."
     );
 
-    private static readonly Option<string[]?> CommitCompletionKeyBindings = new(
-        aliases: new[] { "--commitCompletionKeys" },
-        description: "Set up key bindings for commit completion item. Can be specified multiple times."
-    );
-
     private static readonly Option<string[]?> TriggerCompletionListKeyBindings = new(
         aliases: new[] { "--triggerCompletionListKeys" },
         description: "Set up key bindings for trigger completion list. Can be specified multiple times."
@@ -128,7 +123,7 @@ internal static class CommandLine
                 new RootCommand("C# REPL")
                 {
                     References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, UseUnicode, Trace, Help, Version,
-                    CommitCompletionKeyBindings, TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings
+                    TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings
                 }
             )
             .UseSuggestDirective() // support autocompletion via dotnet-suggest
@@ -155,7 +150,6 @@ internal static class CommandLine
             promptMarkup: commandLine.ValueForOption(Prompt) ?? Configuration.PromptDefault,
             useUnicode: commandLine.ValueForOption(UseUnicode),
             trace: commandLine.ValueForOption(Trace),
-            commitCompletionKeyPatterns: commandLine.ValueForOption(CommitCompletionKeyBindings),
             triggerCompletionListKeyPatterns: commandLine.ValueForOption(TriggerCompletionListKeyBindings),
             newLineKeyPatterns: commandLine.ValueForOption(NewLineKeyBindings),
             submitPromptKeyPatterns: commandLine.ValueForOption(SubmitPromptKeyBindings),
@@ -253,7 +247,6 @@ internal static class CommandLine
             $"  [green]--useUnicode[/]:                               {UseUnicode.Description}" + NewLine +
             $"  [green]-v[/] or [green]--version[/]:                            {Version.Description}" + NewLine +
             $"  [green]-h[/] or [green]--help[/]:                               {Help.Description}" + NewLine +
-            $"  [green]--commitCompletionKeys[/] [cyan]<key-binding>[/]:       {CommitCompletionKeyBindings.Description}" + NewLine +
             $"  [green]--triggerCompletionListKeys[/] [cyan]<key-binding>[/]:  {TriggerCompletionListKeyBindings.Description}" + NewLine +
             $"  [green]--newLineKeys[/] [cyan]<key-binding>[/]:                {NewLineKeyBindings.Description}" + NewLine +
             $"  [green]--submitPromptKeys[/] [cyan]<key-binding>[/]:           {SubmitPromptKeyBindings.Description}" + NewLine +


### PR DESCRIPTION
Resolves #96.

Also '--commitCompletionKeys' option is removed.