### PR TITLE
Fix minor nuget installation bugs

### DIFF
--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
@@ -22,13 +22,15 @@ internal sealed class CompositeAlternativeReferenceResolver
     public async Task<ImmutableArray<PortableExecutableReference>> GetAllAlternativeReferences(string code, CancellationToken cancellationToken)
     {
         var splitCommands = code.Split(new[] { '\r', '\n' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        var commandMap = alternativeResolvers.ToDictionary(x => x, x => splitCommands.Where(c => x.CanResolve(c)));
 
-        var resolvingTaks = commandMap
-            .SelectMany(kvp => kvp.Value.Select(reference => kvp.Key.ResolveAsync(reference, cancellationToken)));
+        var resolveReferencesTasks =
+            from cmd in splitCommands
+            from resolver in alternativeResolvers
+            where resolver.CanResolve(cmd)
+            select resolver.ResolveAsync(cmd, cancellationToken);
 
-        await Task.WhenAll(resolvingTaks);
-
-        return resolvingTaks.SelectMany(t => t.Result).ToImmutableArray();
+        return (await Task.WhenAll(resolveReferencesTasks))
+            .SelectMany(r => r)
+            .ToImmutableArray();
     }
 }

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -72,7 +72,9 @@ internal sealed class ScriptRunner
         {
             var alternativeResolutions = await alternativeReferenceResolver.GetAllAlternativeReferences(text, cancellationToken);
             if (alternativeResolutions.Length > 0)
+            {
                 this.scriptOptions = this.scriptOptions.AddReferences(alternativeResolutions);
+            }
 
             var usings = referenceAssemblyService.GetUsings(text);
             referenceAssemblyService.TrackUsings(usings);

--- a/CSharpRepl.Tests/NugetPackageInstallerTests.cs
+++ b/CSharpRepl.Tests/NugetPackageInstallerTests.cs
@@ -54,4 +54,16 @@ public class NugetPackageInstallerTests : IAsyncLifetime
         Assert.NotNull(reference);
         Assert.True(reference.FilePath.Contains("lib", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task InstallPackageThatOnlyContainsDependencies()
+    {
+        // humanizer does not target any frameworks itself, but depends on nuget packages that do.
+        var references = await installer.InstallAsync("Humanizer", "2.14.1");
+
+        Assert.True(references.Length >= 1);
+        var reference = references.FirstOrDefault(r => r.FilePath.EndsWith("Humanizer.dll", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(reference);
+        Assert.True(reference.FilePath.Contains("lib", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,12 +13,14 @@ namespace CSharpRepl.Tests;
 public sealed class RoslynServicesFixture : IAsyncLifetime
 {
     public IConsole ConsoleStub { get; }
+    public StringBuilder CapturedConsoleOutput { get; }
+    public StringBuilder CapturedConsoleError { get; }
     public IPrompt PromptStub { get; }
     public RoslynServices RoslynServices { get; }
 
     public RoslynServicesFixture()
     {
-        this.ConsoleStub = Substitute.For<IConsole>();
+        (this.ConsoleStub, this.CapturedConsoleOutput, this.CapturedConsoleError) = FakeConsole.CreateStubbedOutputAndError();
         this.PromptStub = Substitute.For<IPrompt>();
         this.RoslynServices = new RoslynServices(ConsoleStub, new Configuration(), new TestTraceLogger());
     }


### PR DESCRIPTION
Fixes two bugs in nuget installation. Neither of these bugs are in the released 0.3.5 version of csharprepl, but are in the `main` branch.

- b519d04b0b75da3d0d117c4c80563767662e8ab9 - handle nuget packages that don't define any compatible frameworks, and only exist to pull in dependencies (e.g. the Humanizer package)
- ddd6c93b355aeb097ea52f5d972cc2d5130d1a25 - alternate reference resolvers are each run twice, due to a repeated reference to a lazy IEnumerable.