### PR TITLE
Printing of 'null' as output for null returning inputs.

### DIFF
--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpObjectFormatterImpl.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpObjectFormatterImpl.cs
@@ -2,18 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Reflection;
 using CSharpRepl.Services;
 using CSharpRepl.Services.SyntaxHighlighting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
+using PrettyPrompt.Highlighting;
 using MemberFilter = Microsoft.CodeAnalysis.Scripting.Hosting.MemberFilter;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 
 internal class CSharpObjectFormatterImpl : CommonObjectFormatter
 {
+    public FormattedString NullLiteral => PrimitiveFormatter.NullLiteral;
+
     protected override CommonTypeNameFormatter TypeNameFormatter { get; }
     protected override CommonPrimitiveFormatter PrimitiveFormatter { get; }
     protected override MemberFilter Filter { get; }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
@@ -26,7 +26,7 @@ internal class CSharpPrimitiveFormatter : CommonPrimitiveFormatter
         NullLiteral = new FormattedString("null", keywordFormat);
     }
 
-    protected override FormattedString NullLiteral { get; }
+    public override FormattedString NullLiteral { get; }
 
     protected override FormattedString FormatLiteral(bool value)
     {

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonPrimitiveFormatter.cs
@@ -17,7 +17,7 @@ internal abstract partial class CommonPrimitiveFormatter
     /// <summary>
     /// String that describes "null" literal in the language.
     /// </summary>
-    protected abstract FormattedString NullLiteral { get; }
+    public abstract FormattedString NullLiteral { get; }
 
     protected abstract FormattedString FormatLiteral(bool value);
     protected abstract FormattedString FormatLiteral(string value, bool quote, bool escapeNonPrintable, int numberRadix = NumberRadixDecimal);

--- a/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
+++ b/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
@@ -35,8 +35,7 @@ internal sealed class PrettyPrinter
     {
         return obj switch
         {
-            // intercept null, don't print the string "null"
-            null => null,
+            null => formatter.NullLiteral,
 
             // when displayDetails is true, don't show the escaped string (i.e. interpret the escape characters, via displaying to console)
             string str when displayDetails => str,

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -79,8 +79,8 @@ public sealed partial class RoslynServices
             // the script runner is used to actually execute the scripts, and the workspace manager
             // is updated alongside. The workspace is a datamodel used in "editor services" like
             // syntax highlighting, autocompletion, and roslyn symbol queries.
-            this.scriptRunner = new ScriptRunner(compilationOptions, referenceService, console, config);
             this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger);
+            this.scriptRunner = new ScriptRunner(workspaceManager, compilationOptions, referenceService, console, config);
 
             this.disassembler = new Disassembler(compilationOptions, referenceService, scriptRunner);
             this.prettyPrinter = new PrettyPrinter(highlighter, config);

--- a/CSharpRepl.Services/Roslyn/Scripting/EvaluationResult.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/EvaluationResult.cs
@@ -2,16 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.Scripting;
 
 /// <remarks>about as close to a discriminated union as I can get</remarks>
 public abstract record EvaluationResult
 {
-    public sealed record Success(string Input, object ReturnValue, IReadOnlyCollection<MetadataReference> References) : EvaluationResult;
+    public sealed record Success(string Input, Optional<object?> ReturnValue, IReadOnlyCollection<MetadataReference> References) : EvaluationResult;
     public sealed record Error(Exception Exception) : EvaluationResult;
     public sealed record Cancelled() : EvaluationResult;
 }

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -2,19 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
-using Microsoft.CodeAnalysis.Scripting;
-using Microsoft.CodeAnalysis.Scripting.Hosting;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading;
-using PrettyPrompt.Consoles;
+using System.Threading.Tasks;
+using CSharpRepl.Services.Dotnet;
 using CSharpRepl.Services.Roslyn.MetadataResolvers;
 using CSharpRepl.Services.Roslyn.References;
 using Microsoft.CodeAnalysis;
-using CSharpRepl.Services.Dotnet;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Text;
+using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.Scripting;
 
@@ -27,17 +29,20 @@ internal sealed class ScriptRunner
     private readonly InteractiveAssemblyLoader assemblyLoader;
     private readonly CompositeAlternativeReferenceResolver alternativeReferenceResolver;
     private readonly MetadataReferenceResolver metadataResolver;
+    private readonly WorkspaceManager workspaceManager;
     private readonly AssemblyReferenceService referenceAssemblyService;
     private ScriptOptions scriptOptions;
     private ScriptState<object>? state;
 
     public ScriptRunner(
+        WorkspaceManager workspaceManager,
         CSharpCompilationOptions compilationOptions,
         AssemblyReferenceService referenceAssemblyService,
         IConsole console,
         Configuration configuration)
     {
         this.console = console;
+        this.workspaceManager = workspaceManager;
         this.referenceAssemblyService = referenceAssemblyService;
         this.assemblyLoader = new InteractiveAssemblyLoader(new MetadataShadowCopyProvider());
 
@@ -79,10 +84,10 @@ internal sealed class ScriptRunner
             var usings = referenceAssemblyService.GetUsings(text);
             referenceAssemblyService.TrackUsings(usings);
 
-            state = await EvaluateStringWithStateAsync(text, state, assemblyLoader, this.scriptOptions, args, cancellationToken).ConfigureAwait(false);
+            state = await EvaluateStringWithStateAsync(text, state, assemblyLoader, scriptOptions, args, cancellationToken).ConfigureAwait(false);
 
             return state.Exception is null
-                ? CreateSuccessfulResult(text, state)
+                ? await CreateSuccessfulResult(text, state, cancellationToken).ConfigureAwait(false)
                 : new EvaluationResult.Error(this.state.Exception);
         }
         catch (Exception oce) when (oce is OperationCanceledException || oce.InnerException is OperationCanceledException)
@@ -113,23 +118,50 @@ internal sealed class ScriptRunner
         );
     }
 
