### PR TITLE
Enhanced NuGet logger rendering

### DIFF
--- a/CSharpRepl.Services/Extensions/MiscExtensions.cs
+++ b/CSharpRepl.Services/Extensions/MiscExtensions.cs
@@ -1,0 +1,21 @@
+﻿using PrettyPrompt.Consoles;
+
+namespace CSharpRepl.Services.Extensions;
+
+internal static class MiscExtensions
+{
+    public static bool TryGet<T>(this T? nullableValue, out T value)
+        where T : struct
+    {
+        if (nullableValue.HasValue)
+        {
+            value = nullableValue.GetValueOrDefault();
+            return true;
+        }
+        else
+        {
+            value = default;
+            return false;
+        }
+    }
+}

--- a/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
+++ b/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
@@ -2,26 +2,43 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using CSharpRepl.Services.Extensions;
+using Microsoft.CodeAnalysis.Classification;
 using NuGet.Common;
 using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
 
 namespace CSharpRepl.Services.Nuget;
 
 /// <summary>
-/// Implementation of <see cref="NuGet.Common.ILogger"/> that logs minimal output to the console.
+/// Implementation of <see cref="ILogger"/> that logs minimal output to the console.
 /// </summary>
 internal sealed class ConsoleNugetLogger : ILogger
 {
-    private readonly IConsole console;
+    private const int NumberOfMessagesToShow = 6;
 
-    public ConsoleNugetLogger(IConsole console)
+    private readonly IConsole console;
+    private readonly Configuration configuration;
+    private readonly string successPrefix;
+    private readonly string errorPrefix;
+    private readonly List<Line> lines = new();
+    private int linesRendered;
+
+    public ConsoleNugetLogger(IConsole console, Configuration configuration)
     {
         this.console = console;
+        this.configuration = configuration;
+
+        successPrefix = configuration.UseUnicode ? "✅ " : "";
+        errorPrefix = configuration.UseUnicode ? "❌ " : "";
     }
 
-    public void Log(ILogMessage message) =>
-        Log(message.Level, message.Message);
+    public void Log(ILogMessage message) => Log(message.Level, message.Message);
 
     public void Log(LogLevel level, string data)
     {
@@ -37,35 +54,54 @@ internal sealed class ConsoleNugetLogger : ILogger
         }
     }
 
-    public void LogMinimal(string data) =>
-        console.WriteLine(Truncate(data));
-
-    public void LogWarning(string data) =>
-        console.WriteLine(Truncate(data));
-
-    public void LogError(string data) =>
-        console.WriteErrorLine(data);
-
-    public void LogInformationSummary(string data) =>
-        console.WriteLine(Truncate(data));
-
-    /// <summary>
-    /// Nuget output can be a bit overwhelming. Truncate some of the longer lines
-    /// </summary>
-    private static string Truncate(string data)
+    public void LogMinimal(string data)
     {
-        if (string.IsNullOrWhiteSpace(data)) return "";
+        var line = CreateLine(data, isError: false);
+        if (line.IsEmpty) return;
 
-        if (data.IndexOf(" to folder") is int discard1 and >= 0)
-            return data.Substring(0, discard1);
+        lines.Add(line);
+        if (lines.Count(l => !l.IsError) > NumberOfMessagesToShow)
+        {
+            for (int i = 0; i < lines.Count; i++)
+            {
+                if (!lines[i].IsError)
+                {
+                    lines.RemoveAt(i);
+                    break;
+                }
+            }
+        }
 
-        if (data.IndexOf(" with respect to project") is int discard2 and >= 0)
-            return data.Substring(0, discard2);
+        RenderLines();
+    }
 
-        if (data.StartsWith("Successfully installed") && data.IndexOf(" to ") is int discard3 and >= 0)
-            return data.Substring(0, discard3);
+    public void LogWarning(string data) => LogMinimal(data);
+    public void LogInformationSummary(string data) => LogMinimal(data);
 
