### PR TITLE
Parsing deps.json files and storing this info when loading assemblies.

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.3.0" />
     <PackageReference Include="PrettyPrompt" Version="4.0.0-beta9" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.10" />
   </ItemGroup>

--- a/CSharpRepl.Services/Nuget/NugetHelper.cs
+++ b/CSharpRepl.Services/Nuget/NugetHelper.cs
@@ -1,0 +1,46 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Versioning;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+
+namespace CSharpRepl.Services.Nuget;
+
+internal static class NugetHelper
+{
+    private const string RuntimeFileName = "runtime.json";
+
+    public static RuntimeGraph GetRuntimeGraph(Action<string>? error)
+    {
+        var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        if (dir != null)
+        {
+            var path = Path.Combine(dir, RuntimeFileName);
+            if (File.Exists(path))
+            {
+                using var stream = File.OpenRead(path);
+                return JsonRuntimeFormat.ReadRuntimeGraph(stream);
+            }
+        }
+        error?.Invoke($"Cannot find '{RuntimeFileName}' in '{dir}'");
+        return new RuntimeGraph();
+    }
+
+    public static NuGetFramework GetCurrentFramework()
+    {
+        var assembly = Assembly.GetEntryAssembly();
+        if (assembly is null ||
+            assembly.Location.EndsWith("testhost.dll", StringComparison.OrdinalIgnoreCase)) //for unit tests (testhost.dll targets netcoreapp2.1 instead of net6.0)
+        {
+            assembly = Assembly.GetExecutingAssembly();
+        }
+
+        var targetFrameworkAttribute = assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+        return NuGetFramework.Parse(targetFrameworkAttribute?.FrameworkName);
+    }
+}

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
@@ -14,6 +14,8 @@ namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 /// </summary>
 public abstract class AlternativeReferenceResolver : IIndividualMetadataReferenceResolver
 {
+    public static PortableExecutableReference DummyReference { get; } = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+
     public ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
     {
         if (CanResolve(reference))
@@ -23,13 +25,11 @@ public abstract class AlternativeReferenceResolver : IIndividualMetadataReferenc
     }
 
     public abstract bool CanResolve(string reference);
-    public virtual Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(Resolve(reference));
-    }
-    public virtual ImmutableArray<PortableExecutableReference> Resolve(string reference)
-    {
-        return ImmutableArray<PortableExecutableReference>.Empty;
-    }
-    public static PortableExecutableReference DummyReference { get; } = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+
+    public virtual Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken) 
+        => Task.FromResult(Resolve(reference));
+
+    public virtual ImmutableArray<PortableExecutableReference> Resolve(string reference) 
+        => ImmutableArray<PortableExecutableReference>.Empty;
+
 }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Nuget;
-using Microsoft.CodeAnalysis;
-using PrettyPrompt.Consoles;
 using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using CSharpRepl.Services.Nuget;
+using Microsoft.CodeAnalysis;
+using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
@@ -18,6 +18,7 @@ namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 internal sealed class NugetPackageMetadataResolver : AlternativeReferenceResolver
 {
     private const string NugetPrefix = "nuget:";
+    private const string NugetPrefixWithHashR = "#r \"" + NugetPrefix;
     private readonly NugetPackageInstaller nugetInstaller;
 
     public NugetPackageMetadataResolver(IConsole console, Configuration configuration)
@@ -25,11 +26,9 @@ internal sealed class NugetPackageMetadataResolver : AlternativeReferenceResolve
         this.nugetInstaller = new NugetPackageInstaller(console, configuration);
     }
 