-    private EvaluationResult.Success CreateSuccessfulResult(string text, ScriptState<object> state)
+    private async Task<EvaluationResult.Success> CreateSuccessfulResult(string text, ScriptState<object> state, CancellationToken cancellationToken)
     {
+        var hasValueReturningStatement = await HasValueReturningStatement(text, cancellationToken).ConfigureAwait(false);
+
         referenceAssemblyService.AddImplementationAssemblyReferences(state.Script.GetCompilation().References);
         var frameworkReferenceAssemblies = referenceAssemblyService.LoadedReferenceAssemblies;
         var frameworkImplementationAssemblies = referenceAssemblyService.LoadedImplementationAssemblies;
         this.scriptOptions = this.scriptOptions.WithReferences(frameworkImplementationAssemblies);
-        return new EvaluationResult.Success(text, state.ReturnValue, frameworkImplementationAssemblies.Concat(frameworkReferenceAssemblies).ToList());
+        var returnValue = hasValueReturningStatement ? new Optional<object?>(state.ReturnValue) : default;
+        return new EvaluationResult.Success(text, returnValue, frameworkImplementationAssemblies.Concat(frameworkReferenceAssemblies).ToList());
     }
 
-    private Task<ScriptState<object>> EvaluateStringWithStateAsync(string text, ScriptState<object>? state, InteractiveAssemblyLoader assemblyLoader, ScriptOptions scriptOptions, string[]? args = null, CancellationToken cancellationToken = default)
+    private async Task<ScriptState<object>> EvaluateStringWithStateAsync(string text, ScriptState<object>? state, InteractiveAssemblyLoader assemblyLoader, ScriptOptions scriptOptions, string[]? args, CancellationToken cancellationToken)
     {
-        return state is null
+        var scriptTask = state is null
             ? CSharpScript
                 .Create(text, scriptOptions, globalsType: typeof(ScriptGlobals), assemblyLoader: assemblyLoader)
                 .RunAsync(globals: CreateGlobalsObject(args), cancellationToken)
             : state
                 .ContinueWithAsync(text, scriptOptions, cancellationToken);
+
+        return await scriptTask.ConfigureAwait(false);
+    }
+
+    private async Task<bool> HasValueReturningStatement(string text, CancellationToken cancellationToken)
+    {
+        var sourceText = SourceText.From(text);
+        var document = workspaceManager.CurrentDocument.WithText(sourceText);
+        var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        if (tree != null &&
+            await tree.GetRootAsync(cancellationToken).ConfigureAwait(false) is CompilationUnitSyntax root &&
+            root.Members.Count > 0 &&
+            root.Members.Last() is GlobalStatementSyntax { Statement: ExpressionStatementSyntax { SemicolonToken.IsMissing: true } possiblyValueReturningStatement })
+        {
+            //now we know the text's last statement does not have semicolon so it can return value
+            //but the statement's return type still can be void - we need to find out
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (semanticModel != null)
+            {
+                var typeInfo = semanticModel.GetTypeInfo(possiblyValueReturningStatement.Expression, cancellationToken);
+                return typeInfo.ConvertedType?.SpecialType != SpecialType.System_Void;
+            }
+        }
+        return false;
     }
 
     private ScriptGlobals CreateGlobalsObject(string[]? args)

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -1,15 +1,13 @@
-﻿using CSharpRepl.Services;
-using CSharpRepl.Services.Disassembly;
-using CSharpRepl.Services.Roslyn;
-using CSharpRepl.Services.Roslyn.References;
-using CSharpRepl.Services.Roslyn.Scripting;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using NSubstitute;
-using PrettyPrompt.Consoles;
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Disassembly;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+using Microsoft.CodeAnalysis;
+using NSubstitute;
+using PrettyPrompt.Consoles;
 using Xunit;
 
 namespace CSharpRepl.Tests;
