### PR TITLE
Partially revert #137 as it interferes with usability

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -152,9 +152,7 @@ public sealed class Configuration
         SubmitPromptDetailedKeys = ParseKeyPressPatterns(submitPromptDetailedKeyPatterns);
 
         var commitCompletion = new KeyPressPatterns(
-            CompletionRules.Default.DefaultCommitCharacters
-            .Except(new[] { ' ', '=' }) // pressing space or equals to select the completion can often cause accidental completions
-            .Select(c => new KeyPressPattern(c))
+            CompletionRules.Default.DefaultCommitCharacters.Select(c => new KeyPressPattern(c))
             .Concat(new KeyPressPattern[] { new(ConsoleKey.Enter), new(ConsoleKey.Tab) })
             .ToArray());
 

--- a/CSharpRepl.Tests/CompleteStatementTests.cs
+++ b/CSharpRepl.Tests/CompleteStatementTests.cs
@@ -103,14 +103,16 @@ public class CompleteStatement_REPL_Tests
         console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
     }
 
-    [Fact]
-    public async Task ObjectInitialization_CompletionDoesNotInterfere()
-    {
-        var (console, repl, configuration) = await InitAsync();
-        console.StubInput($@"new {{ c = 5 }}.c{Enter}{Enter}exit{Enter}");
-        await repl.RunAsync(configuration);
-        console.Received().WriteLine("5");
-    }
+    // this test is currently failing. There was an attempt to fix it in https://github.com/waf/CSharpRepl/pull/137/commits/7f2c801c6efb2eec07d0149d26c05658a19ef35f
+    // but that commit hurts usability of the prompt. See https://github.com/waf/CSharpRepl/issues/148 for details.
+    //[Fact]
+    //public async Task ObjectInitialization_CompletionDoesNotInterfere()
+    //{
+    //    var (console, repl, configuration) = await InitAsync();
+    //    console.StubInput($@"new {{ c = 5 }}.c{Enter}{Enter}exit{Enter}");
+    //    await repl.RunAsync(configuration);
+    //    console.Received().WriteLine("5");
+    //}
 
     private static async Task<(IConsole Console, ReadEvalPrintLoop Repl, Configuration Configuration)> InitAsync(Configuration? configuration = null)
     {


### PR DESCRIPTION
Resolves #148 (see for context).

https://github.com/waf/CSharpRepl/pull/137/commits/7f2c801c6efb2eec07d0149d26c05658a19ef35f was an attempt to improve the current behavior of our roslyn completion commit characters -- the commit characters currently trigger aggressively and cause unwanted completions (see https://github.com/waf/CSharpRepl/issues/145 and first bullet point of #137).

Commit 7f2c801c6efb2eec07d0149d26c05658a19ef35f "worked around" it by removing some of the more egregious commit characters, but that brings us farther from Visual Studio's behavior, which is the opposite of what we want. A better approach is to figure out what's wrong with our roslyn completion commit character usage.

In this PR, there's a commented-out unit test (`ObjectInitialization_CompletionDoesNotInterfere`) that fails when uncommented. This is useful when troubleshooting the commit character implementation.