### PR TITLE
Handle exceptions in the pretty printer

### DIFF
--- a/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
+++ b/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
@@ -33,10 +33,22 @@ internal sealed class PrettyPrinter
     {
         null => null, // intercept null, don't print the string "null"
         string str when displayDetails => str, // when displayDetails is true, don't show the escaped string (i.e. interpret the escape characters, via displaying to console)
-        _ => formatter.FormatObject(obj, displayDetails ? detailedOptions : summaryOptions)
+        _ => FormatObjectSafe(obj, displayDetails ? detailedOptions : summaryOptions)
     };
 
     public string FormatException(Exception obj, bool displayDetails) => displayDetails
         ? formatter.FormatException(obj)
         : obj.Message;
+
+    private string? FormatObjectSafe(object obj, PrintOptions options)
+    {
+        try
+        {
+            return formatter.FormatObject(obj, options);
+        }
+        catch (Exception) // sometimes the roslyn formatter APIs fail to format. Most notably with ref structs.
+        {
+            return obj.ToString();
+        }
+    }
 }

--- a/CSharpRepl.Tests/PrettyPrinterTests.cs
+++ b/CSharpRepl.Tests/PrettyPrinterTests.cs
@@ -2,6 +2,7 @@
 using CSharpRepl.Services.Roslyn;
 using System.Collections.Generic;
 using static System.Environment;
+using System.Text;
 
 namespace CSharpRepl.Tests;
 
@@ -17,13 +18,14 @@ public class PrettyPrinterTests
 
     public static IEnumerable<object[]> FormatObjectInputs = new[]
     {
-            new object[] { null, false, null },
-            new object[] { null, true, null },
-            new object[] { @"""hello world""", false, @"""\""hello world\"""""},
-            new object[] { @"""hello world""", true, @"""hello world"""},
-            new object[] { "a\nb", false, @"""a\nb"""},
-            new object[] { "a\nb", true, "a\nb"},
-            new object[] { new[] { 1, 2, 3 }, false, "int[3] { 1, 2, 3 }"},
-            new object[] { new[] { 1, 2, 3 }, true, $"int[3] {"{"}{NewLine}  1,{NewLine}  2,{NewLine}  3{NewLine}{"}"}{NewLine}"},
-        };
+        new object[] { null, false, null },
+        new object[] { null, true, null },
+        new object[] { @"""hello world""", false, @"""\""hello world\"""""},
+        new object[] { @"""hello world""", true, @"""hello world"""},
+        new object[] { "a\nb", false, @"""a\nb"""},
+        new object[] { "a\nb", true, "a\nb"},
+        new object[] { new[] { 1, 2, 3 }, false, "int[3] { 1, 2, 3 }"},
+        new object[] { new[] { 1, 2, 3 }, true, $"int[3] {"{"}{NewLine}  1,{NewLine}  2,{NewLine}  3{NewLine}{"}"}{NewLine}"},
+        new object[] { Encoding.UTF8, true, "System.Text.UTF8Encoding+UTF8EncodingSealed"},
+    };
 }


### PR DESCRIPTION
Sometimes Roslyn's CSharpObjectFormatter class throws exceptions. We've seen this with ref structs and some other cases. For example, Encoding.UTF8 will trigger a crash. Any class containing a "ref struct" (like UTF8Encoding) currently crashes.

These exceptions shouldn't cause the entire REPL to crash, so catch them and just return the ToString representation in those cases.