### PR TITLE
Automatic formatting on ';', '{' or '}' key press.

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.2.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta6" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.10" />
   </ItemGroup>
 

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -94,7 +94,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta6" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.10" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -16,11 +16,11 @@ using static System.ConsoleModifiers;
 namespace CSharpRepl.Tests;
 
 [Collection(nameof(RoslynServices))]
-public class CompleteStatementTests : IAsyncLifetime
+public class RoslynServicesTests : IAsyncLifetime
 {
     private readonly RoslynServices services;
 
-    public CompleteStatementTests()
+    public RoslynServicesTests()
     {
         var (console, _) = FakeConsole.CreateStubbedOutput();
         this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());
@@ -40,10 +40,45 @@ public class CompleteStatementTests : IAsyncLifetime
         bool isCompleteStatement = await services.IsTextCompleteStatementAsync(code);
         Assert.Equal(shouldBeCompleteStatement, isCompleteStatement);
     }
+
+
+    /// <summary>
+    /// https://github.com/waf/CSharpRepl/issues/159
+    /// </summary>
+    [Theory]
+    [InlineData("if(true){}", 10, "if (true) { }", 13, false)]
+    [InlineData("if(true){}", 9, "if (true) { }", 11, false)]
+    [InlineData("if(true){M  ( x  );}", 9, "if (true) { M(x); }", 11, false)]
+    [InlineData("if(true){M  ( x  );}", 19, "if (true) { M(x); }", 17, false)]
+    [InlineData("if(true){M  ( x  );}", 20, "if (true) { M(x); }", 19, false)]
+    [InlineData("class C{", 8, "class C {", 9, false)]
+    [InlineData("class C{int F;", 14, "class C { int F;", 16, false)]
+    [InlineData("class C{int F;}", 15, "class C { int F; }", 18, false)]
+    [InlineData("class C{\n\n}", 8, "class C\n{\n\n}", 9, false)]
+    [InlineData("class C{\n\n}", 11, "class C\n{\n\n}", 12, false)]
+    [InlineData("class C{\n\n    }", 15, "class C\n{\n\n}", 12, false)]
+    
+    [InlineData("Console.Write( 1+1 ); if(true  ){", 33, "Console.Write(1 + 1); if (true) {", 33, false)]
+    [InlineData("Console.Write( 1+1 ); if(true  ){", 33, "Console.Write( 1+1 ); if (true) {", 33, true)]
+    public async Task AutoFormat(string text, int caret, string expectedText, int expectedCaret, bool formatParentNodeOnly)
+    {
+        var (formattedText, formattedCaret) = await services.FormatInput(text, caret, formatParentNodeOnly, default);
+
+        if (Environment.NewLine.Length == 2)
+        {
+            for (int i = 0; i < formattedCaret; i++)
+            {
+                if (formattedText[i] == '\r') ++expectedCaret;
+            }
+        }
+
+        Assert.Equal(expectedText, formattedText.Replace("\r", ""));
+        Assert.Equal(expectedCaret, formattedCaret);
+    }
 }
 
 [Collection(nameof(RoslynServices))]
-public class CompleteStatement_REPL_Tests
+public class RoslynServices_REPL_Tests
 {
     [Fact]
     public async Task CompleteStatement_DefaultKeyBindings()

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.0-beta6" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
   </ItemGroup>

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -133,6 +133,26 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
     protected override Task<bool> ConfirmCompletionCommit(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
         => roslyn.ConfirmCompletionCommit(text, caret, keyPress, cancellationToken);
 
+    protected override async Task<(string Text, int Caret)> FormatInput(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+    {
+        var keyChar = keyPress.ConsoleKeyInfo.KeyChar;
+
+        if (caret > 0)
+        {
+            switch (keyChar)
+            {
+                case ';' or '}':
+                    return await roslyn.FormatInput(text, caret, formatParentNodeOnly: false, cancellationToken).ConfigureAwait(false);
+                case '{':
+                    return await roslyn.FormatInput(text, caret, formatParentNodeOnly: true, cancellationToken).ConfigureAwait(false);
+                default:
+                    break;
+            }
+        }
+
+        return (text, caret);
+    }
+
     protected override Task<(IReadOnlyList<OverloadItem>, int ArgumentIndex)> GetOverloadsAsync(string text, int caret, CancellationToken cancellationToken)
         => roslyn.GetOverloadsAsync(text, caret, cancellationToken);
 


### PR DESCRIPTION
Resolves #159.
![VsDebugConsole_yizdiZ4arL](https://user-images.githubusercontent.com/11704036/182693822-d3dc070b-298b-4903-916a-a9aeab5363e5.gif)