-        return data;
+    public void LogError(string data)
+    {
+        lines.Add(CreateLine(data, isError: true));
+        RenderLines();
+    }
+
+    public void Reset()
+    {
+        lines.Clear();
+        linesRendered = 0;
+    }
+
+    public void LogFinish(string text, bool success)
+    {
+        for (int i = 0; i < linesRendered; i++)
+        {
+            console.Write(AnsiEscapeCodes.MoveCursorUp(1));
+            console.Write(AnsiEscapeCodes.ClearLine);
+        }
+
+        linesRendered = 0;
+        lines.Clear();
+        lines.Add(CreateLine(text, isError: !success));
+        RenderLines();
     }
 
     // unused
@@ -74,4 +110,86 @@ internal sealed class ConsoleNugetLogger : ILogger
     public void LogDebug(string data) { /* ignore, we don't need this much output */ }
     public void LogVerbose(string data) { /* ignore, we don't need this much output */ }
     public void LogInformation(string data) { /* ignore, we don't need this much output */ }
+
+    private Line CreateLine(string data, bool isError) => new(data, isError, isError ? errorPrefix : successPrefix, configuration);
+
+    private void RenderLines()
+    {
+        console.HideCursor();
+        for (int i = 0; i < linesRendered; i++)
+        {
+            console.Write(AnsiEscapeCodes.MoveCursorUp(1));
+            console.Write(AnsiEscapeCodes.ClearLine);
+        }
+
+        linesRendered = 0;
+        foreach (var line in lines)
+        {
+            if (line.IsError)
+            {
+                console.Write(AnsiColor.Red.GetEscapeSequence());
+                console.WriteLine(line.Text.Text);
+                console.Write(AnsiEscapeCodes.Reset);
+            }
+            else
+            {
+                console.WriteLine(line.Text);
+            }
+
+            linesRendered += Math.DivRem(line.Text.Length, console.BufferWidth, out var remainder) + (remainder == 0 ? 0 : 1);
+        }
+        console.ShowCursor();
+    }
+
+    private readonly struct Line
+    {
+        private static readonly Regex QuotesRegex = new(@"'.*?'");
+
+        public readonly FormattedString Text;
+        public readonly bool IsError;
+        public readonly bool IsEmpty;
+
+        public Line(string data, bool isError, string prefix, Configuration configuration)
+        {
+            data = Truncate(data);
+            IsEmpty = data.Length == 0;
+            Text = Format(data, prefix, configuration);
+            IsError = isError;
+        }
+
+        /// <summary>
+        /// Nuget output can be a bit overwhelming. Truncate some of the longer lines
+        /// </summary>
+        private static string Truncate(string data)
+        {
+            if (string.IsNullOrWhiteSpace(data)) return "";
+
+            if (data.IndexOf(" to folder") is int discard1 and >= 0)
+                return data.Substring(0, discard1);
+
+            if (data.IndexOf(" with respect to project") is int discard2 and >= 0)
+                return data.Substring(0, discard2);
+
+            if (data.StartsWith("Successfully installed"))
+                return ""; //ignore; NugetPackageInstaller will log success on its own
+
+            return data;
+        }
+
+        private static FormattedString Format(string text, string prefix, Configuration configuration)
+        {
+            text = prefix + text;
+            if (configuration.Theme.GetSyntaxHighlightingColorOrDefault(ClassificationTypeNames.StringLiteral).TryGet(out var color))
+            {
+                var formattings = new List<FormatSpan>(1);
+                foreach (Match match in QuotesRegex.Matches(text))
+                {
+                    formattings.Add(new FormatSpan(match.Index, match.Length, color));
+                }
+                return new FormattedString(text, formattings.ToArray());
+            }
+
+            return text;
+        }
+    }
 }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
@@ -21,9 +21,9 @@ internal sealed class NugetPackageMetadataResolver : IIndividualMetadataReferenc
     private readonly NugetPackageInstaller nugetInstaller;
     private readonly ImmutableArray<PortableExecutableReference> dummyPlaceholder;
 
