### PR TITLE
Simplify disassembly output for simple cases.

### DIFF
--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -13,6 +13,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Threading;
 
@@ -35,17 +37,16 @@ internal class Disassembler
         // we will try to compile the user's code several different ways. The first one that succeeds will be used.
         this.compilers = new (string name, CompileDelegate compile)[]
         {
-                // "console application" will work for standalone statements, due to C#'s top-level statement feature.
-                (name: "Console Application (with top-level statements)",
-                 compile: (code, optimizationLevel) => Compile(code, optimizationLevel, OutputKind.ConsoleApplication)),
-                // "DLL" will work if the user doesn't have statements, for example, they're only defining types.
-                (name:"DLL",
-                 compile: (code, optimizationLevel) => Compile(code, optimizationLevel, OutputKind.DynamicallyLinkedLibrary)),
-                // Compiling as a script will work for most other cases, but it's quite verbose so we use it as a last resort.
-                (name:"Scripting session (will be overly verbose)",
-                 compile: (code, optimizationLevel) => scriptRunner.CompileTransient(code, optimizationLevel))
+            // "console application" will work for standalone statements, due to C#'s top-level statement feature.
+            (name: "Console Application (with top-level statements)",
+             compile: (code, optimizationLevel) => Compile(code, optimizationLevel, OutputKind.ConsoleApplication)),
+            // "DLL" will work if the user doesn't have statements, for example, they're only defining types.
+            (name: "DLL",
+             compile: (code, optimizationLevel) => Compile(code, optimizationLevel, OutputKind.DynamicallyLinkedLibrary)),
+            // Compiling as a script will work for most other cases, but it's quite verbose so we use it as a last resort.
+            (name: "Scripting session (will be overly verbose)",
+             compile: (code, optimizationLevel) => scriptRunner.CompileTransient(code, optimizationLevel))
         };
-
     }
 
     public EvaluationResult Disassemble(string code, bool debugMode)
@@ -55,30 +56,31 @@ internal class Disassembler
 
         var optimizationLevel = debugMode ? OptimizationLevel.Debug : OptimizationLevel.Release;
         var commentFooter = new List<string>
-            {
-                $"// Disassembled in {optimizationLevel} Mode."
-                + (optimizationLevel == OptimizationLevel.Debug
-                    ? " Press Ctrl+F9 to disassemble in Release Mode."
-                    : string.Empty)
-            };
-
-        // the disassembler will write to the ilCodeOutput variable when invoked.
-        var ilCodeOutput = new PlainTextOutput { IndentationString = new string(' ', 4) };
-        var disassembler = new ReflectionDisassembler(ilCodeOutput, CancellationToken.None);
+        {
+            $"// Disassembled in {optimizationLevel} Mode."
+            + (optimizationLevel == OptimizationLevel.Debug
+                ? " Press Ctrl+F9 to disassemble in Release Mode."
+                : string.Empty)
+        };
 
         using var stream = new MemoryStream();
 
         foreach (var (name, compile) in compilers)
         {
+            // step 1, try to compile the input using one of our compiler configurations.
             stream.SetLength(0);
             var compiled = compile(code, optimizationLevel);
             var compilationResult = compiled.Emit(stream);
+
+            // step 2, disassemble the compiled result and return the IL
             if (compilationResult.Success)
             {
                 commentFooter.Add($"// Compiling code as {name}: succeeded.");
                 stream.Position = 0;
                 var file = new PEFile(Guid.NewGuid().ToString(), stream, PEStreamOptions.LeaveOpen);
-                disassembler.WriteModuleContents(file); // writes to the "ilCodeOutput" variable
+
+                var ilCodeOutput = DisassembleFile(file);
+
                 var ilCode =
                     string.Join('\n', ilCodeOutput
                         .ToString()
@@ -88,15 +90,14 @@ internal class Disassembler
                     + string.Join('\n', commentFooter);
                 return new EvaluationResult.Success(code, ilCode, Array.Empty<MetadataReference>());
             }
-            else
-            {
-                commentFooter.Add($"// Compiling code as {name}: failed.");
-                commentFooter.AddRange(compilationResult
-                    .Diagnostics
-                    .Where(d => d.Severity == DiagnosticSeverity.Error)
-                    .Select(err => "//   - " + err.GetMessage())
-                );
-            }
+
+            // failure, we couldn't compile it, move on to the next compiler configuration.
+            commentFooter.Add($"// Compiling code as {name}: failed.");
+            commentFooter.AddRange(compilationResult
+                .Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(err => "//   - " + err.GetMessage())
+            );
         }
 
         return new EvaluationResult.Error(
@@ -104,10 +105,44 @@ internal class Disassembler
         );
     }
 
