### PR TITLE
Adds all projects when a solution is referenced.

### DIFF
--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -1,4 +1,8 @@
-﻿using CSharpRepl.Services.Roslyn.References;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.Disassembler;

--- a/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
+++ b/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
@@ -1,0 +1,115 @@
+﻿using PrettyPrompt.Consoles;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Dotnet;
+
+internal interface IDotnetBuilder
+{
+    ImmutableDictionary<string, string> ParseBuildGraph(ImmutableArray<string> buildOutput);
+    (int exitCode, ImmutableArray<string> outputLines) Build(string path);
+    Task<(int exitCode, ImmutableArray<string> outputLines)> BuildAsync(string path, CancellationToken cancellationToken);
+}
+
+internal class DotnetBuilder : IDotnetBuilder
+{
+    private readonly IConsole console;
+
+    public DotnetBuilder(IConsole console)
+    {
+        this.console = console;
+    }
+
+    public (int exitCode, ImmutableArray<string> outputLines) Build(string path)
+    {
+        var output = new List<string>();
+
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet",
+                ArgumentList = { "build", path },
+                RedirectStandardOutput = true
+            }
+        };
+        process.OutputDataReceived += (_, data) =>
+        {
+            if (data.Data is null) return;
+
+            output.Add(data.Data);
+            console.WriteLine(data.Data);
+        };
+        console.WriteLine("Building " + path);
+        process.Start();
+        process.BeginOutputReadLine();
+        process.WaitForExit();
+
+        return (process.ExitCode, output.ToImmutableArray());
+    }
+
+    public async Task<(int exitCode, ImmutableArray<string> outputLines)> BuildAsync(string path, CancellationToken cancellationToken)
+    {
+        var output = new List<string>();
+
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet",
+                ArgumentList = { "build", path },
+                RedirectStandardOutput = true
+            }
+        };
+        process.OutputDataReceived += (_, data) =>
+        {
+            if (data.Data is null) return;
+
+            output.Add(data.Data);
+            console.WriteLine(data.Data);
+        };
+        console.WriteLine("Building " + path);
+        process.Start();
+        process.BeginOutputReadLine();
+        await process.WaitForExitAsync(cancellationToken);
+
+        return (process.ExitCode, output.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Parses the output of dotnet-build to determine every project that was build.
+    /// </summary>
+    /// <returns>
+    /// Every project reference in the output.
+    /// </returns>
+    /// <remarks>
+    /// Sample output that's being parsed below. We extract "C:\Projects\CSharpRepl\bin\Debug\net5.0\CSharpRepl.dll"
+    ///
+    /// Microsoft (R) Build Engine version 17.0.0-preview-21302-02+018bed83d for .NET
+    /// Copyright (C) Microsoft Corporation. All rights reserved.
+    /// 
+    ///   Determining projects to restore...
+    ///   All projects are up-to-date for restore.
+    ///   You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
+    ///   CSharpRepl.Services -> C:\Projects\CSharpRepl.Services\bin\Debug\net5.0\CSharpRepl.Services.dll
+    ///   CSharpRepl -> C:\Projects\CSharpRepl\bin\Debug\net5.0\CSharpRepl.dll
+    /// 
+    /// Build succeeded.
+    ///     0 Warning(s)
+    ///     0 Error(s)
+    /// 
+    /// Time Elapsed 00:00:02.15
+    /// </remarks>
+    public ImmutableDictionary<string, string> ParseBuildGraph(ImmutableArray<string> buildOutput)
+    {
+        return buildOutput
+            .Where(line => line.Contains(" -> "))
+            .Select(line => line.Split(" -> ", 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .ToImmutableDictionary(x => x.First(), x => x.Last());
+    }
+}

--- a/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
+++ b/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
@@ -1,4 +1,8 @@
-﻿using PrettyPrompt.Consoles;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using PrettyPrompt.Consoles;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
+/// <summary>
+/// An alternative to MetadataReferenceResolver.ResolveReference. <br/>
+/// This can be used when multiple references can be added from a single ResolveReference call, as Roslyn does not yet support it (https://github.com/dotnet/roslyn/issues/6900).
+/// </summary>
+public abstract class AlternativeReferenceResolver : IIndividualMetadataReferenceResolver
+{
+    public ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
+    {
+        if (CanResolve(reference))
+            return ImmutableArray.Create(DummyReference);
+
+        return ImmutableArray<PortableExecutableReference>.Empty;
+    }
+
+    public abstract bool CanResolve(string reference);
+    public virtual Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(Resolve(reference));
+    }
+    public virtual ImmutableArray<PortableExecutableReference> Resolve(string reference)
+    {
+        return ImmutableArray<PortableExecutableReference>.Empty;
+    }
+    public static PortableExecutableReference DummyReference { get; } = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+}

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Immutable;
 using System.Linq;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
@@ -15,7 +15,7 @@ internal sealed class CompositeAlternativeReferenceResolver
         this.alternativeResolvers = alternativeResolvers;
     }
 
