### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 0.5.1
+
+- Update Nuget package libraries to work on .NET 7
+- Ensure the .NET 7 version of nuget libraries are installed if they're available, rather than e.g. falling back to .NET Standard
+
 ## Release 0.5.0
 
 - Targets .NET 7

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>


### PR DESCRIPTION
Improves and fixes nuget loading for .NET 7

- Update `Nuget.*` libraries to work on .NET 7
- Ensure the .NET 7 version of nuget libraries are installed if they're available, rather than e.g. falling back to .NET Standard