@@ -17,22 +15,12 @@ namespace CSharpRepl.Tests;
 [Collection(nameof(RoslynServices))]
 public class DisassemblerTests : IAsyncLifetime
 {
-    private readonly Disassembler disassembler;
     private readonly RoslynServices services;
 
     public DisassemblerTests()
     {
-        var options = new CSharpCompilationOptions(
-            OutputKind.DynamicallyLinkedLibrary,
-            usings: Array.Empty<string>()
-        );
         var console = Substitute.For<IConsole>();
         console.BufferWidth.Returns(200);
-        var config = new Configuration();
-        var referenceService = new AssemblyReferenceService(config, new TestTraceLogger());
-        var scriptRunner = new ScriptRunner(options, referenceService, console, config);
-
-        this.disassembler = new Disassembler(options, referenceService, scriptRunner);
         this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());
     }
 
@@ -49,7 +37,7 @@ public class DisassemblerTests : IAsyncLifetime
         var input = File.ReadAllText($"./Data/Disassembly/{testCase}.Input.txt").Replace("\r\n", "\n");
         var expectedOutput = File.ReadAllText($"./Data/Disassembly/{testCase}.Output.{optimizationLevel}.il").Replace("\r\n", "\n");
 
-        var result = disassembler.Disassemble(input, debugMode: optimizationLevel == OptimizationLevel.Debug);
+        var result = services.ConvertToIntermediateLanguage(input, debugMode: optimizationLevel == OptimizationLevel.Debug).Result;
         var actualOutput = Assert
             .IsType<EvaluationResult.Success>(result)
             .ReturnValue

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -40,7 +40,7 @@ public class EvaluationTests : IAsyncLifetime
         var success = Assert.IsType<EvaluationResult.Success>(result);
         Assert.Equal("5", success.Input);
 
-        var returnValue = Assert.IsType<int>(success.ReturnValue);
+        var returnValue = Assert.IsType<int>(success.ReturnValue.Value);
         Assert.Equal(5, returnValue);
     }
 
@@ -52,7 +52,7 @@ public class EvaluationTests : IAsyncLifetime
 
         var assignment = Assert.IsType<EvaluationResult.Success>(variableAssignment);
         var usage = Assert.IsType<EvaluationResult.Success>(variableUsage);
-        Assert.Null(assignment.ReturnValue);
+        Assert.Null(assignment.ReturnValue.Value);
         Assert.Equal("Hello Mundo", usage.ReturnValue);
     }
 
@@ -65,7 +65,7 @@ public class EvaluationTests : IAsyncLifetime
         var installationResult = Assert.IsType<EvaluationResult.Success>(installation);
         var usageResult = Assert.IsType<EvaluationResult.Success>(usage);
 
-        Assert.Null(installationResult.ReturnValue);
+        Assert.Null(installationResult.ReturnValue.Value);
         Assert.Contains(installationResult.References, r => r.Display.EndsWith("Newtonsoft.Json.dll"));
         Assert.Contains("Adding references for 'Newtonsoft.Json", ProgramTests.RemoveFormatting(stdout.ToString()));
         Assert.Equal(@"{""Foo"":""bar""}", usageResult.ReturnValue);