-    public override bool CanResolve(string reference)
-    {
-        return reference.ToLowerInvariant() is string lowercased
-                && (lowercased.StartsWith(NugetPrefix) || lowercased.StartsWith($"#r \"{NugetPrefix}")); // roslyn trims the "#r" prefix when passing to the resolver, but it has the prefix when called from our ScriptRunner
-    }
+    public override bool CanResolve(string reference) =>
+        reference.StartsWith(NugetPrefix, StringComparison.OrdinalIgnoreCase) ||
+        reference.StartsWith(NugetPrefixWithHashR, StringComparison.OrdinalIgnoreCase); // roslyn trims the "#r" prefix when passing to the resolver, but it has the prefix when called from our ScriptRunner
 
     public override Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
     {

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
@@ -17,10 +17,10 @@ namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 /// </summary>
 internal sealed class ProjectFileMetadataResolver : IIndividualMetadataReferenceResolver
 {
-    private readonly IDotnetBuilder builder;
+    private readonly DotnetBuilder builder;
     private readonly IConsole console;
 
-    public ProjectFileMetadataResolver(IDotnetBuilder builder, IConsole console)
+    public ProjectFileMetadataResolver(DotnetBuilder builder, IConsole console)
     {
         this.builder = builder;
         this.console = console;
@@ -39,7 +39,6 @@ internal sealed class ProjectFileMetadataResolver : IIndividualMetadataReference
 
     private ImmutableArray<PortableExecutableReference> LoadProjectReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
     {
-
         var (exitCode, output) = builder.Build(reference);
 
         if (exitCode != 0)

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/ProjectFileMetadataResolver.cs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Immutable;
+using System.Linq;
 using CSharpRepl.Services.Dotnet;
 using Microsoft.CodeAnalysis;
 using PrettyPrompt.Consoles;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
@@ -35,10 +35,7 @@ internal sealed class ProjectFileMetadataResolver : IIndividualMetadataReference
     }
 
     private static bool IsProjectReference(string reference)
-    {
-        var extension = Path.GetExtension(reference)?.ToLower();
-        return extension == ".csproj";
-    }
+        => reference.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase);
 
     private ImmutableArray<PortableExecutableReference> LoadProjectReference(string reference, string? baseFilePath, MetadataReferenceProperties properties, MetadataReferenceResolver compositeResolver)
     {

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -14,13 +14,12 @@ using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
-
 internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolver
 {
-    private readonly IDotnetBuilder builder;
+    private readonly DotnetBuilder builder;
     private readonly IConsole console;
 
-    public SolutionFileMetadataResolver(IDotnetBuilder builder, IConsole console)
+    public SolutionFileMetadataResolver(DotnetBuilder builder, IConsole console)
     {
         this.builder = builder;
         this.console = console;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -2,15 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Dotnet;
-using Microsoft.CodeAnalysis;
-using PrettyPrompt.Consoles;
 using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CSharpRepl.Services.Dotnet;
+using Microsoft.CodeAnalysis;
+using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
@@ -26,10 +26,9 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
         this.console = console;
     }
 
-    public override bool CanResolve(string reference)
-    {
-        return reference.Replace("\"", string.Empty).EndsWith(".sln");
-    }
+    public override bool CanResolve(string reference) =>
+        reference.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+        reference.EndsWith(".sln\"", StringComparison.OrdinalIgnoreCase);
 
     public override async Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
     {

--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -152,7 +152,7 @@ internal sealed class DotNetInstallationLocator
             userProfilePath,
             ".nuget",
             "packages",
-            (framework + ".runtime." + platform + "-" + RuntimeInformation.ProcessArchitecture).ToLowerInvariant()
+            $"{framework}.runtime.{platform}-{RuntimeInformation.ProcessArchitecture}".ToLowerInvariant()
         );
 
         logger.LogPaths("NuGet Implementation Assemblies", () => ListDirectoriesIfExists(nugetImplementationAssemblyRoot));

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,33 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
-    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
-    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
-    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
-    <EmbeddedResource Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
-    <None Remove="Data\DemoSolution\DemoSolution.DemoProject1\bin\**" />
-    <None Remove="Data\DemoSolution\DemoSolution.DemoProject1\obj\**" />
-    <None Remove="Data\DemoSolution\DemoSolution.DemoProject2\bin\**" />
-    <None Remove="Data\DemoSolution\DemoSolution.DemoProject2\obj\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\DemoClass1.cs" />
-    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\DemoClass2.cs" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject1\**" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject2\**" />
+    <Compile Remove="Data\DemoSolution\DemoSolution.DemoProject3\**" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="Data\DemoSolution\DemoSolution.DemoProject1\DemoClass1.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="Data\DemoSolution\DemoSolution.DemoProject2\DemoClass2.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject3\DemoClass3.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -84,6 +70,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Data\DemoSolution\DemoSolution.DemoProject2\DemoSolution.DemoProject2.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Data\DemoSolution\DemoSolution.DemoProject3\DemoSolution.DemoProject3.csproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Data\DemoSolution\DemoSolution.sln">

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject3/DemoClass3.cs
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject3/DemoClass3.cs
@@ -1,0 +1,10 @@
+﻿namespace DemoSolution.DemoProject3
+{
+    public static class DemoClass3
+    {
+        public static void Main() { }
+
+        public static string GetSystemManagementPath()
+            => typeof(System.Management.ConnectionOptions).Assembly.Location;
+    }
+}

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject3/DemoSolution.DemoProject3.csproj
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.DemoProject3/DemoSolution.DemoProject3.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="6.0.0" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
Information about runtime dependencies is then used when loading them.
Resolves #128.