### PR TITLE
Nuget loading improvements

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -20,29 +20,8 @@
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    <!-- when updating NuGet.PackageManagement also update the RuntimeCopyLocalItems configuration below -->
-    <PackageReference Include="NuGet.PackageManagement" Version="6.3.1" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
   </ItemGroup>
-
-  <!--
-    We shouldn't package the Nuget.* DLLs, but should instead have them loaded from the runtime sdk.
-    https://github.com/microsoft/qsharp-compiler/issues/1470
-    https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dc
-  -->
-  <Target AfterTargets="AfterResolveReferences" Name="SkipCopyOfHostDlls">
-    <ItemGroup>
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.common\6.3.1\lib\netstandard2.0\NuGet.Common.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.configuration\6.3.1\lib\netstandard2.0\NuGet.Configuration.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.dependencyresolver.core\6.3.1\lib\net5.0\NuGet.DependencyResolver.Core.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.frameworks\6.3.1\lib\netstandard2.0\NuGet.Frameworks.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.librarymodel\6.3.1\lib\netstandard2.0\NuGet.LibraryModel.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging.core\6.3.1\lib\net5.0\NuGet.Packaging.Core.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging\6.3.1\lib\net5.0\NuGet.Packaging.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.projectmodel\6.3.1\lib\net5.0\NuGet.ProjectModel.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.protocol\6.3.1\lib\net5.0\NuGet.Protocol.dll" />
-      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.versioning\6.3.1\lib\netstandard2.0\NuGet.Versioning.dll" />
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -17,12 +17,32 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.3.1" />
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    
+    <!-- when updating NuGet.PackageManagement also update the RuntimeCopyLocalItems configuration below -->
+    <PackageReference Include="NuGet.PackageManagement" Version="6.3.1" />
   </ItemGroup>
+
+  <!--
+    We shouldn't package the Nuget.* DLLs, but should instead have them loaded from the runtime sdk.
+    https://github.com/microsoft/qsharp-compiler/issues/1470
+    https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dc
+  -->
+  <Target AfterTargets="AfterResolveReferences" Name="SkipCopyOfHostDlls">
+    <ItemGroup>
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.common\6.3.1\lib\netstandard2.0\NuGet.Common.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.configuration\6.3.1\lib\netstandard2.0\NuGet.Configuration.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.dependencyresolver.core\6.3.1\lib\net5.0\NuGet.DependencyResolver.Core.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.frameworks\6.3.1\lib\netstandard2.0\NuGet.Frameworks.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.librarymodel\6.3.1\lib\netstandard2.0\NuGet.LibraryModel.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging.core\6.3.1\lib\net5.0\NuGet.Packaging.Core.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging\6.3.1\lib\net5.0\NuGet.Packaging.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.projectmodel\6.3.1\lib\net5.0\NuGet.ProjectModel.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.protocol\6.3.1\lib\net5.0\NuGet.Protocol.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.versioning\6.3.1\lib\netstandard2.0\NuGet.Versioning.dll" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
+++ b/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
@@ -53,7 +53,7 @@ internal sealed class NugetPackageInstaller
         {
             ISettings settings = ReadSettings();
             var targetFramework = NugetHelper.GetCurrentFramework();
-            var nuGetProject = CreateFolderProject(Path.Combine(Configuration.ApplicationDirectory, "packages"));
+            var nuGetProject = CreateFolderProject(targetFramework, Path.Combine(Configuration.ApplicationDirectory, "packages"));
             var sourceRepositoryProvider = new SourceRepositoryProvider(new PackageSourceProvider(settings), Repository.Provider.GetCoreV3());
             var packageManager = CreatePackageManager(settings, nuGetProject, sourceRepositoryProvider);
 
@@ -260,14 +260,15 @@ internal sealed class NugetPackageInstaller
         return packageManager;
     }
 
-    private static FolderNuGetProject CreateFolderProject(string directory)
+    private static FolderNuGetProject CreateFolderProject(NuGetFramework targetFramework, string directory)
     {
         string projectRoot = Path.GetFullPath(directory);
         Directory.CreateDirectory(projectRoot);
         if (!Directory.Exists(projectRoot)) Directory.CreateDirectory(projectRoot);
         var nuGetProject = new FolderNuGetProject(
             projectRoot,
-            packagePathResolver: new PackagePathResolver(projectRoot)
+            packagePathResolver: new PackagePathResolver(projectRoot),
+            targetFramework
         );
         return nuGetProject;
     }

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -165,12 +165,15 @@ public class EvaluationTests : IAsyncLifetime
         var importLibraryA = await services.EvaluateAsync(@"using LibraryA;");
         var importLibraryB = await services.EvaluateAsync(@"using LibraryB;");
         var callResult = await services.EvaluateAsync(@"Program.Main();");
+        // we should be able to import the nuget package dependency from LibraryB.
+        var importNugetPackage = await services.EvaluateAsync(@"using Newtonsoft.Json;");
 
         Assert.IsType<EvaluationResult.Success>(referenceResult);
         Assert.IsType<EvaluationResult.Success>(importEntryPoint);
         Assert.IsType<EvaluationResult.Success>(importLibraryA);
         Assert.IsType<EvaluationResult.Success>(importLibraryB);
         Assert.IsType<EvaluationResult.Success>(callResult);
+        Assert.IsType<EvaluationResult.Success>(importNugetPackage);
     }
 
     /// <summary>


### PR DESCRIPTION
- ~~msbuild target to exclude nuget from final package, so we load the libraries from the SDK instead. See 27bef35d06ec4a94a1e0fa9f10428c03a21727c6 for more details.~~
    - This ended up not being required -- an upgrade to the latest nuget version works around this by matching the nuget versions in the SDK. As we specifically target .NET 7 I think this should be OK. The included unit test will catch any version mismatches in the future.
- Small fix to set the target framework of our FolderNuGetProject used to download/resolve nuget dependencies. See 39768bec23c5ac8117e09238b090fcced1760b16 for more details.