### PR TITLE
Completion window UX fixes

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -152,7 +152,9 @@ public sealed class Configuration
         SubmitPromptDetailedKeys = ParseKeyPressPatterns(submitPromptDetailedKeyPatterns);
 
         var commitCompletion = new KeyPressPatterns(
-            CompletionRules.Default.DefaultCommitCharacters.Select(c => new KeyPressPattern(c))
+            CompletionRules.Default.DefaultCommitCharacters
+            .Except(new[] { ' ', '=' }) // pressing space or equals to select the completion can often cause accidental completions
+            .Select(c => new KeyPressPattern(c))
             .Concat(new KeyPressPattern[] { new(ConsoleKey.Enter), new(ConsoleKey.Tab) })
             .ToArray());
 

--- a/CSharpRepl.Tests/CompleteStatementTests.cs
+++ b/CSharpRepl.Tests/CompleteStatementTests.cs
@@ -95,6 +95,15 @@ public class CompleteStatement_REPL_Tests
     }
 
     [Fact]
+    public async Task UsingStatement_CanBeCompleted()
+    {
+        var (console, repl, configuration) = await InitAsync();
+        console.StubInput($@"using Syst{Tab};{Enter}exit{Enter}");
+        await repl.RunAsync(configuration);
+        console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
+    }
+
+    [Fact]
     public async Task ObjectInitialization_CompletionDoesNotInterfere()
     {
         var (console, repl, configuration) = await InitAsync();

--- a/CSharpRepl.Tests/CompleteStatementTests.cs
+++ b/CSharpRepl.Tests/CompleteStatementTests.cs
@@ -94,6 +94,15 @@ public class CompleteStatement_REPL_Tests
         console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task ObjectInitialization_CompletionDoesNotInterfere()
+    {
+        var (console, repl, configuration) = await InitAsync();
+        console.StubInput($@"new {{ c = 5 }}.c{Enter}{Enter}exit{Enter}");
+        await repl.RunAsync(configuration);
+        console.Received().WriteLine("5");
+    }
+
     private static async Task<(IConsole Console, ReadEvalPrintLoop Repl, Configuration Configuration)> InitAsync(Configuration? configuration = null)
     {
         var console = FakeConsole.Create();

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -20,9 +20,14 @@ using PrettyPrompt.Completion;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
+using RoslynCharacterSetModificationRule = Microsoft.CodeAnalysis.Completion.CharacterSetModificationRule;
 
 namespace CSharpRepl.PrettyPromptConfig;
 
+/// <summary>
+/// An implementation of <see cref="PrettyPrompt.PromptCallbacks"/> that configures C#-specific
+/// behavior for our prompt using Roslyn.
+/// </summary>
 internal class CSharpReplPromptCallbacks : PromptCallbacks
 {
     private readonly IConsole console;

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -77,17 +77,39 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
     protected override async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
     {
         var completions = await roslyn.CompleteAsync(text, caret).ConfigureAwait(false);
+        var commitKeybinding = CreateCommitRuleForUserKeybinding(configuration.KeyBindings.CommitCompletion);
         return completions
-              .OrderByDescending(i => i.Item.Rules.MatchPriority)
-              .ThenBy(i => i.Item.SortText)
-              .Select(r => new CompletionItem(
-                  replacementText: r.Item.DisplayText,
-                  displayText: r.DisplayText,
-                  getExtendedDescription: r.GetDescriptionAsync,
-                  filterText: r.Item.FilterText,
-                  commitCharacterRules: r.Item.Rules.CommitCharacterRules.Select(r => new CharacterSetModificationRule((CharacterSetModificationKind)r.Kind, r.Characters)).ToImmutableArray()
-              ))
-              .ToArray();
+            .OrderByDescending(i => i.Item.Rules.MatchPriority)
+            .ThenBy(i => i.Item.SortText)
+            .Select(r => new CompletionItem(
+                replacementText: r.Item.DisplayText,
+                displayText: r.DisplayText,
+                getExtendedDescription: r.GetDescriptionAsync,
+                filterText: r.Item.FilterText,
+                commitCharacterRules: MergeCommitRules(r.Item.Rules.CommitCharacterRules, commitKeybinding)
+            ))
+            .ToArray();
+    }
+
+    private static CharacterSetModificationRule CreateCommitRuleForUserKeybinding(in KeyPressPatterns commitCompletion)
+    {
+        var alwaysCommitCharacters = commitCompletion.DefinedPatterns?.Select(key => key.Character).ToArray() ?? Array.Empty<char>();
+        return new CharacterSetModificationRule(CharacterSetModificationKind.Add, ImmutableArray.Create(alwaysCommitCharacters));
+    }
+
+    // no matter what the roslyn API returns, we should always respect the user's keybindings to commit the completion.
+    private static ImmutableArray<CharacterSetModificationRule> MergeCommitRules(
+        ImmutableArray<RoslynCharacterSetModificationRule> roslynCompletionRules,
+        in CharacterSetModificationRule userDefinedRule)
+    {
+        var completionRules = roslynCompletionRules
+            .Select(r => new CharacterSetModificationRule((CharacterSetModificationKind)r.Kind, r.Characters))
+            .ToImmutableArray();
+
+        if (userDefinedRule.Characters.Length == 0)
+            return completionRules;
+
+        return completionRules.Insert(0, userDefinedRule);
     }
 
     protected override async Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text, CancellationToken cancellationToken)


### PR DESCRIPTION
Now that we've moved to roslyn-suggested completion item commit-characters, the prompt feels great, but I've found a few edge cases that need to be fixed:

1. It's very hard to type Anonymous Object initializers, as the completion window will open when typing the property name, and pressing space will commit the first suggestion. e.g. trying to type `new { i = 0 }` (ignoring the completion window) will result in `new { int= 0 }` because `int` is autoinserted for `i` and committed when <kbd>Spacebar</kbd> is pressed. The fix is to remove both space and equals from the roslyn-suggested completion character list.
1. `using` directives aren't tab-completing. The completion window opens, but pressing <kbd>Tab</kbd> to select the option just inserts a literal tab character. The fix is to ensure we pass the configured commit-character keybindings along with the roslyn-suggested commit-characters.