### PR TITLE
Smart indentation.

### DIFF
--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -125,8 +125,27 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
             configuration.KeyBindings.SubmitPrompt.Matches(keyPress.ConsoleKeyInfo) &&
             !await roslyn.IsTextCompleteStatementAsync(text).ConfigureAwait(false))
         {
+            //Soft Enter.
             return new KeyPress(ConsoleKey.Insert.ToKeyInfo('\0', shift: true), "\n");
         }
+
+        if (configuration.KeyBindings.NewLine.Matches(keyPress.ConsoleKeyInfo))
+        {
+            //Smart indentation
+            int openBraces = 0;
+            var end = Math.Min(text.Length, caret);
+            for (int i = 0; i < end; i++)
+            {
+                var c = text[i];
+                if (c == '{') ++openBraces;
+                if (c == '}') --openBraces;
+            }
+            return
+                openBraces == 0 ?
+                keyPress :
+                new KeyPress(ConsoleKey.Insert.ToKeyInfo('\0', shift: true), "\n" + new string('\t', openBraces));
+        }
+
         return keyPress;
     }
 


### PR DESCRIPTION
Resolves #98.

It works beautifully with #160.
![WindowsTerminal_KYtN8t861C](https://user-images.githubusercontent.com/11704036/182789892-d7d6ee0b-3284-4111-a991-34c503c87cc8.gif)
