### PR TITLE
Overload help support for methods and indexers.

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -158,7 +158,12 @@ public sealed class Configuration
             .Concat(new KeyPressPattern[] { new(ConsoleKey.Enter), new(ConsoleKey.Tab) })
             .ToArray());
 
-        KeyBindings = new(commitCompletion, triggerCompletionList, newLine, submitPrompt);
+        KeyBindings = new(
+            commitCompletion,
+            triggerCompletionList,
+            newLine,
+            submitPrompt,
+            triggerOverloadList: new(new KeyPressPattern('('), new KeyPressPattern('['), new KeyPressPattern(',')));
     }
 
     private static KeyPressPatterns ParseKeyPressPatterns(string[] keyPatterns)

--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -68,14 +68,14 @@ internal class Disassembler
 
         using var stream = new MemoryStream();
 
-        foreach (var compiler in compilers)
+        foreach (var (name, compile) in compilers)
         {
             stream.SetLength(0);
-            var compiled = compiler.compile(code, optimizationLevel);
+            var compiled = compile(code, optimizationLevel);
             var compilationResult = compiled.Emit(stream);
             if (compilationResult.Success)
             {
-                commentFooter.Add($"// Compiling code as {compiler.name}: succeeded.");
+                commentFooter.Add($"// Compiling code as {name}: succeeded.");
                 stream.Position = 0;
                 var file = new PEFile(Guid.NewGuid().ToString(), stream, PEStreamOptions.LeaveOpen);
                 disassembler.WriteModuleContents(file); // writes to the "ilCodeOutput" variable
@@ -90,7 +90,7 @@ internal class Disassembler
             }
             else
             {
-                commentFooter.Add($"// Compiling code as {compiler.name}: failed.");
+                commentFooter.Add($"// Compiling code as {name}: failed.");
                 commentFooter.AddRange(compilationResult
                     .Diagnostics
                     .Where(d => d.Severity == DiagnosticSeverity.Error)

--- a/CSharpRepl.Services/Extensions/RoslynExtensions.cs
+++ b/CSharpRepl.Services/Extensions/RoslynExtensions.cs
@@ -56,4 +56,41 @@ internal static class RoslynExtensions
             _ => null,
         };
     }
+
+    //TextTagToClassificationTypeName analogue
+    public static string? SymbolDisplayPartKindToClassificationTypeName(SymbolDisplayPartKind kind)
+    {
+        return kind switch
+        {
+            SymbolDisplayPartKind.Keyword => ClassificationTypeNames.Keyword,
+            SymbolDisplayPartKind.ClassName => ClassificationTypeNames.ClassName,
+            SymbolDisplayPartKind.DelegateName => ClassificationTypeNames.DelegateName,
+            SymbolDisplayPartKind.EnumName => ClassificationTypeNames.EnumName,
+            SymbolDisplayPartKind.InterfaceName => ClassificationTypeNames.InterfaceName,
+            SymbolDisplayPartKind.ModuleName => ClassificationTypeNames.ModuleName,
+            SymbolDisplayPartKind.StructName => ClassificationTypeNames.StructName,
+            SymbolDisplayPartKind.TypeParameterName => ClassificationTypeNames.TypeParameterName,
+            SymbolDisplayPartKind.FieldName => ClassificationTypeNames.FieldName,
+            SymbolDisplayPartKind.EventName => ClassificationTypeNames.EventName,
+            SymbolDisplayPartKind.LabelName => ClassificationTypeNames.LabelName,
+            SymbolDisplayPartKind.LocalName => ClassificationTypeNames.LocalName,
+            SymbolDisplayPartKind.MethodName => ClassificationTypeNames.MethodName,
+            SymbolDisplayPartKind.NamespaceName => ClassificationTypeNames.NamespaceName,
+            SymbolDisplayPartKind.ParameterName => ClassificationTypeNames.ParameterName,
+            SymbolDisplayPartKind.PropertyName => ClassificationTypeNames.PropertyName,
+            SymbolDisplayPartKind.ExtensionMethodName => ClassificationTypeNames.ExtensionMethodName,
+            SymbolDisplayPartKind.EnumMemberName => ClassificationTypeNames.EnumMemberName,
+            SymbolDisplayPartKind.ConstantName => ClassificationTypeNames.ConstantName,
+            SymbolDisplayPartKind.AliasName or SymbolDisplayPartKind.AssemblyName or SymbolDisplayPartKind.ErrorTypeName or SymbolDisplayPartKind.RangeVariableName => ClassificationTypeNames.Identifier,
+            SymbolDisplayPartKind.NumericLiteral => ClassificationTypeNames.NumericLiteral,
+            SymbolDisplayPartKind.StringLiteral => ClassificationTypeNames.StringLiteral,
+            SymbolDisplayPartKind.Space or SymbolDisplayPartKind.LineBreak => ClassificationTypeNames.WhiteSpace,
+            SymbolDisplayPartKind.Operator => ClassificationTypeNames.Operator,
+            SymbolDisplayPartKind.Punctuation => ClassificationTypeNames.Punctuation,
+            SymbolDisplayPartKind.AnonymousTypeIndicator or SymbolDisplayPartKind.Text => ClassificationTypeNames.Text,
+            SymbolDisplayPartKind.RecordClassName => ClassificationTypeNames.RecordClassName,
+            SymbolDisplayPartKind.RecordStructName => ClassificationTypeNames.RecordStructName,
+            _ => null,
+        };
+    }
 }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