-    public NugetPackageMetadataResolver(IConsole console)
+    public NugetPackageMetadataResolver(IConsole console, Configuration configuration)
     {
-        this.nugetInstaller = new NugetPackageInstaller(console);
+        this.nugetInstaller = new NugetPackageInstaller(console, configuration);
         this.dummyPlaceholder = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) }.ToImmutableArray();
     }
 

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -73,7 +73,7 @@ public sealed class RoslynServices
             // the script runner is used to actually execute the scripts, and the workspace manager
             // is updated alongside. The workspace is a datamodel used in "editor services" like
             // syntax highlighting, autocompletion, and roslyn symbol queries.
-            this.scriptRunner = new ScriptRunner(compilationOptions, referenceService, console);
+            this.scriptRunner = new ScriptRunner(compilationOptions, referenceService, console, config);
             this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger);
 
             this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -30,12 +30,16 @@ internal sealed class ScriptRunner
     private ScriptOptions scriptOptions;
     private ScriptState<object>? state;
 
-    public ScriptRunner(CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsole console)
+    public ScriptRunner(
+        CSharpCompilationOptions compilationOptions,
+        AssemblyReferenceService referenceAssemblyService,
+        IConsole console,
+        Configuration configuration)
     {
         this.console = console;
         this.referenceAssemblyService = referenceAssemblyService;
         this.assemblyLoader = new InteractiveAssemblyLoader(new MetadataShadowCopyProvider());
-        this.nugetResolver = new NugetPackageMetadataResolver(console);
+        this.nugetResolver = new NugetPackageMetadataResolver(console, configuration);
 
         this.metadataResolver = new CompositeMetadataReferenceResolver(
             nugetResolver,

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -28,8 +28,9 @@ public class DisassemblerTests : IAsyncLifetime
         );
         var console = Substitute.For<IConsole>();
         console.BufferWidth.Returns(200);
-        var referenceService = new AssemblyReferenceService(new Configuration(), new TestTraceLogger());
-        var scriptRunner = new ScriptRunner(options, referenceService, console);
+        var config = new Configuration();
+        var referenceService = new AssemblyReferenceService(config, new TestTraceLogger());
+        var scriptRunner = new ScriptRunner(options, referenceService, console, config);
 
         this.disassembler = new Disassembler(options, referenceService, scriptRunner);
         this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -65,7 +65,7 @@ public class EvaluationTests : IAsyncLifetime
 
         Assert.Null(installationResult.ReturnValue);
         Assert.Contains(installationResult.References, r => r.Display.EndsWith("Newtonsoft.Json.dll"));
-        Assert.Contains("Adding references for Newtonsoft.Json", stdout.ToString());
+        Assert.Contains("Adding references for 'Newtonsoft.Json", ProgramTests.RemoveFormatting(stdout.ToString()));
         Assert.Equal(@"{""Foo"":""bar""}", usageResult.ReturnValue);
     }
 
@@ -80,7 +80,7 @@ public class EvaluationTests : IAsyncLifetime
 
         Assert.Null(installationResult.ReturnValue);
         Assert.NotNull(usageResult.ReturnValue);
-        Assert.Contains("Adding references for Microsoft.CodeAnalysis.CSharp.3.11.0", stdout.ToString());
+        Assert.Contains("Adding references for 'Microsoft.CodeAnalysis.CSharp.3.11.0'", ProgramTests.RemoveFormatting(stdout.ToString()));
     }
 
     [Fact]

--- a/CSharpRepl.Tests/ProgramTests.cs
+++ b/CSharpRepl.Tests/ProgramTests.cs
@@ -11,7 +11,7 @@ public class ProgramTests
 {
     private static readonly Regex AnsiEscapeCodeRegex = new(@"\u001b\[.+?m");
 
-    private static string RemoveFormatting(string input) => AnsiEscapeCodeRegex.Replace(input, "");
+    public static string RemoveFormatting(string input) => AnsiEscapeCodeRegex.Replace(input, "");
 
     [Fact]
     public async Task MainMethod_Help_ShowsHelp()


### PR DESCRIPTION
1. Formatting of nugget install messages
2. Rendering only moving window of last 6 messages
3. Clear of this window in the end.

Example (intentionally slowed down a little bit):
![WindowsTerminal_ufs3ohcrHe](https://user-images.githubusercontent.com/11704036/160436933-4795fc6f-eb7e-40d1-ba67-b9e4bd5e8a48.gif)

