### PR TITLE
Improve intellisense behavior for quotes inside blocks

### DIFF
--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -182,7 +182,7 @@ public sealed class RoslynServices
     {
         var keyChar = keyPress.ConsoleKeyInfo.KeyChar;
         var keyModifiers = keyPress.ConsoleKeyInfo.Modifiers;
-        if (keyChar is '\0' or ' ' or '{' or '(' or '[' or '<' or ':' ||
+        if (keyChar is '\0' or ' ' or '{' or '(' or '[' or '<' or ':' or '"' ||
             (keyModifiers & ConsoleModifiers.Control) != 0 ||
             (keyModifiers & ConsoleModifiers.Alt) != 0)
         {

--- a/CSharpRepl.Tests/CompleteStatementTests.cs
+++ b/CSharpRepl.Tests/CompleteStatementTests.cs
@@ -81,6 +81,19 @@ public class CompleteStatement_REPL_Tests
         console.Received().WriteErrorLine(Arg.Is<string>(str => str.Contains("Expected expression")));
     }
 
+    [Fact]
+    public async Task QuoteInsideCodeBlock_DoesNotOpenCompletionWindow()
+    {
+        // Typing the characters: { Console.WriteLine("Hello"); }
+        // results in the string: { Console.WriteLine("Hello"as); }
+        // because the completion window would open on the closing quote and commit on the closing parenthesis.
+        // It happens quite often e.g. inside an if statement with parentheses.
+        var (console, repl, configuration) = await InitAsync(GetCustomKeyBindingsConfiguration());
+        console.StubInput($@"{{ Console.WriteLine(""Hello""); }}{Control}{Enter}exit{Control}{Enter}");
+        await repl.RunAsync(configuration);
+        console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
+    }
+
     private static async Task<(IConsole Console, ReadEvalPrintLoop Repl, Configuration Configuration)> InitAsync(Configuration? configuration = null)
     {
         var console = FakeConsole.Create();


### PR DESCRIPTION
Fixes the completion window behavior when there's a quote inside a block (e.g. the code `{ "asdf" }`). In this case, the completion window was automatically opening on the closing quotation mark.

This causes an issue because if you type something like `if(cond) { Console.WriteLine("asdf"); }`, the completion window would open on the closing quotation mark, and then commit the first completion when the closing parenthesis was typed. This resulted in `if(cond) { Console.WriteLine("asdf"as); }` where that extra `as` was committed from the completion window.

As far as I can tell, in Visual Studio pressing quote will never open the completion window, so I added it to the list of skipped characters in the `ShouldOpenCompletionWindowAsync` callback.

Also contains a small fix to our test helpers to properly treat escaped braces (`{{`) in interpolated strings.