+    private static PlainTextOutput DisassembleFile(PEFile file)
+    {
+        // the disassemblers will write to the ilCodeOutput variable when invoked.
+        var ilCodeOutput = new PlainTextOutput { IndentationString = new string(' ', 4) };
+
+        // if the user provides a simple statement (e.g. like "Console.WriteLine(5);") our goal is to return
+        // only the IL that corresponds to this exact input without any generated enclosing Program or Main method classes.
+
+        // if we find any additional types, fallback to disassembling and returning the entire file.
+        var asm = file.Reader;
+        var asmReader = asm.GetMetadataReader();
+        var definedTypes = asmReader.TypeDefinitions.ToArray();
+        var definedTypeNames = definedTypes.Select(t => asmReader.GetString(asmReader.GetTypeDefinition(t).Name)).ToArray();
+        if (definedTypeNames.Except(new[] { "<Module>", "Program" }).Any())
+        {
+            new ReflectionDisassembler(ilCodeOutput, CancellationToken.None).WriteModuleContents(file); // writes to the "ilCodeOutput" variable
+            return ilCodeOutput;
+        }
+
+        // if we find any additional methods, fallback to disassembling and returning the entire file.
+        var programType = asmReader.GetTypeDefinition(definedTypes[Array.IndexOf(definedTypeNames, "Program")]);
+        var methods = programType.GetMethods().ToArray();
+        var methodNames = methods.Select(m => asmReader.GetString(asmReader.GetMethodDefinition(m).Name)).ToArray();
+        if (methodNames.Except(new[] { "<Main>$", ".ctor" }).Any())
+        {
+            new ReflectionDisassembler(ilCodeOutput, CancellationToken.None).WriteModuleContents(file); // writes to the "ilCodeOutput" variable
+            return ilCodeOutput;
+        }
+
+        // we successfully found that there's only a simple Program.Main, so disassemble just the Main method body.
+        new MethodBodyDisassembler(ilCodeOutput, CancellationToken.None).Disassemble(file, methods[Array.IndexOf(methodNames, "<Main>$")]);
+        return ilCodeOutput;
+    }
+
     private Compilation Compile(string code, OptimizationLevel optimizationLevel, OutputKind outputKind)
     {
         var ast = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(LanguageVersion.Latest));
