### PR TITLE
Enable smart indentation for incomplete statements

### DIFF
--- a/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using CSharpRepl.PrettyPromptConfig;
 using CSharpRepl.Services;
@@ -37,6 +38,18 @@ public class PromptConfigurationTests : IAsyncLifetime
         IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
         Assert.True(configuration.TryGetKeyPressCallbacks(keyInfo, out var callback));
         callback.Invoke("Console.WriteLine(\"Hi!\");", 0, default);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task PromptConfiguration_Identation(bool shiftPressed)
+    {
+        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
+        var enterKey = new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.Enter, shift: shiftPressed, alt: false, control: false));
+
+        var transformed = await configuration.TransformKeyPressAsync("if (true) {", 11, enterKey, CancellationToken.None);
+        Assert.Equal("\n\t", transformed.PastedText);
     }
 
     public static IEnumerable<object[]> KeyPresses()


### PR DESCRIPTION
Applies the existing smart indentation logic (which is super-slick, thanks @kindermannhubert) to scenarios where the prompt is incomplete but the user pressed <kbd>Enter</kbd> or their configured newline keybinding.

e.g. if the user pressed <kbd>Enter</kbd> where the pipe character is below:

```csharp
if(true)
{|
```

This would be considered an incomplete prompt submission and we'd insert a newline automatically. Now we'll insert both the newline and the correct level of indentation.