### PR TITLE
Upgrade nuget packages

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -6,17 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.0.6844" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.1.0" />
-    <PackageReference Include="PrettyPrompt" Version="3.0.5" />
-    <PackageReference Include="System.IO.Abstractions" Version="16.1.22" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.2.0" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.6" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -48,12 +48,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="3.0.5" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="16.1.22" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.6" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.10" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CSharpRepl.Tests/ConfigurationTests.cs
+++ b/CSharpRepl.Tests/ConfigurationTests.cs
@@ -11,19 +11,19 @@ namespace CSharpRepl.Tests;
 public class ConfigurationTests
 {
     [Theory]
-    [InlineData("Enter", ConsoleKey.Enter, default(ConsoleModifiers))]
-    [InlineData("Control+Enter", ConsoleKey.Enter, ConsoleModifiers.Control)]
-    [InlineData("Control+Alt+Enter", ConsoleKey.Enter, ConsoleModifiers.Control | ConsoleModifiers.Alt)]
-    [InlineData("ctrl+enter", ConsoleKey.Enter, ConsoleModifiers.Control)]
-    [InlineData("A", ConsoleKey.A, default(ConsoleModifiers))]
-    [InlineData("a", ConsoleKey.A, default(ConsoleModifiers))]
-    [InlineData("Alt+Shift+A", ConsoleKey.A, ConsoleModifiers.Alt | ConsoleModifiers.Shift)]
-    public void ParseKeyPressPattern_Key(string pattern, ConsoleKey key, ConsoleModifiers modifiers)
+    [InlineData("Enter", ConsoleKey.Enter, '\n', default(ConsoleModifiers))]
+    [InlineData("Control+Enter", ConsoleKey.Enter, '\n', ConsoleModifiers.Control)]
+    [InlineData("Control+Alt+Enter", ConsoleKey.Enter, '\n', ConsoleModifiers.Control | ConsoleModifiers.Alt)]
+    [InlineData("ctrl+enter", ConsoleKey.Enter, '\n', ConsoleModifiers.Control)]
+    [InlineData("A", ConsoleKey.A, 'A', default(ConsoleModifiers))]
+    [InlineData("a", ConsoleKey.A, 'A', default(ConsoleModifiers))]
+    [InlineData("Alt+Shift+A", ConsoleKey.A, 'A', ConsoleModifiers.Alt | ConsoleModifiers.Shift)]
+    public void ParseKeyPressPattern_Key(string pattern, ConsoleKey expectedKey, char expectedChar, ConsoleModifiers expectedModifiers)
     {
         var parsed = Configuration.ParseKeyPressPattern(pattern);
-        Assert.Equal(key, parsed.Key);
-        Assert.Equal(default, parsed.Character);
-        Assert.Equal(modifiers, parsed.Modifiers);
+        Assert.Equal(expectedKey, parsed.Key);
+        Assert.Equal(expectedChar, parsed.Character);
+        Assert.Equal(expectedModifiers, parsed.Modifiers);
     }
 
     [Theory]

--- a/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
+++ b/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
@@ -14,12 +14,12 @@ public class DotNetInstallationLocatorTest
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", MockFileData.NullObject }
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/data/FrameworkList.xml", string.Empty },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", string.Empty },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", string.Empty },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", string.Empty }
             });
 
         var locator = new DotNetInstallationLocator(
@@ -47,25 +47,25 @@ public class DotNetInstallationLocatorTest
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 // no net5.0 reference assemblies
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/data/FrameworkList.xml", string.Empty },
+                { @"/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0-rc.1.21451.13/ref/net6.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10/Microsoft.CSharp.dll", string.Empty },
+                { @"/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.0-rc.1.21451.13/Microsoft.CSharp.dll", string.Empty },
 
                 // reference assemblies in .nuget installation
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", string.Empty },
 
                 // implement assemblies in .nuget installation
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
             });
 
         var locator = new DotNetInstallationLocator(
@@ -97,19 +97,19 @@ public class DotNetInstallationLocatorTest
                 //
 
                 // reference assemblies in .nuget installation
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/data/FrameworkList.xml", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/3.1.0/ref/netcoreapp3.1/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/data/FrameworkList.xml", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.ref/5.0.0/ref/net5.0/Microsoft.CSharp.dll", string.Empty },
 
                 // implement assemblies in .nuget installation
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
-                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", MockFileData.NullObject },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/5.0.8/runtimes/win-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x64/3.1.15/runtimes/win-x64/lib/necoreapp3.1/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-x86/5.0.8/runtimes/win-x86/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm/5.0.8/runtimes/win-arm/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.win-arm64/5.0.8/runtimes/win-arm64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.osx-x64/5.0.8/runtimes/osx-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
+                { @"/Users/bob/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/5.0.8/runtimes/linux-x64/lib/net5.0/Microsoft.CSharp.dll", string.Empty },
             });
 
         var locator = new DotNetInstallationLocator(

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="3.0.5" />
+    <PackageReference Include="PrettyPrompt" Version="3.0.6" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
   </ItemGroup>

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -106,22 +106,34 @@ internal static class CommandLine
     private static readonly Option<string[]?> TriggerCompletionListKeyBindings = new(
         aliases: new[] { "--triggerCompletionListKeys" },
         description: "Set up key bindings for trigger completion list. Can be specified multiple times."
-    );
+    )
+    {
+        AllowMultipleArgumentsPerToken = true,
+    };
 
     private static readonly Option<string[]?> NewLineKeyBindings = new(
         aliases: new[] { "--newLineKeys" },
         description: "Set up key bindings for new line character insertion. Can be specified multiple times."
-    );
+    )
+    {
+        AllowMultipleArgumentsPerToken = true,
+    };
 
     private static readonly Option<string[]?> SubmitPromptKeyBindings = new(
         aliases: new[] { "--submitPromptKeys" },
         description: "Set up key bindings for the submit of current prompt. Can be specified multiple times."
-    );
+    )
+    {
+        AllowMultipleArgumentsPerToken = true,
+    };
 
     private static readonly Option<string[]?> SubmitPromptDetailedKeyBindings = new(
         aliases: new[] { "--submitPromptDetailedKeys" },
         description: "Set up key bindings for the submit of current prompt with detailed output. Can be specified multiple times."
-    );
+    )
+    {
+        AllowMultipleArgumentsPerToken = true,
+    };
 
     public static Configuration Parse(string[] args, string configFilePath)
     {


### PR DESCRIPTION
The following breaking changes are handled in this PR:

- PrettyPrompt, no longer returns `default(char)` when parsing ConsoleKey
- System.IO.Abstractions, made MockFileData.NullObject internal, recommended to use string.Empty instead.
- System.CommandLine, we now need AllowMultipleArgumentsPerToken to support supplying multiple values to a single option (e.g. `--foo a b`). This should have been handled in #131 but was missed.

Other libraries, like `NuGet.PackageManagement` and `Microsoft.CodeAnalysis.*` had no breaking changes.