@@ -43,7 +43,7 @@ internal sealed class NugetPackageMetadataResolver : AlternativeReferenceResolve
         return packageParts.Length switch
         {
             2 => nugetInstaller.InstallAsync(packageId: packageParts[1], cancellationToken: cancellationToken),
-            3 => nugetInstaller.InstallAsync(packageId: packageParts[1], version: packageParts[2].TrimStart('v'), cancellationToken: cancellationToken),
+            3 => nugetInstaller.InstallAsync(packageId: packageParts[1], version: packageParts[2].TrimStart('v'), cancellationToken),
             _ => throw new InvalidOperationException(@"Malformed nuget reference. Expected #r ""nuget: PackageName"" or #r ""nuget: PackageName, version""")
         };
     }

--- a/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
+++ b/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Xml;
+using CSharpRepl.Services.Extensions;
+using CSharpRepl.Services.SyntaxHighlighting;
+using Microsoft.CodeAnalysis;
+using PrettyPrompt.Completion;
+using PrettyPrompt.Highlighting;
+
+namespace CSharpRepl.Services.Roslyn;
+
+internal class OverloadItemGenerator
+{
+    private const char LineEnd = '\n';
+
+    private readonly FormattedStringBuilder summaryBuilder = new();
+    private readonly FormattedStringBuilder returnBuilder = new();
+    private readonly FormattedStringBuilder parameterBuilder = new();
+    private readonly FormattedStringBuilder signatureBuilder = new();
+    private readonly SyntaxHighlighter highlighter;
+
+    public OverloadItemGenerator(SyntaxHighlighter highlighter)
+    {
+        this.highlighter = highlighter;
+    }
+
+    public OverloadItem? Create(ISymbol symbol, CancellationToken cancellationToken)
+    {
+        var xml = symbol.GetDocumentationCommentXml(cancellationToken: cancellationToken);
+        if (TryParse(xml, out var parsedXml))
+        {
+            foreach (var part in symbol.ToDisplayParts(SymbolDisplayFormat.MinimallyQualifiedFormat))
+            {
+                var classification = RoslynExtensions.SymbolDisplayPartKindToClassificationTypeName(part.Kind);
+                if (classification is not null &&
+                    highlighter.TryGetColor(classification, out var color))
+                {
+                    signatureBuilder.Append(part.ToString(), new ConsoleFormat(color));
+                }
+                else
+                {
+                    signatureBuilder.Append(part.ToString());
+                }
+            }
+
+            var result = new OverloadItem(signatureBuilder.ToFormattedString(), parsedXml.Summary, parsedXml.ReturnDescription, parsedXml.Parameters);
+            signatureBuilder.Clear();
+            return result;
+        }
+        return null;
+    }
+
+    private bool TryParse(string? xmlDocumentation, out (FormattedString Summary, FormattedString ReturnDescription, IReadOnlyList<OverloadItem.Parameter> Parameters) result)
+    {
+        if (string.IsNullOrEmpty(xmlDocumentation))
+        {
+            result = default;
+            return false;
+        }
+
+        var parameters = new List<OverloadItem.Parameter>();
+        FormattedStringBuilder currentBuilder = default;
+        string? currentParameter = null;
+        using var reader = new StringReader("<docroot>" + xmlDocumentation + "</docroot>");
+        using var xml = XmlReader.Create(reader);
+        while (xml.Read())
+        {
+            string? elementName = null;
+            if (xml.NodeType == XmlNodeType.Element)
+            {
+                elementName = xml.Name.ToLowerInvariant();
+                switch (elementName)
+                {
+                    case "docroot":
+                        break;
+
+                    //TODO
+                    //case "filterpriority":
+                    //case "remarks":
+                    //case "example":
+                    //case "typeparam":
+                    //case "value":
+                    //case "exception":
+                    //    xml.Skip();
+                    //    break;
+
+                    case "see":
+                    case "seealso":
+                        var value = xml["cref"];
+                        if (value != null)
+                        {
+                            //TODO type name simplicifiction/coloring/generic args/...
+                            currentBuilder.Append(' ');
+                            AppendMultiLineString(currentBuilder, value);
+                            currentBuilder.Append(' ');
+                        }
+                        else
+                        {
+                            value = xml["href"] ?? xml["langword"];
+                            if (value != null)
+                            {
+                                currentBuilder.Append(' ');
+                                AppendMultiLineString(currentBuilder, value);
+                                currentBuilder.Append(' ');
+                            }
+                        }
+                        break;
+
+                    case "returns":
+                        ChangeCurrentBuilder(returnBuilder);
+                        break;
+
+                    case "summary":
+                        ChangeCurrentBuilder(summaryBuilder);
+                        break;
+
+                    //TODO
+                    //case "paramref":
+                    //    currentSectionBuilder.Append(xml["name"]);
+                    //    currentSectionBuilder.Append(' ');
+                    //    break;
+
+                    case "param":
+                        ChangeCurrentBuilder(parameterBuilder);
+                        currentParameter = xml["name"];
+                        break;
+
+                    //TODO
+                    //case "typeparamref":
+                    //    currentSectionBuilder.Append(xml["name"]);
+                    //    currentSectionBuilder.Append(' ');
+                    //    break;
+
+                    case "br":
+                    case "para":
+                        if (!currentBuilder.IsDefault)
+                        {
+                            currentBuilder.Append(LineEnd);
+                        }
+                        break;
+
+                    default:
+                        xml.Skip();
+                        break;
+                }
+            }
+            else if (xml.NodeType == XmlNodeType.Text && !currentBuilder.IsDefault)
+            {
+                if (elementName == "code")
+                {
+                    currentBuilder.Append(xml.Value);
+                }
+                else
+                {
+                    AppendMultiLineString(currentBuilder, xml.Value);
+                }
+            }
+        }
+
+        ChangeCurrentBuilder(default);
+        result = (summaryBuilder.ToFormattedString(), returnBuilder.ToFormattedString(), parameters);
+
+        summaryBuilder.Clear();
+        returnBuilder.Clear();
+
+        return true;
+
+        void ChangeCurrentBuilder(FormattedStringBuilder builder)
+        {
+            if (currentBuilder == parameterBuilder)
+            {
+                parameters.Add(new OverloadItem.Parameter(currentParameter ?? "", parameterBuilder.ToFormattedString()));
+                parameterBuilder.Clear();
+            }
+            currentBuilder = builder;
+        }
+    }
+
+    private void AppendMultiLineString(FormattedStringBuilder builder, string? input)
+    {
+        if (input is null) return;
+
+        var lines = input.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < lines.Length; i++)
+        {
+            builder.Append(lines[i].AsSpan().Trim());
+            if (i < lines.Length - 1) builder.Append(LineEnd);
+        }
+    }
+}

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -127,9 +127,9 @@ internal sealed class ScriptRunner
         return state is null
             ? CSharpScript
                 .Create(text, scriptOptions, globalsType: typeof(ScriptGlobals), assemblyLoader: assemblyLoader)
