### PR TITLE
Start scripts are loaded via #load instead of executing contents of the script.

### DIFF
--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -97,7 +97,7 @@ public class CommandLineTests
         Assert.Equal(new[] { "System.Linq", "System.Data", "Newtonsoft.Json" }, result.Usings);
         Assert.Equal(new[] { "foo.dll", "bar.dll", "baz.dll" }, result.References);
         Assert.Equal("Microsoft.AspNetCore.App", result.Framework);
-        Assert.Equal(@"Console.WriteLine(""Hello World!"");" + Environment.NewLine, result.LoadScript);
+        Assert.Equal(@"#load ""Data/LoadScript.csx""" + Environment.NewLine, result.LoadScript);
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class CommandLineTests
         var csxResult = Parse(new[] { "Data/LoadScript.csx", "--", "Data/LoadScript.csx" });
         // load script filename passed before "--" is a load script, after "--" we just pass it to the load script as an arg.
         Assert.Equal(new[] { "Data/LoadScript.csx" }, csxResult.LoadScriptArgs);
-        Assert.Equal(@"Console.WriteLine(""Hello World!"");" + Environment.NewLine, csxResult.LoadScript);
+        Assert.Equal(@"#load ""Data/LoadScript.csx""" + Environment.NewLine, csxResult.LoadScript);
 
         var quotedResult = Parse(new[] { "-r", "Foo.dll", "--", @"""a b c""", @"""d e f""" });
         Assert.Equal(new[] { @"""a b c""", @"""d e f""" }, quotedResult.LoadScriptArgs);

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -272,7 +272,9 @@ internal static class CommandLine
             if (arg == DisableFurtherOptionParsing) break;
             if (!arg.EndsWith(".csx")) continue;
             if (!File.Exists(arg)) throw new FileNotFoundException($@"Script file ""{arg}"" was not found");
-            stringBuilder.AppendLine(File.ReadAllText(arg));
+
+            //we are not loading content of the script manually because of https://github.com/waf/CSharpRepl/issues/140
+            stringBuilder.AppendLine($"#load \"{arg}\"");
         }
         return stringBuilder.Length == 0 ? null : stringBuilder.ToString();
     }


### PR DESCRIPTION
Resolves #140.