-        var compilation = CSharpCompilation.Create("CompilationForDecompilation",
+        var compilation = CSharpCompilation.Create("CompilationForDisassembly",
             new[] { ast },
             referenceService.LoadedReferenceAssemblies,
             compilationOptions

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
@@ -1,56 +1,22 @@
-﻿.class private auto ansi '<Module>'
-{
-} // end of class <Module>
+﻿// Method begins at RVA 0x2050
+// Header size: 12
+// Code size: 14 (0xe)
+.maxstack 2
+.entrypoint
+.locals init (
+    [0] int32,
+    [1] int32
+)
 
-.class private auto ansi beforefieldinit Program
-    extends [System.Runtime]System.Object
-{
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-        01 00 00 00
-    )
-    // Methods
-    .method private hidebysig static
-        void '<Main>$' (
-            string[] args
-        ) cil managed
-    {
-        // Method begins at RVA 0x2050
-        // Header size: 12
-        // Code size: 14 (0xe)
-        .maxstack 2
-        .entrypoint
-        .locals init (
-            [0] int32,
-            [1] int32
-        )
-
-        IL_0000: ldc.i4.5
-        IL_0001: stloc.0
-        IL_0002: ldc.i4.3
-        IL_0003: stloc.1
-        IL_0004: ldloc.0
-        IL_0005: ldloc.1
-        IL_0006: add
-        IL_0007: call void [System.Console]System.Console::WriteLine(int32)
-        IL_000c: nop
-        IL_000d: ret
-    } // end of method Program::'<Main>$'
-
-    .method public hidebysig specialname rtspecialname
-        instance void .ctor () cil managed
-    {
-        // Method begins at RVA 0x206a
-        // Header size: 1
-        // Code size: 8 (0x8)
-        .maxstack 8
-
-        IL_0000: ldarg.0
-        IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-        IL_0006: nop
-        IL_0007: ret
-    } // end of method Program::.ctor
-
-} // end of class Program
-
+IL_0000: ldc.i4.5
+IL_0001: stloc.0
+IL_0002: ldc.i4.3
+IL_0003: stloc.1
+IL_0004: ldloc.0
+IL_0005: ldloc.1
+IL_0006: add
+IL_0007: call void [System.Console]System.Console::WriteLine(int32)
+IL_000c: nop
+IL_000d: ret
 // Disassembled in Debug Mode. Press Ctrl+F9 to disassemble in Release Mode.
 // Compiling code as Console Application (with top-level statements): succeeded.

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
@@ -1,51 +1,18 @@
-﻿.class private auto ansi '<Module>'
-{
-} // end of class <Module>
+﻿// Method begins at RVA 0x2050
+// Header size: 12
+// Code size: 11 (0xb)
+.maxstack 2
+.entrypoint
+.locals init (
+    [0] int32
+)
 
-.class private auto ansi beforefieldinit Program
-    extends [System.Runtime]System.Object
-{
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-        01 00 00 00
-    )
-    // Methods
-    .method private hidebysig static
-        void '<Main>$' (
-            string[] args
-        ) cil managed
-    {
-        // Method begins at RVA 0x2050
-        // Header size: 12
-        // Code size: 11 (0xb)
-        .maxstack 2
-        .entrypoint
-        .locals init (
-            [0] int32
-        )
-
-        IL_0000: ldc.i4.5
-        IL_0001: ldc.i4.3
-        IL_0002: stloc.0
-        IL_0003: ldloc.0
-        IL_0004: add
-        IL_0005: call void [System.Console]System.Console::WriteLine(int32)
-        IL_000a: ret
-    } // end of method Program::'<Main>$'
-
-    .method public hidebysig specialname rtspecialname
-        instance void .ctor () cil managed
-    {
-        // Method begins at RVA 0x2067
-        // Header size: 1
-        // Code size: 7 (0x7)
-        .maxstack 8
-
-        IL_0000: ldarg.0
-        IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-        IL_0006: ret
-    } // end of method Program::.ctor
-
-} // end of class Program
-
+IL_0000: ldc.i4.5
+IL_0001: ldc.i4.3
+IL_0002: stloc.0
+IL_0003: ldloc.0
+IL_0004: add
+IL_0005: call void [System.Console]System.Console::WriteLine(int32)
+IL_000a: ret
 // Disassembled in Release Mode.
 // Compiling code as Console Application (with top-level statements): succeeded.

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -189,9 +189,8 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         {
             case EvaluationResult.Success success:
                 var ilCode = success.ReturnValue.ToString()!;
-                var highlighting = await roslyn.SyntaxHighlightAsync(ilCode).ConfigureAwait(false);
-                var syntaxHighlightedOutput = Prompt.RenderAnsiOutput(ilCode, highlighting.ToFormatSpans(), console.BufferWidth);
-                return new KeyPressCallbackResult(text, syntaxHighlightedOutput);
+                var output = Prompt.RenderAnsiOutput(ilCode, Array.Empty<FormatSpan>(), console.BufferWidth);
+                return new KeyPressCallbackResult(text, output);
             case EvaluationResult.Error err:
                 return new KeyPressCallbackResult(text, AnsiColor.Red.GetEscapeSequence() + err.Exception.Message + AnsiEscapeCodes.Reset);
             default:


### PR DESCRIPTION
In the case where a simple statement like "var sum = 5 + 3;" is submitted for decompilation, we send back a ton of text: the `<Module>` declaration, the generated Program, its constructor, as well as the generated `<Main>$` method.

This PR simplifies the output so that in cases where there's only a Program.Main, we return just the contents of the Program.Main method. In other cases, like where functions and types are created, we still return the full output.

This PR also unfortunately removes the syntax highlighting attempt for IL -- we were co-opting the roslyn c# highlighting logic (which happened to mostly work, but now throws an exception).