### PR TITLE
Add formatting call to warmup logic

### DIFF
--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -340,6 +340,7 @@ public sealed partial class RoslynServices
 
             var evaluationTask = EvaluateAsync(@"_ = ""REPL Warmup""", args);
             var highlightTask = SyntaxHighlightAsync(@"_ = ""REPL Warmup""");
+            var formattingTask = FormatInput(@"_=""REPL Warmup"";", caret: 16, formatParentNodeOnly: false, default);
             var completionTask = Task.WhenAny(
                 (await CompleteAsync(@"C", 1))
                     .Where(completion => completion.Item.DisplayText.StartsWith("C"))
@@ -347,7 +348,7 @@ public sealed partial class RoslynServices
                     .Select(completion => completion.GetDescriptionAsync(cancellationToken: default))
             );
 
-            await Task.WhenAll(evaluationTask, highlightTask, completionTask).ConfigureAwait(false);
+            await Task.WhenAll(evaluationTask, highlightTask, formattingTask, completionTask).ConfigureAwait(false);
             logger.Log("Warm-up Complete");
         });
 }


### PR DESCRIPTION
The initial formatting of input is a bit slow, so this PR adds formatting to our warmup function to keep the prompt snappy.

To reproduce the issue, open a new instance of csharprepl and type `Console.WriteLine(  "hello world")` and then type a semicolon. When pressing semicolon you'll notice a small amount of lag before the semicolon appears and the input is formatted.

This commit resolves that lag.