### PR TITLE
Add configuration file support

### DIFF
--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="Data\Config.rsp">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Data\ResponseFile.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/CSharpRepl.Tests/Data/Config.rsp
+++ b/CSharpRepl.Tests/Data/Config.rsp
@@ -1,0 +1,5 @@
+﻿# Here's a comment
+--using
+System.Text
+
+# Here's another comment

--- a/CSharpRepl.Tests/Data/Config.rsp
+++ b/CSharpRepl.Tests/Data/Config.rsp
@@ -1,5 +1,4 @@
 ﻿# Here's a comment
---using
-System.Text
+--using System.Text
 
 # Here's another comment

--- a/CSharpRepl.Tests/ProgramTests.cs
+++ b/CSharpRepl.Tests/ProgramTests.cs
@@ -49,7 +49,7 @@ public class ProgramTests
 
         var error = capturedError.ToString();
         Assert.Equal(
-            "Unrecognized command or argument 'bonk'" + Environment.NewLine,
+            "Unrecognized command or argument 'bonk'." + Environment.NewLine,
             error
         );
     }

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="PrettyPrompt" Version="3.0.5" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
   </ItemGroup>
 

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -26,8 +26,10 @@ internal static class Program
     internal static async Task<int> Main(string[] args)
     {
         var console = new SystemConsole();
+        var appStorage = CreateApplicationStorageDirectory();
+        var configFile = Path.Combine(appStorage, "config.rsp");
 
-        if (!TryParseArguments(args, out var config))
+        if (!TryParseArguments(args, configFile, out var config))
             return ExitCodes.ErrorParseArguments;
 
         if (config.UseUnicode)
@@ -38,8 +40,6 @@ internal static class Program
             console.WriteLine(config.OutputForEarlyExit);
             return ExitCodes.Success;
         }
-
-        var appStorage = CreateApplicationStorageDirectory();
 
         var logger = InitializeLogging(config.Trace);
         var roslyn = new RoslynServices(console, config, logger);
@@ -55,11 +55,11 @@ internal static class Program
         return exitCode;
     }
 
-    private static bool TryParseArguments(string[] args, [NotNullWhen(true)] out Configuration? configuration)
+    private static bool TryParseArguments(string[] args, string configFilePath, [NotNullWhen(true)] out Configuration? configuration)
     {
         try
         {
-            configuration = CommandLine.Parse(args);
+            configuration = CommandLine.Parse(args, configFilePath);
             return true;
         }
         catch (Exception ex)

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Adds configuration file support for CSharpRepl. The configuration file is located in the application directory along with other csharprepl files (the filepath is printed in the `--help` output; in Windows it's `C:\Users\username\AppData\Roaming\.csharprepl\config.rsp`). It contains a list of command line flags, and these flags are merged with any flags typed in at the command line.

This requires a very preview version of [System.CommandLine 2.0.0-beta3.22222.1](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-libraries/NuGet/System.CommandLine/2.0.0-beta3.22222.1/overview) which is on the dotnet-libraries engineering nuget feed. Whenever that version leaves preview we can go back to what's published on nuget.org.

- [x] Feature
- [x] Tests
- [ ] Docs

Fixes #48 