-                .RunAsync(globals: CreateGlobalsObject(args), cancellationToken: cancellationToken)
+                .RunAsync(globals: CreateGlobalsObject(args), cancellationToken)
             : state
-                .ContinueWithAsync(text, scriptOptions, cancellationToken: cancellationToken);
+                .ContinueWithAsync(text, scriptOptions, cancellationToken);
     }
 
     private ScriptGlobals CreateGlobalsObject(string[]? args)

--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services;
-using CSharpRepl.Services.Roslyn;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using PrettyPrompt.Completion;
 using Xunit;
 
 namespace CSharpRepl.Tests;
@@ -98,5 +100,206 @@ public class CompletionTests : IAsyncLifetime
         Assert.NotNull(whereCompletion);
         var whereDescription = await whereCompletion.GetDescriptionAsync(cancellationToken: default);
         Assert.Contains("Filters a sequence of values based on a predicate", whereDescription.Text);
+    }
+
+    [Fact]
+    public async Task Complete_Overloads()
+    {
+        for (int whiteSpacesCount = 0; whiteSpacesCount < 3; whiteSpacesCount++)
+        {
+            var _ = new string(' ', whiteSpacesCount);
+            var code = $"{_}Math{_}.{_}Max{_}({_}";
+            var overloadsHelpStart = code.Length - _.Length;
+
+            (IReadOnlyList<OverloadItem> Overloads, int ArgumentIndex) result;
+            for (int caret = 0; caret < overloadsHelpStart; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            result = await services.GetOverloadsAsync(code, caret: overloadsHelpStart, cancellationToken: default);
+            Assert.True(result.Overloads.Count > 0);
+            Assert.Equal(0, result.ArgumentIndex);
+            foreach (var overload in result.Overloads)
+            {
+                Assert.Contains("Max", overload.Signature.Text);
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+            code = $"{_}Math{_}.{_}Max{_}({_}){_};{_}";
+            overloadsHelpStart = code.Length - $"{_}){_};{_}".Length;
+            var overloadsHelpEndExclusive = code.Length - $"{_};{_}".Length;
+
+            for (int caret = 0; caret < overloadsHelpStart; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            for (int caret = overloadsHelpStart; caret < overloadsHelpEndExclusive; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.True(result.Overloads.Count > 0);
+                Assert.Equal(0, result.ArgumentIndex);
+                Assert.Equal(0, result.ArgumentIndex);
+                foreach (var overload in result.Overloads)
+                {
+                    Assert.Contains("Max", overload.Signature.Text);
+                }
+            }
+
+            for (int caret = overloadsHelpEndExclusive; caret <= code.Length; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+            code = $"{_}Math{_}.{_}Max{_}({_}123,{_}456{_}){_};{_}";
+            overloadsHelpStart = code.Length - $"{_}123,{_}456{_}){_};{_}".Length;
+            overloadsHelpEndExclusive = code.Length - $"{_};{_}".Length;
+
+            for (int caret = 0; caret < overloadsHelpStart; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            for (int caret = overloadsHelpStart; caret < overloadsHelpEndExclusive; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.True(result.Overloads.Count > 0);
+                Assert.Equal(caret <= $"{_}Math{_}.{_}Max{_}({_}123".Length ? 0 : 1, result.ArgumentIndex);
+                foreach (var overload in result.Overloads)
+                {
+                    Assert.Contains("Max", overload.Signature.Text);
+                }
+            }
+
+            for (int caret = overloadsHelpEndExclusive; caret <= code.Length; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+            code = $"{_}Math{_}.{_}Max{_}({_}Math{_}.{_}Abs{_}({_}-123{_}),{_}456{_}){_};{_}";
+            overloadsHelpStart = code.Length - $"{_}Math{_}.{_}Abs{_}({_}-123{_}),{_}456{_}){_};{_}".Length;
+            overloadsHelpEndExclusive = code.Length - $"{_}-123{_}),{_}456{_}){_};{_}".Length;
+
+            for (int caret = 0; caret < overloadsHelpStart; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+
+            for (int caret = overloadsHelpStart; caret < overloadsHelpEndExclusive; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.True(result.Overloads.Count > 0);
+                Assert.Equal(caret <= $"{_}Math{_}.{_}Max{_}({_}Math{_}.{_}Abs{_}({_}-123{_})".Length ? 0 : 1, result.ArgumentIndex);
+                foreach (var overload in result.Overloads)
+                {
+                    Assert.Contains("Max", overload.Signature.Text);
+                }
+            }
+
+            //abs arg list start
+            overloadsHelpStart = overloadsHelpEndExclusive;
+            overloadsHelpEndExclusive = code.Length - $",{_}456{_}){_};{_}".Length;
+            for (int caret = overloadsHelpStart; caret < overloadsHelpEndExclusive; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.True(result.Overloads.Count > 0);
+                Assert.Equal(0, result.ArgumentIndex);
+                foreach (var overload in result.Overloads)
+                {
+                    Assert.Contains("Abs", overload.Signature.Text);
+                }
+            }
+            //abs arg list end
+
+            overloadsHelpStart = overloadsHelpEndExclusive;
+            overloadsHelpEndExclusive = code.Length - $"{_};{_}".Length;
+            for (int caret = overloadsHelpStart; caret < overloadsHelpEndExclusive; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.True(result.Overloads.Count > 0);
+                Assert.Equal(caret <= $"{_}Math{_}.{_}Max{_}({_}Math{_}.{_}Abs{_}({_}-123{_})".Length ? 0 : 1, result.ArgumentIndex);
+                foreach (var overload in result.Overloads)
+                {
+                    Assert.Contains("Max", overload.Signature.Text);
+                }
+            }
+
+            for (int caret = overloadsHelpEndExclusive; caret <= code.Length; caret++)
+            {
+                result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+                Assert.Empty(result.Overloads);
+                Assert.Equal(0, result.ArgumentIndex);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Complete_Overloads_NewInstance()
+    {
+        var code = $"new string('x'";
+        var overloadsHelpStart = $"new string(".Length;
+
+        (IReadOnlyList<OverloadItem> Overloads, int ArgumentIndex) result;
+        for (int caret = 0; caret < overloadsHelpStart; caret++)
+        {
+            result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+            Assert.Empty(result.Overloads);
+            Assert.Equal(0, result.ArgumentIndex);
+        }
+
+        for (int caret = overloadsHelpStart; caret < code.Length; caret++)
+        {
+            result = await services.GetOverloadsAsync(code, caret: overloadsHelpStart, cancellationToken: default);
+            Assert.True(result.Overloads.Count > 0);
+            Assert.Equal(0, result.ArgumentIndex);
+            foreach (var overload in result.Overloads)
+            {
+                Assert.Contains("string", overload.Signature.Text);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Complete_Overloads_Indexer()
+    {
+        var code = $"\"abc\"[0";
+        var overloadsHelpStart = $"\"abc\"[".Length;
+
+        (IReadOnlyList<OverloadItem> Overloads, int ArgumentIndex) result;
+        for (int caret = 0; caret < overloadsHelpStart; caret++)
+        {
+            result = await services.GetOverloadsAsync(code, caret, cancellationToken: default);
+            Assert.Empty(result.Overloads);
+            Assert.Equal(0, result.ArgumentIndex);
+        }
+
+        for (int caret = overloadsHelpStart; caret < code.Length; caret++)
+        {
+            result = await services.GetOverloadsAsync(code, caret: overloadsHelpStart, cancellationToken: default);
+            Assert.True(result.Overloads.Count > 0);
+            Assert.Equal(0, result.ArgumentIndex);
+            foreach (var overload in result.Overloads)
+            {
+                Assert.Contains("string", overload.Signature.Text);
+            }
+        }
     }
 }

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -130,6 +130,9 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         return keyPress;
     }
 
+    protected override Task<(IReadOnlyList<OverloadItem>, int ArgumentIndex)> GetOverloadsAsync(string text, int caret, CancellationToken cancellationToken)
+        => roslyn.GetOverloadsAsync(text, caret, cancellationToken);
+
     private static async Task<KeyPressCallbackResult?> Disassemble(RoslynServices roslyn, string text, IConsole console, bool debugMode)
     {
         var result = await roslyn.ConvertToIntermediateLanguage(text, debugMode);


### PR DESCRIPTION
Resolves #102.

This brings support for VS-like overload help for methods/indexers/constructors. Nested method calls and argument tracking is implemented.

![WindowsTerminal_qTop5oop8T](https://user-images.githubusercontent.com/11704036/180066918-cd227e86-75a2-4676-96fc-bbe6ad25e58b.gif)