-    public async Task<ImmutableArray<PortableExecutableReference>> GetAllAlternativeRefences(string code, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<PortableExecutableReference>> GetAllAlternativeReferences(string code, CancellationToken cancellationToken)
     {
         var splitCommands = code.Split(new[] { '\r', '\n' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         var commandMap = alternativeResolvers.ToDictionary(x => x, x => splitCommands.Where(c => x.CanResolve(c)));

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
+internal sealed class CompositeAlternativeReferenceResolver
+{
+    private readonly AlternativeReferenceResolver[] alternativeResolvers;
+
+    public CompositeAlternativeReferenceResolver(params AlternativeReferenceResolver[] alternativeResolvers)
+    {
+        this.alternativeResolvers = alternativeResolvers;
+    }
+
+    public async Task<ImmutableArray<PortableExecutableReference>> GetAllAlternativeRefences(string code, CancellationToken cancellationToken)
+    {
+        var splitCommands = code.Split(new[] { '\r', '\n' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var commandMap = alternativeResolvers.ToDictionary(x => x, x => splitCommands.Where(c => x.CanResolve(c)));
+
+        var resolvingTaks = commandMap
+            .SelectMany(kvp => kvp.Value.Select(reference => kvp.Key.ResolveAsync(reference, cancellationToken)));
+
+        await Task.WhenAll(resolvingTaks);
+
+        return resolvingTaks.SelectMany(t => t.Result).ToImmutableArray();
+    }
+}

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
@@ -15,37 +15,23 @@ namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 /// <summary>
 /// Resolves nuget references, e.g. #r "nuget: Newtonsoft.Json" or #r "nuget: Newtonsoft.Json, 13.0.1"
 /// </summary>
-internal sealed class NugetPackageMetadataResolver : IIndividualMetadataReferenceResolver
+internal sealed class NugetPackageMetadataResolver : AlternativeReferenceResolver
 {
     private const string NugetPrefix = "nuget:";
     private readonly NugetPackageInstaller nugetInstaller;
-    private readonly ImmutableArray<PortableExecutableReference> dummyPlaceholder;
 
     public NugetPackageMetadataResolver(IConsole console, Configuration configuration)
     {
         this.nugetInstaller = new NugetPackageInstaller(console, configuration);
-        this.dummyPlaceholder = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) }.ToImmutableArray();
     }
 
-    public ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
+    public override bool CanResolve(string reference)
     {
-        // This is a bit of a kludge. roslyn does not yet support adding multiple references from a single ResolveReference call, which
-        // can happen with nuget packages (because they can have multiple DLLs and dependencies). https://github.com/dotnet/roslyn/issues/6900
-        // We still want to use the "mostly standard" syntax of `#r "nuget:PackageName"` though, so make this a no-op and install the package
-        // in the InstallNugetPackage method instead. Additional benefit is that we can use "real async" rather than needing to block here.
-        if (IsNugetReference(reference))
-        {
-            return dummyPlaceholder;
-        }
-
-        return ImmutableArray<PortableExecutableReference>.Empty;
+        return reference.ToLowerInvariant() is string lowercased
+                && (lowercased.StartsWith(NugetPrefix) || lowercased.StartsWith($"#r \"{NugetPrefix}")); // roslyn trims the "#r" prefix when passing to the resolver, but it has the prefix when called from our ScriptRunner
     }
 
-    public bool IsNugetReference(string reference) =>
-        reference.ToLowerInvariant() is string lowercased
-        && (lowercased.StartsWith(NugetPrefix) || lowercased.StartsWith($"#r \"{NugetPrefix}")); // roslyn trims the "#r" prefix when passing to the resolver, but it has the prefix when called from our ScriptRunner
-
-    public Task<ImmutableArray<PortableExecutableReference>> InstallNugetPackageAsync(string reference, CancellationToken cancellationToken)
+    public override Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
     {
         // we can be a bit loose in our parsing here, because we were more strict in IsNugetReference.
         // the 0th element will be the "nuget" keyword, which we ignore.

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -1,131 +1,58 @@
-﻿using CSharpRepl.Services.Roslyn.References;
+﻿using CSharpRepl.Services.Dotnet;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Scripting;
 using PrettyPrompt.Consoles;
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
 
 internal sealed class SolutionFileMetadataResolver : IIndividualMetadataReferenceResolver
 {
-    private readonly AssemblyLoadContext loadContext;
-    private readonly IConsole console;
     private readonly ImmutableArray<PortableExecutableReference> dummyPlaceholder;
 
-    public SolutionFileMetadataResolver(IConsole console)
+    private readonly IDotnetBuilder builder;
+    private readonly IConsole console;
+
+    public SolutionFileMetadataResolver(IDotnetBuilder builder, IConsole console)
     {
+        this.builder = builder;
         this.console = console;
-        this.loadContext = new AssemblyLoadContext(nameof(CSharpRepl) + "LoadContext");
         this.dummyPlaceholder = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) }.ToImmutableArray();
     }
 
-
     public ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
     {
-        // This is a bit of a kludge. roslyn does not yet support adding multiple references from a single ResolveReference call, which
-        // can happen with nuget packages (because they can have multiple DLLs and dependencies). https://github.com/dotnet/roslyn/issues/6900
-        // We still want to use the "mostly standard" syntax of `#r "nuget:PackageName"` though, so make this a no-op and install the package
-        // in the InstallNugetPackage method instead. Additional benefit is that we can use "real async" rather than needing to block here.
         if (IsSolutionReference(reference))
-        {
             return dummyPlaceholder;
-        }
 
         return ImmutableArray<PortableExecutableReference>.Empty;
     }
 
     public ImmutableArray<PortableExecutableReference> LoadSolutionReference(string reference)
     {
-        console.WriteLine("Building " + reference);
-        var solutionPath = reference.Split('\"', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Last();
-        var (exitCode, output) = RunDotNetBuild(solutionPath);
+        var solutionPath = Path.GetFullPath(reference
+            .Split('\"', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Last());
 
-        if (exitCode != 0)
-        {
-            console.WriteErrorLine("Project reference not added: received non-zero exit code from dotnet-build process");
-            return ImmutableArray<PortableExecutableReference>.Empty;
-        }
+        var (exitCode, output) = builder.Build(solutionPath);
 
-        var assemblies = GetAssemblies(output).ToArray();
+        var projectPaths = builder
+            .ParseBuildGraph(output)
+            .Select(kvp => Path.GetFullPath(kvp.Value)); //GetFullPath will normalize separators
 
-        if (!assemblies.Any())
+        if (!projectPaths.Any())
         {
             console.WriteErrorLine("Project reference not added: could not determine built assembly");
             return ImmutableArray<PortableExecutableReference>.Empty;
         }
 
-        var allReferences = assemblies
-                .Select(assembly => MetadataReference.CreateFromFile(Path.GetFullPath(assembly))) //GetFullPath will normalize separators
+        return projectPaths
+                .Select(projectPath => MetadataReference.CreateFromFile(projectPath))
                 .ToImmutableArray();
-
-        return allReferences;
     }
-
-    private (int exitCode, IReadOnlyList<string> linesOfOutput) RunDotNetBuild(string reference)
-    {
-        var output = new List<string>();
-
-        var process = new Process
-        {
-            StartInfo =
-                {
-                    FileName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet",
-                    ArgumentList = { "build", reference },
-                    RedirectStandardOutput = true
-                }
-        };
-        process.OutputDataReceived += (_, data) =>
-        {
-            if (data.Data is null) return;
-
-            output.Add(data.Data);
-            console.WriteLine(data.Data);
-        };
-        process.Start();
-        process.BeginOutputReadLine();
-        process.WaitForExit();
-
-        return (process.ExitCode, output);
-    }
-
-    /// <summary>
-    /// Parses the output of dotnet-build to determine every project that was build.
-    /// </summary>
-    /// <returns>
-    /// Every project reference in the output.
-    /// </returns>
-    /// <remarks>
-    /// Sample output that's being parsed below. We extract "C:\Projects\CSharpRepl\bin\Debug\net5.0\CSharpRepl.dll"
-    ///
-    /// Microsoft (R) Build Engine version 17.0.0-preview-21302-02+018bed83d for .NET
-    /// Copyright (C) Microsoft Corporation. All rights reserved.
-    /// 
-    ///   Determining projects to restore...
-    ///   All projects are up-to-date for restore.
-    ///   You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
-    ///   CSharpRepl.Services -> C:\Projects\CSharpRepl.Services\bin\Debug\net5.0\CSharpRepl.Services.dll
-    ///   CSharpRepl -> C:\Projects\CSharpRepl\bin\Debug\net5.0\CSharpRepl.dll
-    /// 
-    /// Build succeeded.
-    ///     0 Warning(s)
-    ///     0 Error(s)
-    /// 
-    /// Time Elapsed 00:00:02.15
-    /// </remarks>
-    private static IEnumerable<string> GetAssemblies(IReadOnlyList<string> output) =>
-        output.Where(line => line.Contains(" -> "))
-            .Select(line => line.Split(" -> ", 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .Select(splitted => splitted.Last());
 
     public static bool IsSolutionReference(string reference)
     {

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -1,4 +1,8 @@
-﻿using CSharpRepl.Services.Dotnet;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Dotnet;
 using Microsoft.CodeAnalysis;
 using PrettyPrompt.Consoles;
 using System;

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -14,6 +14,7 @@ using PrettyPrompt.Consoles;
 using CSharpRepl.Services.Roslyn.MetadataResolvers;
 using CSharpRepl.Services.Roslyn.References;
 using Microsoft.CodeAnalysis;
+using CSharpRepl.Services.Dotnet;
 
 namespace CSharpRepl.Services.Roslyn.Scripting;
 
@@ -40,12 +41,14 @@ internal sealed class ScriptRunner
         this.console = console;
         this.referenceAssemblyService = referenceAssemblyService;
         this.assemblyLoader = new InteractiveAssemblyLoader(new MetadataShadowCopyProvider());
+        var dotnetBuilder = new DotnetBuilder(console);
+
         this.nugetResolver = new NugetPackageMetadataResolver(console, configuration);
-        this.solutionFileMetadataResolver = new SolutionFileMetadataResolver(console);
+        this.solutionFileMetadataResolver = new SolutionFileMetadataResolver(dotnetBuilder, console);
         this.metadataResolver = new CompositeMetadataReferenceResolver(
             nugetResolver,
             solutionFileMetadataResolver,
-            new ProjectFileMetadataResolver(console),
+            new ProjectFileMetadataResolver(dotnetBuilder, console),
             new AssemblyReferenceMetadataResolver(console, referenceAssemblyService)
         );
         this.scriptOptions = ScriptOptions.Default

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -70,7 +70,7 @@ internal sealed class ScriptRunner
     {
         try
         {
-            var alternativeResolutions = await alternativeReferenceResolver.GetAllAlternativeRefences(text, cancellationToken);
+            var alternativeResolutions = await alternativeReferenceResolver.GetAllAlternativeReferences(text, cancellationToken);
             if (alternativeResolutions.Length > 0)
                 this.scriptOptions = this.scriptOptions.AddReferences(alternativeResolutions);
 

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -80,8 +80,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Data\DemoSolution\.vs\DemoSolution\DesignTimeBuild\.dtbcache.v2" />
-    <None Include="Data\DemoSolution\.vs\DemoSolution\v17\.futdcache.v1" />
     <Content Include="Data\DemoSolution\DemoSolution.DemoProject1\DemoSolution.DemoProject1.csproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -6,6 +6,38 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
+    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
+    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
+    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
+    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
+    <None Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
+    <None Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
+    <None Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
+    <None Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\DemoClass1.cs" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\DemoClass2.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject1\DemoClass1.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject2\DemoClass2.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="Data\Config.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -43,6 +75,20 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Data\Disassembly\TopLevelProgram.Output.Release.il">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Data\DemoSolution\.vs\DemoSolution\DesignTimeBuild\.dtbcache.v2" />
+    <None Include="Data\DemoSolution\.vs\DemoSolution\v17\.futdcache.v1" />
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject1\DemoSolution.DemoProject1.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject2\DemoSolution.DemoProject2.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Data\DemoSolution\DemoSolution.sln">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject1/DemoClass1.cs
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject1/DemoClass1.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DemoSolution.DemoProject1
+{
+    public class DemoClass1
+    {
+        public int Add(int a, int b) => a + b;
+    }
+}

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject1/DemoSolution.DemoProject1.csproj
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject1/DemoSolution.DemoProject1.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject2/DemoClass2.cs
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject2/DemoClass2.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DemoSolution.DemoProject2
+{
+    public class DemoClass2
+    {
+        public int Add(int a, int b) => a + b;
+    }
+}

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject2/DemoSolution.DemoProject2.csproj
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject2/DemoSolution.DemoProject2.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.sln
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoSolution.DemoProject1", "DemoSolution.DemoProject1\DemoSolution.DemoProject1.csproj", "{7E5196C3-33EB-4414-8289-1437EBAAC5AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoSolution.DemoProject2", "DemoSolution.DemoProject2\DemoSolution.DemoProject2.csproj", "{2378794F-E814-4B2B-91C0-7FFE41C1A2B1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7E5196C3-33EB-4414-8289-1437EBAAC5AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E5196C3-33EB-4414-8289-1437EBAAC5AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E5196C3-33EB-4414-8289-1437EBAAC5AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E5196C3-33EB-4414-8289-1437EBAAC5AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2378794F-E814-4B2B-91C0-7FFE41C1A2B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2378794F-E814-4B2B-91C0-7FFE41C1A2B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2378794F-E814-4B2B-91C0-7FFE41C1A2B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2378794F-E814-4B2B-91C0-7FFE41C1A2B1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D58EC23D-FF84-4825-AC3E-78F9B787C0AC}
+	EndGlobalSection
+EndGlobal

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -142,4 +142,16 @@ public class EvaluationTests : IAsyncLifetime
         Assert.IsType<EvaluationResult.Success>(referenceResult);
         Assert.IsType<EvaluationResult.Success>(importResult);
     }
+
+    [Fact]
+    public async Task Evaluate_SolutionReference_ReferencesAllProjects()
+    {
+        var referenceResult = await services.EvaluateAsync(@"#r ""./Data/DemoSolution/DemoSolution.sln""");
+        var importProject1Result = await services.EvaluateAsync(@"using DemoSolution.DemoProject1;");
+        var importProject2Result = await services.EvaluateAsync(@"using DemoSolution.DemoProject2;");
+
+        Assert.IsType<EvaluationResult.Success>(referenceResult);
+        Assert.IsType<EvaluationResult.Success>(importProject1Result);
+        Assert.IsType<EvaluationResult.Success>(importProject2Result);
+    }
 }


### PR DESCRIPTION
Partially solves #134 

Adds:
- SolutionFileReferenceMetadataResolver, wich will load all projects from a solution
- DemoSolution for testing purproses
- Abstractions for RefereceResolvers that must return a dummy reference to Roslyn during ResolveReferences()
- DotnetBuilder, an abstraction for `dotnet build`, wich is now shared in two ReferenceResolvers

Changes: 
- ProjectFileReferenceMetadataResolver now only concerns itselft with building .csproj files
- ProjectFileReferenceMetadataResolver now uses the IDotnetBuild
- NugetPackageMetadataResolver now follows the AlternativeReferenceResolver abstraction

A new test `EvaluationTests.Evaluate_SolutionReference_ReferencesAllProjects` was introduced to test this new behaviour.
Every test is running on my local copy, except for: `CompleteStatement_REPL_Tests.IncompleteStatement_CustomKeyBindings`, but it didnt even run before the changes.