@@ -80,8 +80,8 @@ public class EvaluationTests : IAsyncLifetime
         var installationResult = Assert.IsType<EvaluationResult.Success>(installation);
         var usageResult = Assert.IsType<EvaluationResult.Success>(usage);
 
-        Assert.Null(installationResult.ReturnValue);
-        Assert.NotNull(usageResult.ReturnValue);
+        Assert.Null(installationResult.ReturnValue.Value);
+        Assert.NotNull(usageResult.ReturnValue.Value);
         Assert.Contains("Adding references for 'Microsoft.CodeAnalysis.CSharp.3.11.0'", ProgramTests.RemoveFormatting(stdout.ToString()));
     }
 
@@ -173,7 +173,7 @@ public class EvaluationTests : IAsyncLifetime
         Assert.IsType<EvaluationResult.Success>(referenceResult);
         Assert.IsType<EvaluationResult.Success>(importResult);
 
-        var referencedSystemManagementPath = (string)((EvaluationResult.Success)importResult).ReturnValue;
+        var referencedSystemManagementPath = (string)((EvaluationResult.Success)importResult).ReturnValue.Value;
         referencedSystemManagementPath = referencedSystemManagementPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
         var winRuntimeSelected = referencedSystemManagementPath.Contains(Path.Combine("runtimes", "win", "lib"), StringComparison.OrdinalIgnoreCase);
         var isWin = Environment.OSVersion.Platform == PlatformID.Win32NT;

--- a/CSharpRepl.Tests/PrettyPrinterTests.cs
+++ b/CSharpRepl.Tests/PrettyPrinterTests.cs
@@ -29,14 +29,18 @@ public class PrettyPrinterTests
 
     public static IEnumerable<object[]> FormatObjectInputs = new[]
     {
-        new object[] { null, false, null },
-        new object[] { null, true, null },
+        new object[] { null, false, "null" },
+        new object[] { null, true, "null" },
+
         new object[] { @"""hello world""", false, @"""\""hello world\"""""},
         new object[] { @"""hello world""", true, @"""hello world"""},
+
         new object[] { "a\nb", false, @"""a\nb"""},
         new object[] { "a\nb", true, "a\nb"},
+
         new object[] { new[] { 1, 2, 3 }, false, "int[3] { 1, 2, 3 }"},
         new object[] { new[] { 1, 2, 3 }, true, $"int[3] {"{"}{NewLine}  1,{NewLine}  2,{NewLine}  3{NewLine}{"}"}{NewLine}"},
+
         new object[] { Encoding.UTF8, true, "System.Text.UTF8Encoding+UTF8EncodingSealed"},
     };
 }

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -188,7 +188,7 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         switch (result)
         {
             case EvaluationResult.Success success:
-                var ilCode = success.ReturnValue.ToString()!;
+                var ilCode = success.ReturnValue.ToString();
                 var output = Prompt.RenderAnsiOutput(ilCode, Array.Empty<FormatSpan>(), console.BufferWidth);
                 return new KeyPressCallbackResult(text, output);
             case EvaluationResult.Error err:

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -114,8 +114,15 @@ internal sealed class ReadEvalPrintLoop
         switch (result)
         {
             case EvaluationResult.Success ok:
-                var formatted = await roslyn.PrettyPrintAsync(ok?.ReturnValue, displayDetails);
-                console.WriteLine(formatted);
+                if (ok.ReturnValue.HasValue)
+                {
+                    var formatted = await roslyn.PrettyPrintAsync(ok.ReturnValue.Value, displayDetails);
+                    console.WriteLine(formatted);
+                }
+                else
+                {
+                    console.WriteLine("");
+                }
                 break;
             case EvaluationResult.Error err:
                 var formattedError = await roslyn.PrettyPrintAsync(err.Exception, displayDetails);


### PR DESCRIPTION
Removal of `null` interception in PrettyPrinter. See #88.
Now we analyze input and decide if the input is void-returning or no-output (->we output nothing) or if it is value-returning (-> we print even null result).

![image](https://user-images.githubusercontent.com/11704036/200117516-85b3e15c-c6d7-4979-8750-b54a7bf7d70e.png)
