### PR TITLE
Upgrade to .NET 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
     - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
     
     - name: Install Dotnet
-      uses: actions/setup-dotnet@e3ce4164b306e5cd25c71d9fcd57e1647b6af302
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
       
     - name: Dotnet Installation Info
       run: dotnet --info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
     
     - name: Install Dotnet
-      uses: actions/setup-dotnet@e3ce4164b306e5cd25c71d9fcd57e1647b6af302
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
       
     - name: Dotnet Installation Info
       run: dotnet --info

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.1" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.3.1" />
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     
   </ItemGroup>
 

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -64,6 +64,7 @@ internal sealed class ScriptRunner
             .WithMetadataResolver(metadataResolver)
             .WithReferences(referenceAssemblyService.LoadedImplementationAssemblies)
             .WithAllowUnsafe(compilationOptions.AllowUnsafe)
+            .WithLanguageVersion(LanguageVersion.Preview)
             .AddImports(compilationOptions.Usings);
     }
 

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
@@ -23,11 +23,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>0.4.0</Version>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades to .NET 7, including setting both the TargetFramework as well as nuget updates. Also sets the C# Language Version to Preview.

Fingers crossed that the CI process likes .NET 7 -- could be some followup commits to enable support.