### PR TITLE
Spectre.Console integration

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageReference Include="PrettyPrompt" Version="4.0.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -12,15 +12,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.1" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.3" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.1.5" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
   </ItemGroup>

--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -93,7 +93,7 @@ internal sealed class AutoCompleteService
                 ClassificationTypeNames.NamespaceName => "⬜",
                 ClassificationTypeNames.TypeParameterName => "⬛",
                 _ => "⚫",
-            }; ;
+            };
             Debug.Assert(symbol.Length <= prefix.Length);
             symbol.CopyTo(prefix);
             prefix[symbol.Length] = ' ';

--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -63,7 +63,7 @@ internal sealed class AutoCompleteService
             {
                 var classification = RoslynExtensions.TextTagToClassificationTypeName(item.Tags.First());
                 if (classification is not null &&
-                    highlighter.TryGetColor(classification, out var color))
+                    highlighter.TryGetAnsiColor(classification, out var color))
                 {
                     var prefix = GetCompletionItemSymbolPrefix(classification, configuration.UseUnicode);
                     return new FormattedString($"{prefix}{text}", new FormatSpan(prefix.Length, text.Length, new ConsoleFormat(Foreground: color)));
@@ -116,7 +116,7 @@ internal sealed class AutoCompleteService
         {
             var classification = RoslynExtensions.TextTagToClassificationTypeName(taggedText.Tag);
             if (classification is not null &&
-                highlighter.TryGetColor(classification, out var color))
+                highlighter.TryGetAnsiColor(classification, out var color))
             {
                 stringBuilder.Append(taggedText.Text, new FormatSpan(0, taggedText.Text.Length, new ConsoleFormat(Foreground: color)));
             }

--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -48,7 +48,7 @@ internal sealed class AutoCompleteService
             .GetCompletionsAsync(document, caret)
             .ConfigureAwait(false);
 
-        var completionsWithDescriptions = completions?.Items
+        var completionsWithDescriptions = completions?.ItemsList
             .Select(item => new CompletionItemWithDescription(item, GetDisplayText(item), cancellationToken => GetExtendedDescriptionAsync(completionService, document, item, highlighter)))
             .ToArray() ?? Array.Empty<CompletionItemWithDescription>();
 

--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -118,7 +118,7 @@ internal class Disassembler
         var asmReader = asm.GetMetadataReader();
         var definedTypes = asmReader.TypeDefinitions.ToArray();
         var definedTypeNames = definedTypes.Select(t => asmReader.GetString(asmReader.GetTypeDefinition(t).Name)).ToArray();
-        if (definedTypeNames.Except(new[] { "<Module>", "Program" }).Any())
+        if (definedTypeNames.Except(new[] { "<Module>", "Program", "RefSafetyRulesAttribute", "EmbeddedAttribute" }).Any())
         {
             new ReflectionDisassembler(ilCodeOutput, CancellationToken.None).WriteModuleContents(file); // writes to the "ilCodeOutput" variable
             return ilCodeOutput;

--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -2,6 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Threading;
 using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using ICSharpCode.Decompiler;
@@ -9,14 +16,6 @@ using ICSharpCode.Decompiler.Disassembler;
 using ICSharpCode.Decompiler.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
-using System.Threading;
 
 namespace CSharpRepl.Services.Disassembly;
 

--- a/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
+++ b/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
@@ -6,18 +6,18 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using PrettyPrompt.Consoles;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.Dotnet;
 
 internal class DotnetBuilder
 {
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
 
-    public DotnetBuilder(IConsole console)
+    public DotnetBuilder(IConsoleEx console)
     {
         this.console = console;
     }

--- a/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
+++ b/CSharpRepl.Services/Dotnet/DotnetBuilder.cs
@@ -8,8 +8,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using PrettyPrompt.Consoles;
-using Spectre.Console;
 
 namespace CSharpRepl.Services.Dotnet;
 

--- a/CSharpRepl.Services/Extensions/MiscExtensions.cs
+++ b/CSharpRepl.Services/Extensions/MiscExtensions.cs
@@ -1,6 +1,4 @@
-﻿using PrettyPrompt.Consoles;
-
-namespace CSharpRepl.Services.Extensions;
+﻿namespace CSharpRepl.Services.Extensions;
 
 internal static class MiscExtensions
 {

--- a/CSharpRepl.Services/Extensions/SpectreExtensions.cs
+++ b/CSharpRepl.Services/Extensions/SpectreExtensions.cs
@@ -1,0 +1,10 @@
+﻿using CSharpRepl.Services.Theming;
+using Spectre.Console;
+
+namespace CSharpRepl.Services.Extensions;
+
+internal static class SpectreExtensions
+{
+    public static Paragraph Append(this Paragraph paragraph, StyledStringSegment text)
+        => paragraph.Append(text.Text, text.Style);
+}

--- a/CSharpRepl.Services/IConsoleEx.cs
+++ b/CSharpRepl.Services/IConsoleEx.cs
@@ -1,0 +1,15 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using PrettyPrompt.Consoles;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace CSharpRepl.Services;
+
+public interface IConsoleEx : IConsole, IAnsiConsole
+{
+    /// <param name="text">Text written to error stream (used only if error stream is redirected).</param>
+    void WriteError(IRenderable renderable, string text);
+}

--- a/CSharpRepl.Services/IConsoleEx.cs
+++ b/CSharpRepl.Services/IConsoleEx.cs
@@ -3,13 +3,77 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using PrettyPrompt.Consoles;
+using PrettyPrompt.Highlighting;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
 namespace CSharpRepl.Services;
 
-public interface IConsoleEx : IConsole, IAnsiConsole
+public interface IConsoleEx : IAnsiConsole
 {
+    IConsole PrettyPromptConsole { get; }
+
+    private IAnsiConsole AnsiConsole => this;
+
+    void Write(string text) => AnsiConsole.Write(text);
+    void Write(FormattedString text) => PrettyPromptConsole.Write(text);
+
+    void WriteLine(string text) => AnsiConsole.WriteLine(text);
+    void WriteLine() => AnsiConsole.WriteLine();
+    void WriteLine(FormattedString text) => PrettyPromptConsole.WriteLine(text);
+
+    void WriteError(string text)
+    {
+        if (PrettyPromptConsole.IsErrorRedirected)
+        {
+            PrettyPromptConsole.WriteError(text);
+        }
+        else
+        {
+            //AnsiConsole is smarter about word wrapping
+            Write(text);
+        }
+    }
+
     /// <param name="text">Text written to error stream (used only if error stream is redirected).</param>
-    void WriteError(IRenderable renderable, string text);
+    void WriteError(IRenderable renderable, string text)
+    {
+        if (PrettyPromptConsole.IsErrorRedirected)
+        {
+            PrettyPromptConsole.WriteError(text);
+        }
+        else
+        {
+            //AnsiConsole is smarter about word wrapping
+            Write(renderable);
+        }
+    }
+
+    /// <param name="text">Text written to error stream (used only if error stream is redirected).</param>
+    void WriteErrorLine(IRenderable renderable, string text)
+    {
+        if (PrettyPromptConsole.IsErrorRedirected)
+        {
+            PrettyPromptConsole.WriteErrorLine(text);
+        }
+        else
+        {
+            //AnsiConsole is smarter about word wrapping
+            Write(renderable);
+            WriteLine();
+        }
+    }
+
+    void WriteErrorLine(string text)
+    {
+        if (PrettyPromptConsole.IsErrorRedirected)
+        {
+            PrettyPromptConsole.WriteErrorLine(text);
+        }
+        else
+        {
+            //AnsiConsole is smarter about word wrapping
+            WriteLine(text);
+        }
+    }
 }

--- a/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
+++ b/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
@@ -125,7 +125,7 @@ internal sealed class ConsoleNugetLogger : ILogger
     {
         try
         {
-            console.HideCursor();
+            console.Cursor.Show(false);
             for (int i = 0; i < linesRendered; i++)
             {
                 console.Write(AnsiEscapeCodes.GetMoveCursorUp(1));
@@ -138,20 +138,20 @@ internal sealed class ConsoleNugetLogger : ILogger
                 if (line.IsError)
                 {
                     console.Write(AnsiColor.Red.GetEscapeSequence());
-                    console.WriteLine(line.Text.Text);
+                    console.WriteLine(line.Text.Text ?? "");
                     console.Write(AnsiEscapeCodes.Reset);
                 }
                 else
                 {
                     console.WriteLine(line.Text);
                 }
-
-                linesRendered += Math.DivRem(line.Text.Length, console.BufferWidth, out var remainder) + (remainder == 0 ? 0 : 1);
+                
+                linesRendered += Math.DivRem(line.Text.Length, console.PrettyPromptConsole.BufferWidth, out var remainder) + (remainder == 0 ? 0 : 1);
             }
         }
         finally
         {
-            console.ShowCursor();
+            console.Cursor.Show(true);
         }
     }
 

--- a/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
+++ b/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using CSharpRepl.Services.Extensions;
 using Microsoft.CodeAnalysis.Classification;
 using NuGet.Common;
 using PrettyPrompt.Consoles;
@@ -22,14 +21,14 @@ internal sealed class ConsoleNugetLogger : ILogger
 {
     private const int NumberOfMessagesToShow = 6;
 
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly Configuration configuration;
     private readonly string successPrefix;
     private readonly string errorPrefix;
     private readonly List<Line> lines = new();
     private int linesRendered;
 
-    public ConsoleNugetLogger(IConsole console, Configuration configuration)
+    public ConsoleNugetLogger(IConsoleEx console, Configuration configuration)
     {
         this.console = console;
         this.configuration = configuration;
@@ -105,7 +104,7 @@ internal sealed class ConsoleNugetLogger : ILogger
         {
             if (!lines[i].IsError) lines.RemoveAt(i);
         }
-        
+
         //add final summary
         lines.Add(CreateLine(text, isError: !success));
 

--- a/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
+++ b/CSharpRepl.Services/Nuget/ConsoleNugetLogger.cs
@@ -194,7 +194,7 @@ internal sealed class ConsoleNugetLogger : ILogger
         private static FormattedString Format(string text, string prefix, Configuration configuration)
         {
             text = prefix + text;
-            if (configuration.Theme.GetSyntaxHighlightingColorOrDefault(ClassificationTypeNames.StringLiteral).TryGet(out var color))
+            if (configuration.Theme.TryGetSyntaxHighlightingAnsiColor(ClassificationTypeNames.StringLiteral, out var color))
             {
                 var formattings = new List<FormatSpan>(1);
                 foreach (Match match in QuotesRegex.Matches(text))

--- a/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
+++ b/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
@@ -25,7 +25,6 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.RuntimeModel;
 using NuGet.Versioning;
-using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Nuget;
 
@@ -36,7 +35,7 @@ internal sealed class NugetPackageInstaller
     private readonly ConsoleNugetLogger logger;
     private readonly bool usePrereleaseNugets;
 
-    public NugetPackageInstaller(IConsole console, Configuration configuration)
+    public NugetPackageInstaller(IConsoleEx console, Configuration configuration)
     {
         this.logger = new ConsoleNugetLogger(console, configuration);
         this.usePrereleaseNugets = configuration.UsePrereleaseNugets;
@@ -282,8 +281,8 @@ internal sealed class NugetPackageInstaller
         return settings;
     }
 
-    public RuntimeGraph GetRuntimeGraph() 
-        => NugetHelper.GetRuntimeGraph(e=>logger.LogError(e));
+    public RuntimeGraph GetRuntimeGraph()
+        => NugetHelper.GetRuntimeGraph(e => logger.LogError(e));
 
     /// <summary>
     /// This is a patch for https://github.com/waf/CSharpRepl/issues/52.

--- a/CSharpRepl.Services/Roslyn/DocumentationComment.cs
+++ b/CSharpRepl.Services/Roslyn/DocumentationComment.cs
@@ -403,7 +403,7 @@ internal sealed class DocumentationComment
                     var langword = reader.GetAttribute(XmlNames.LangwordAttributeName);
                     if (langword != null)
                     {
-                        text.Append(langword, new ConsoleFormat(highlighter.GetColor(ClassificationTypeNames.Keyword)));
+                        text.Append(langword, new ConsoleFormat(highlighter.GetAnsiColor(ClassificationTypeNames.Keyword)));
                         reader.Read();
                         return;
                     }
@@ -447,7 +447,7 @@ internal sealed class DocumentationComment
                 var partText = part.ToString();
                 var classification = RoslynExtensions.SymbolDisplayPartKindToClassificationTypeName(part.Kind);
                 if (classification is not null &&
-                    highlighter.TryGetColor(classification, out var color))
+                    highlighter.TryGetAnsiColor(classification, out var color))
                 {
                     text.Append(partText, new ConsoleFormat(color));
                 }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AlternativeReferenceResolver.cs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 /// <summary>
@@ -26,10 +26,10 @@ public abstract class AlternativeReferenceResolver : IIndividualMetadataReferenc
 
     public abstract bool CanResolve(string reference);
 
-    public virtual Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken) 
+    public virtual Task<ImmutableArray<PortableExecutableReference>> ResolveAsync(string reference, CancellationToken cancellationToken)
         => Task.FromResult(Resolve(reference));
 
-    public virtual ImmutableArray<PortableExecutableReference> Resolve(string reference) 
+    public virtual ImmutableArray<PortableExecutableReference> Resolve(string reference)
         => ImmutableArray<PortableExecutableReference>.Empty;
 
 }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
@@ -17,7 +17,6 @@ using CSharpRepl.Services.Roslyn.References;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.Extensions.DependencyModel;
-using PrettyPrompt.Consoles;
 using Spectre.Console;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/AssemblyReferenceMetadataResolver.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.Extensions.DependencyModel;
 using PrettyPrompt.Consoles;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
@@ -31,10 +32,10 @@ internal sealed class AssemblyReferenceMetadataResolver : IIndividualMetadataRef
     private readonly AssemblyReferenceService referenceAssemblyService;
     private readonly AssemblyLoadContext loadContext;
     private readonly DependencyContextJsonReader dependencyContextJsonReader = new();
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly Dictionary<string, DependenciesInfo> dependencyContextsPerAssemblyName = new();
 
-    public AssemblyReferenceMetadataResolver(IConsole console, AssemblyReferenceService referenceAssemblyService)
+    public AssemblyReferenceMetadataResolver(IConsoleEx console, AssemblyReferenceService referenceAssemblyService)
     {
         this.console = console;
         this.referenceAssemblyService = referenceAssemblyService;

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeAlternativeReferenceResolver.cs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 internal sealed class CompositeAlternativeReferenceResolver

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeMetadataReferenceResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/CompositeMetadataReferenceResolver.cs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/NugetPackageMetadataResolver.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using CSharpRepl.Services.Nuget;
 using Microsoft.CodeAnalysis;
-using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
@@ -21,7 +20,7 @@ internal sealed class NugetPackageMetadataResolver : AlternativeReferenceResolve
     private const string NugetPrefixWithHashR = "#r \"" + NugetPrefix;
     private readonly NugetPackageInstaller nugetInstaller;
 
-    public NugetPackageMetadataResolver(IConsole console, Configuration configuration)
+    public NugetPackageMetadataResolver(IConsoleEx console, Configuration configuration)
     {
         this.nugetInstaller = new NugetPackageInstaller(console, configuration);
     }

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -13,16 +12,15 @@ using CSharpRepl.Services.Dotnet;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
-using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.MetadataResolvers;
 
 internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolver
 {
     private readonly DotnetBuilder builder;
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
 
-    public SolutionFileMetadataResolver(DotnetBuilder builder, IConsole console)
+    public SolutionFileMetadataResolver(DotnetBuilder builder, IConsoleEx console)
     {
         this.builder = builder;
         this.console = console;
@@ -53,7 +51,7 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
             return ImmutableArray<PortableExecutableReference>.Empty;
         }
 
-        console.WriteErrorLine("Adding references from built project...");
+        console.WriteLine("Adding references from built project...");
         var metadataReferences = await GetMetadataReferences(solutionPath, cancellationToken);
         return metadataReferences;
     }
@@ -75,7 +73,7 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
         }
 
         return projects
-            .SelectMany(p => 
+            .SelectMany(p =>
                 p.MetadataReferences
                 .OfType<PortableExecutableReference>()
                 .Concat(p.OutputFilePath is not null

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpObjectFormatterImpl.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpObjectFormatterImpl.cs
@@ -5,15 +5,15 @@
 using System.Reflection;
 using CSharpRepl.Services;
 using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using PrettyPrompt.Highlighting;
 using MemberFilter = Microsoft.CodeAnalysis.Scripting.Hosting.MemberFilter;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 
 internal class CSharpObjectFormatterImpl : CommonObjectFormatter
 {
-    public FormattedString NullLiteral => PrimitiveFormatter.NullLiteral;
+    public StyledStringSegment NullLiteral => PrimitiveFormatter.NullLiteral;
 
     protected override CommonTypeNameFormatter TypeNameFormatter { get; }
     protected override CommonPrimitiveFormatter PrimitiveFormatter { get; }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
@@ -20,9 +20,9 @@ internal class CSharpPrimitiveFormatter : CommonPrimitiveFormatter
 
     public CSharpPrimitiveFormatter(SyntaxHighlighter syntaxHighlighter)
     {
-        numericLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetColor(ClassificationTypeNames.NumericLiteral));
-        stringLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetColor(ClassificationTypeNames.StringLiteral));
-        keywordFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetColor(ClassificationTypeNames.Keyword));
+        numericLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.NumericLiteral));
+        stringLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.StringLiteral));
+        keywordFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.Keyword));
         NullLiteral = new FormattedString("null", keywordFormat);
     }
 

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
@@ -4,9 +4,10 @@
 
 using System.Globalization;
 using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 
@@ -14,88 +15,88 @@ using static ObjectFormatterHelpers;
 
 internal class CSharpPrimitiveFormatter : CommonPrimitiveFormatter
 {
-    private readonly ConsoleFormat numericLiteralFormat;
-    private readonly ConsoleFormat stringLiteralFormat;
-    private readonly ConsoleFormat keywordFormat;
+    private readonly Style numericLiteralFormat;
+    private readonly Style stringLiteralFormat;
+    private readonly Style keywordFormat;
 
     public CSharpPrimitiveFormatter(SyntaxHighlighter syntaxHighlighter)
     {
-        numericLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.NumericLiteral));
-        stringLiteralFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.StringLiteral));
-        keywordFormat = new ConsoleFormat(Foreground: syntaxHighlighter.GetAnsiColor(ClassificationTypeNames.Keyword));
-        NullLiteral = new FormattedString("null", keywordFormat);
+        numericLiteralFormat = new Style(foreground: syntaxHighlighter.GetSpectreColor(ClassificationTypeNames.NumericLiteral));
+        stringLiteralFormat = new Style(foreground: syntaxHighlighter.GetSpectreColor(ClassificationTypeNames.StringLiteral));
+        keywordFormat = new Style(foreground: syntaxHighlighter.GetSpectreColor(ClassificationTypeNames.Keyword));
+        NullLiteral = new StyledStringSegment("null", keywordFormat);
     }
 
-    public override FormattedString NullLiteral { get; }
+    public override StyledStringSegment NullLiteral { get; }
 
-    protected override FormattedString FormatLiteral(bool value)
+    protected override StyledStringSegment FormatLiteral(bool value)
     {
         return new(ObjectDisplay.FormatLiteral(value), keywordFormat);
     }
 
-    protected override FormattedString FormatLiteral(string value, bool useQuotes, bool escapeNonPrintable, int numberRadix = NumberRadixDecimal)
+    protected override StyledStringSegment FormatLiteral(string value, bool useQuotes, bool escapeNonPrintable, int numberRadix = NumberRadixDecimal)
     {
         var options = GetObjectDisplayOptions(useQuotes: useQuotes, escapeNonPrintable: escapeNonPrintable, numberRadix: numberRadix);
         return new(ObjectDisplay.FormatLiteral(value, options), stringLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(char c, bool useQuotes, bool escapeNonPrintable, bool includeCodePoints = false, int numberRadix = NumberRadixDecimal)
+    protected override StyledStringSegment FormatLiteral(char c, bool useQuotes, bool escapeNonPrintable, bool includeCodePoints = false, int numberRadix = NumberRadixDecimal)
     {
         var options = GetObjectDisplayOptions(useQuotes: useQuotes, escapeNonPrintable: escapeNonPrintable, includeCodePoints: includeCodePoints, numberRadix: numberRadix);
         return new(ObjectDisplay.FormatLiteral(c, options), stringLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(sbyte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(sbyte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(byte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(byte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(short value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(short value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(ushort value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(ushort value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(int value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(int value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(uint value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(uint value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(long value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(long value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(ulong value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(ulong value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(numberRadix: numberRadix), cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(double value, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(double value, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(float value, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(float value, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, cultureInfo), numericLiteralFormat);
     }
 
-    protected override FormattedString FormatLiteral(decimal value, CultureInfo? cultureInfo = null)
+    protected override StyledStringSegment FormatLiteral(decimal value, CultureInfo? cultureInfo = null)
     {
         return new(ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, cultureInfo), numericLiteralFormat);
     }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Symbols/GeneratedNameParser.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Symbols/GeneratedNameParser.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols;
 

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp/ObjectDisplay.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp/ObjectDisplay.cs
@@ -5,10 +5,7 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
-using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp;

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Builder.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Builder.cs
@@ -5,7 +5,7 @@
 #nullable disable
 
 using System;
-using PrettyPrompt.Highlighting;
+using CSharpRepl.Services.Theming;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -16,7 +16,7 @@ internal abstract partial class CommonObjectFormatter
 {
     private sealed class Builder
     {
-        private readonly FormattedStringBuilder _sb = new();
+        private StyledStringBuilder _sb = new();
         private readonly bool _suppressEllipsis;
         private readonly BuilderOptions _options;
 
@@ -88,7 +88,7 @@ internal abstract partial class CommonObjectFormatter
             }
         }
 
-        public void Append(FormattedString str, int start = 0, int count = Int32.MaxValue)
+        public void Append(StyledString str, int start = 0, int count = Int32.MaxValue)
         {
             if (str.IsEmpty || CurrentRemaining < 0)
             {
@@ -172,7 +172,7 @@ internal abstract partial class CommonObjectFormatter
             AppendGroupClosing(inline: true);
         }
 
-        public FormattedString ToFormattedString() => _sb.ToFormattedString();
+        public StyledString ToTextWithStyle() => _sb.ToStyledString();
         public override string ToString() => _sb.ToString();
     }
 }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.BuilderOptions.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.BuilderOptions.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.FormattedMember.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.FormattedMember.cs
@@ -5,7 +5,7 @@
 #nullable disable
 
 using System.Diagnostics;
-using PrettyPrompt.Highlighting;
+using CSharpRepl.Services.Theming;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -19,14 +19,14 @@ internal abstract partial class CommonObjectFormatter
             public readonly int Index;
 
             // Formatted name of the member or null if it doesn't have a name (Index is >=0 then).
-            public readonly FormattedString Name;
+            public readonly StyledString Name;
 
             // Formatted value of the member.
-            public readonly FormattedString Value;
+            public readonly StyledString Value;
 
-            public FormattedMember(int index, FormattedString name, FormattedString value)
+            public FormattedMember(int index, StyledString name, StyledString value)
             {
-                Debug.Assert((name != null) || (index >= 0));
+                Debug.Assert(!name.IsEmpty || (index >= 0));
                 Name = name;
                 Index = index;
                 Value = value;
@@ -37,16 +37,16 @@ internal abstract partial class CommonObjectFormatter
             /// it's only used for a conservative approximation (shorter is more conservative when trying
             /// to determine the minimum number of members that will fill the output).
             /// </remarks>
-            public int MinimalLength => (Name != null ? Name.Length : "[0]".Length) + Value.Length;
+            public int MinimalLength => (!Name.IsEmpty ? Name.Length : "[0]".Length) + Value.Length;
 
-            public FormattedString GetDisplayName()
+            public StyledString GetDisplayName()
             {
                 return Name.IsEmpty ? "[" + Index.ToString() + "]" : Name;
             }
 
             public bool HasKeyName()
             {
-                return Index >= 0 && Name != null && Name.Length >= 2 && Name.Text[0] == '[' && Name.Text[Name.Length - 1] == ']';
+                return Index >= 0 && !Name.IsEmpty && Name.Length >= 2 && Name.FirstChar == '[' && Name.LastChar == ']';
             }
 
             public bool AppendAsCollectionEntry(Builder result)

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
@@ -483,7 +483,7 @@ internal abstract partial class CommonObjectFormatter
                     {
                         var classification = RoslynExtensions.MemberTypeToClassificationTypeName(member.MemberType);
                         var prefix = AutoCompleteService.GetCompletionItemSymbolPrefix(classification, _config.UseUnicode);
-                        var color = _syntaxHighlighter.GetColor(classification);
+                        var color = _syntaxHighlighter.GetAnsiColor(classification);
                         name = new FormattedString($"{prefix}{member.Name}", new FormatSpan(prefix.Length, member.Name.Length, new ConsoleFormat(Foreground: color)));
                     }
                     else

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
@@ -15,8 +15,9 @@ using CSharpRepl.Services;
 using CSharpRepl.Services.Completion;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.SyntaxHighlighting;
-using PrettyPrompt.Highlighting;
+using CSharpRepl.Services.Theming;
 using Roslyn.Utilities;
+using Spectre.Console;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -70,16 +71,16 @@ internal abstract partial class CommonObjectFormatter
             return new Builder(_builderOptions.WithMaximumOutputLength(Math.Min(_builderOptions.MaximumLineLength, limit)), suppressEllipsis: true);
         }
 
-        public FormattedString FormatObject(object obj)
+        public StyledString FormatObject(object obj)
         {
             try
             {
                 var builder = new Builder(_builderOptions, suppressEllipsis: false);
-                return FormatObjectRecursive(builder, obj, isRoot: true, debuggerDisplayName: out _).ToFormattedString();
+                return FormatObjectRecursive(builder, obj, isRoot: true, debuggerDisplayName: out _).ToTextWithStyle();
             }
             catch (InsufficientExecutionStackException)
             {
-                return new FormattedString("<Stack overflow while evaluating object>", new ConsoleFormat(AnsiColor.Red));
+                return new StyledString("<Stack overflow while evaluating object>", new Style(foreground: Color.Red));
             }
         }
 
@@ -416,7 +417,7 @@ internal abstract partial class CommonObjectFormatter
                 if (debuggerDisplay != null)
                 {
                     var k = FormatWithEmbeddedExpressions(lengthLimit, debuggerDisplay.Name, obj) ?? member.Name;
-                    var v = FormatWithEmbeddedExpressions(lengthLimit, debuggerDisplay.Value, obj) ?? FormattedString.Empty; // TODO: ?
+                    var v = FormatWithEmbeddedExpressions(lengthLimit, debuggerDisplay.Value, obj) ?? StyledString.Empty; // TODO: ?
                     if (!AddMember(result, new FormattedMember(-1, k, v), ref lengthLimit))
                     {
                         return;
@@ -425,13 +426,12 @@ internal abstract partial class CommonObjectFormatter
                     continue;
                 }
 
-                Exception exception;
-                object value = GetMemberValue(member, obj, out exception);
+                object value = GetMemberValue(member, obj, out var exception);
                 if (exception != null)
                 {
                     var memberValueBuilder = MakeMemberBuilder(lengthLimit);
                     FormatException(memberValueBuilder, exception);
-                    if (!AddMember(result, new FormattedMember(-1, member.Name, memberValueBuilder.ToFormattedString()), ref lengthLimit))
+                    if (!AddMember(result, new FormattedMember(-1, member.Name, memberValueBuilder.ToTextWithStyle()), ref lengthLimit))
                     {
                         return;
                     }
@@ -452,13 +452,13 @@ internal abstract partial class CommonObjectFormatter
                                 Builder valueBuilder = MakeMemberBuilder(lengthLimit);
                                 FormatObjectRecursive(valueBuilder, item, isRoot: false, debuggerDisplayName: out var debuggerDisplayName);
 
-                                FormattedString name = FormattedString.Empty;
+                                StyledString name = StyledString.Empty;
                                 if (!string.IsNullOrEmpty(debuggerDisplayName))
                                 {
-                                    name = FormatWithEmbeddedExpressions(MakeMemberBuilder(lengthLimit), debuggerDisplayName, item).ToFormattedString();
+                                    name = FormatWithEmbeddedExpressions(MakeMemberBuilder(lengthLimit), debuggerDisplayName, item).ToTextWithStyle();
                                 }
 
-                                if (!AddMember(result, new FormattedMember(i, name, valueBuilder.ToFormattedString()), ref lengthLimit))
+                                if (!AddMember(result, new FormattedMember(i, name, valueBuilder.ToTextWithStyle()), ref lengthLimit))
                                 {
                                     return;
                                 }
@@ -478,20 +478,20 @@ internal abstract partial class CommonObjectFormatter
                     Builder valueBuilder = MakeMemberBuilder(lengthLimit);
                     FormatObjectRecursive(valueBuilder, value, isRoot: false, debuggerDisplayName: out var debuggerDisplayName);
 
-                    FormattedString name;
+                    StyledString name;
                     if (string.IsNullOrEmpty(debuggerDisplayName))
                     {
                         var classification = RoslynExtensions.MemberTypeToClassificationTypeName(member.MemberType);
                         var prefix = AutoCompleteService.GetCompletionItemSymbolPrefix(classification, _config.UseUnicode);
-                        var color = _syntaxHighlighter.GetAnsiColor(classification);
-                        name = new FormattedString($"{prefix}{member.Name}", new FormatSpan(prefix.Length, member.Name.Length, new ConsoleFormat(Foreground: color)));
+                        var color = _syntaxHighlighter.GetSpectreColor(classification);
+                        name = new StyledString(new StyledStringSegment[] { prefix, new StyledStringSegment(member.Name, new Style(foreground: color)) });
                     }
                     else
                     {
-                        name = FormatWithEmbeddedExpressions(MakeMemberBuilder(lengthLimit), debuggerDisplayName, value).ToFormattedString();
+                        name = FormatWithEmbeddedExpressions(MakeMemberBuilder(lengthLimit), debuggerDisplayName, value).ToTextWithStyle();
                     }
 
-                    if (!AddMember(result, new FormattedMember(-1, name, valueBuilder.ToFormattedString()), ref lengthLimit))
+                    if (!AddMember(result, new FormattedMember(-1, name, valueBuilder.ToTextWithStyle()), ref lengthLimit))
                     {
                         return;
                     }
@@ -786,7 +786,7 @@ internal abstract partial class CommonObjectFormatter
         /// If parentheses are present we only look for methods.
         /// Only parameterless members are considered.
         /// </remarks>
-        private FormattedString? FormatWithEmbeddedExpressions(int lengthLimit, string format, object obj)
+        private StyledString? FormatWithEmbeddedExpressions(int lengthLimit, string format, object obj)
         {
             if (string.IsNullOrEmpty(format))
             {
@@ -794,7 +794,7 @@ internal abstract partial class CommonObjectFormatter
             }
 
             var builder = new Builder(_builderOptions.WithMaximumOutputLength(lengthLimit), suppressEllipsis: true);
-            return FormatWithEmbeddedExpressions(builder, format, obj).ToFormattedString();
+            return FormatWithEmbeddedExpressions(builder, format, obj).ToTextWithStyle();
         }
 
         private Builder FormatWithEmbeddedExpressions(Builder result, string format, object obj)

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.cs
@@ -9,8 +9,9 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using CSharpRepl.Services;
 using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis.PooledObjects;
-using PrettyPrompt.Highlighting;
+using Spectre.Console;
 using static Microsoft.CodeAnalysis.Scripting.Hosting.ObjectFormatterHelpers;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
@@ -29,7 +30,7 @@ internal abstract partial class CommonObjectFormatter
         this.config = config;
     }
 
-    public FormattedString FormatObject(object obj, PrintOptions options)
+    public StyledString FormatObject(object obj, PrintOptions options)
     {
         if (options == null)
         {
@@ -69,7 +70,7 @@ internal abstract partial class CommonObjectFormatter
             arrayBoundRadix: printOptions.NumberRadix,
             showNamespaces: false);
 
-    public FormattedString FormatException(Exception e)
+    public StyledString FormatException(Exception e)
     {
         if (e == null)
         {
@@ -111,7 +112,7 @@ internal abstract partial class CommonObjectFormatter
             }
         }
 
-        return new FormattedString(pooled.ToStringAndFree(), new ConsoleFormat(AnsiColor.Red));
+        return new StyledString(pooled.ToStringAndFree(), new Style(foreground: Color.Red));
     }
 
     /// <summary>

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonPrimitiveFormatter.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Globalization;
 using System.Reflection;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis;
-using PrettyPrompt.Highlighting;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -17,27 +17,27 @@ internal abstract partial class CommonPrimitiveFormatter
     /// <summary>
     /// String that describes "null" literal in the language.
     /// </summary>
-    public abstract FormattedString NullLiteral { get; }
+    public abstract StyledStringSegment NullLiteral { get; }
 
-    protected abstract FormattedString FormatLiteral(bool value);
-    protected abstract FormattedString FormatLiteral(string value, bool quote, bool escapeNonPrintable, int numberRadix = NumberRadixDecimal);
-    protected abstract FormattedString FormatLiteral(char value, bool quote, bool escapeNonPrintable, bool includeCodePoints = false, int numberRadix = NumberRadixDecimal);
-    protected abstract FormattedString FormatLiteral(sbyte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(byte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(short value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(ushort value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(int value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(uint value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(long value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(ulong value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(double value, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(float value, CultureInfo? cultureInfo = null);
-    protected abstract FormattedString FormatLiteral(decimal value, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(bool value);
+    protected abstract StyledStringSegment FormatLiteral(string value, bool quote, bool escapeNonPrintable, int numberRadix = NumberRadixDecimal);
+    protected abstract StyledStringSegment FormatLiteral(char value, bool quote, bool escapeNonPrintable, bool includeCodePoints = false, int numberRadix = NumberRadixDecimal);
+    protected abstract StyledStringSegment FormatLiteral(sbyte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(byte value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(short value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(ushort value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(int value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(uint value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(long value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(ulong value, int numberRadix = NumberRadixDecimal, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(double value, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(float value, CultureInfo? cultureInfo = null);
+    protected abstract StyledStringSegment FormatLiteral(decimal value, CultureInfo? cultureInfo = null);
 
     /// <summary>
     /// Returns null if the type is not considered primitive in the target language.
     /// </summary>
-    public FormattedString? FormatPrimitive(object? obj, CommonPrimitiveFormatterOptions options)
+    public StyledStringSegment? FormatPrimitive(object? obj, CommonPrimitiveFormatterOptions options)
     {
         if (ReferenceEquals(obj, VoidValue))
         {
@@ -53,7 +53,7 @@ internal abstract partial class CommonPrimitiveFormatter
 
         if (type.GetTypeInfo().IsEnum)
         {
-            return obj.ToString();
+            return obj.ToString() ?? "";
         }
 
         switch (GetPrimitiveSpecialType(type))

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatter.cs
@@ -8,9 +8,8 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/ObjectFormatterHelpers.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/ObjectFormatterHelpers.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis/SynthesizedLocalKind.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis/SynthesizedLocalKind.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis;

--- a/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
+++ b/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
@@ -10,8 +10,6 @@ using System.Threading;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.SyntaxHighlighting;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.QuickInfo;
 using PrettyPrompt.Completion;
 using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;

--- a/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
+++ b/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
@@ -69,7 +69,7 @@ internal class OverloadItemGenerator
             var partText = part.ToString();
             var classification = RoslynExtensions.SymbolDisplayPartKindToClassificationTypeName(part.Kind);
             if (classification is not null &&
-                highlighter.TryGetColor(classification, out var color))
+                highlighter.TryGetAnsiColor(classification, out var color))
             {
                 bool bold = false;
                 if (currentArgumentSpan.Length > 0 &&

--- a/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
+++ b/CSharpRepl.Services/Roslyn/PrettyPrinter.cs
@@ -4,10 +4,11 @@
 
 using System;
 using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.Roslyn;
 
@@ -32,7 +33,7 @@ internal sealed class PrettyPrinter
         };
     }
 
-    public FormattedString FormatObject(object? obj, bool displayDetails)
+    public StyledString FormatObject(object? obj, bool displayDetails)
     {
         return obj switch
         {
@@ -47,13 +48,13 @@ internal sealed class PrettyPrinter
             Exception exception =>
                     displayDetails ?
                     formatter.FormatException(exception) :
-                    new FormattedString(exception.Message, new ConsoleFormat(AnsiColor.Red)),
+                    new StyledStringSegment(exception.Message, new Style(foreground: Color.Red)),
 
             _ => FormatObjectSafe(obj, displayDetails ? detailedOptions : summaryOptions)
         };
     }
 
-    private FormattedString FormatObjectSafe(object obj, PrintOptions options)
+    private StyledString FormatObjectSafe(object obj, PrintOptions options)
     {
         try
         {
@@ -61,7 +62,7 @@ internal sealed class PrettyPrinter
         }
         catch (Exception) // sometimes the roslyn formatter APIs fail to format. Most notably with ref structs.
         {
-            return obj.ToString();
+            return obj.ToString() ?? "";
         }
     }
 }

--- a/CSharpRepl.Services/Roslyn/References/AssemblyReferenceComparer.cs
+++ b/CSharpRepl.Services/Roslyn/References/AssemblyReferenceComparer.cs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.References;
 

--- a/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
+++ b/CSharpRepl.Services/Roslyn/References/AssemblyReferenceService.cs
@@ -2,17 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Extensions;
-using CSharpRepl.Services.Logging;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using CSharpRepl.Services.Extensions;
+using CSharpRepl.Services.Logging;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpRepl.Services.Roslyn.References;
 

--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Logging;
 using System;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Runtime.InteropServices;
+using CSharpRepl.Services.Logging;
 
 namespace CSharpRepl.Services.Roslyn.References;
 

--- a/CSharpRepl.Services/Roslyn/References/SharedFramework.cs
+++ b/CSharpRepl.Services/Roslyn/References/SharedFramework.cs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace CSharpRepl.Services.Roslyn.References;
 

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -142,7 +142,7 @@ public sealed partial class RoslynServices
     }
 
     public AnsiColor ToColor(string keyword) =>
-        highlighter.GetColor(keyword);
+        highlighter.GetAnsiColor(keyword);
 
     public async Task<IReadOnlyCollection<HighlightedSpan>> SyntaxHighlightAsync(string text)
     {

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -57,7 +57,7 @@ public sealed partial class RoslynServices
         nameof(referenceService), nameof(compilationOptions))]
     private Task Initialization { get; }
 
-    public RoslynServices(IConsole console, Configuration config, ITraceLogger logger)
+    public RoslynServices(IConsoleEx console, Configuration config, ITraceLogger logger)
     {
         var cache = new MemoryCache(new MemoryCacheOptions());
         this.logger = logger;

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -16,6 +16,7 @@ using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using CSharpRepl.Services.SymbolExploration;
 using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
@@ -120,7 +121,7 @@ public sealed partial class RoslynServices
         }
     }
 
-    public async Task<FormattedString> PrettyPrintAsync(object? obj, bool displayDetails)
+    public async Task<StyledString> PrettyPrintAsync(object? obj, bool displayDetails)
     {
         await Initialization.ConfigureAwait(false);
         return prettyPrinter.FormatObject(obj, displayDetails);

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System.Collections.Generic;
-using PrettyPrompt.Consoles;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
 
 namespace CSharpRepl.Services.Roslyn.Scripting;

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptGlobals.cs
@@ -14,9 +14,9 @@ namespace CSharpRepl.Services.Roslyn.Scripting;
 /// <remarks>Must be public so it can be referenced by the script</remarks>
 public sealed class ScriptGlobals
 {
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
 
-    public ScriptGlobals(IConsole console, string[] args)
+    public ScriptGlobals(IConsoleEx console, string[] args)
     {
         this.console = console;
         this.args = args;

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
-using PrettyPrompt.Consoles;
 
 namespace CSharpRepl.Services.Roslyn.Scripting;
 
@@ -25,7 +24,7 @@ namespace CSharpRepl.Services.Roslyn.Scripting;
 /// </summary>
 internal sealed class ScriptRunner
 {
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly InteractiveAssemblyLoader assemblyLoader;
     private readonly CompositeAlternativeReferenceResolver alternativeReferenceResolver;
     private readonly MetadataReferenceResolver metadataResolver;
@@ -38,7 +37,7 @@ internal sealed class ScriptRunner
         WorkspaceManager workspaceManager,
         CSharpCompilationOptions compilationOptions,
         AssemblyReferenceService referenceAssemblyService,
-        IConsole console,
+        IConsoleEx console,
         Configuration configuration)
     {
         this.console = console;

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Logging;
 using CSharpRepl.Services.Roslyn.References;
@@ -10,9 +13,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace CSharpRepl.Services.Roslyn;
 

--- a/CSharpRepl.Services/SymbolExploration/DebugSymbolLoader.cs
+++ b/CSharpRepl.Services/SymbolExploration/DebugSymbolLoader.cs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.SymbolStore;
-using Microsoft.SymbolStore.KeyGenerators;
-using Microsoft.SymbolStore.SymbolStores;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,6 +9,9 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SymbolStore;
+using Microsoft.SymbolStore.KeyGenerators;
+using Microsoft.SymbolStore.SymbolStores;
 
 namespace CSharpRepl.Services.SymbolExploration;
 

--- a/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
+++ b/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
@@ -3,18 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Reflection.Metadata;
-using System.Reflection;
-using Microsoft.SymbolStore;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.SymbolStore;
 
 namespace CSharpRepl.Services.SymbolExploration;
 

--- a/CSharpRepl.Services/SyntaxHighlighting/HighlightedSpan.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/HighlightedSpan.cs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis.Text;
-using PrettyPrompt.Highlighting;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.Text;
+using PrettyPrompt.Highlighting;
 
 namespace CSharpRepl.Services.SyntaxHighlighting;
 

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -30,7 +30,7 @@ internal sealed class SyntaxHighlighter
     {
         this.cache = cache;
         this.theme = theme;
-        this.unhighlightedColor = theme.GetSyntaxHighlightingColorOrDefault("text") ?? AnsiColor.White;
+        this.unhighlightedColor = theme.GetSyntaxHighlightingAnsiColor("text", AnsiColor.White);
     }
 
     internal async Task<IReadOnlyCollection<HighlightedSpan>> HighlightAsync(Document document)
@@ -48,7 +48,7 @@ internal sealed class SyntaxHighlighter
             .Select(classifications =>
             {
                 var highlight = classifications
-                    .Select(classification => theme.GetSyntaxHighlightingColorOrDefault(classification.ClassificationType))
+                    .Select(classification => theme.GetSyntaxHighlightingAnsiColor(classification.ClassificationType))
                     .FirstOrDefault(themeColor => themeColor is not null)
                     ?? unhighlightedColor;
                 return new HighlightedSpan(classifications.Key, highlight);
@@ -60,6 +60,6 @@ internal sealed class SyntaxHighlighter
         return highlighted;
     }
 
-    internal AnsiColor GetColor(string keyword) => theme.GetSyntaxHighlightingColorOrDefault(keyword, unhighlightedColor);
-    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingColor(keyword, out color);
+    internal AnsiColor GetColor(string keyword) => theme.GetSyntaxHighlightingAnsiColor(keyword, unhighlightedColor);
+    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingAnsiColor(keyword, out color);
 }

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Caching.Memory;
 using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.SyntaxHighlighting;
 
@@ -23,14 +24,16 @@ internal sealed class SyntaxHighlighter
 {
     private const string CacheKeyPrefix = "SyntaxHighlighter_";
     private readonly Theme theme;
-    private readonly AnsiColor unhighlightedColor;
+    private readonly AnsiColor unhighlightedAnsiColor;
+    private readonly Color unhighlightedSpectreColor;
     private readonly MemoryCache cache;
 
     public SyntaxHighlighter(MemoryCache cache, Theme theme)
     {
         this.cache = cache;
         this.theme = theme;
-        this.unhighlightedColor = theme.GetSyntaxHighlightingAnsiColor("text", AnsiColor.White);
+        this.unhighlightedAnsiColor = theme.GetSyntaxHighlightingAnsiColor("text", AnsiColor.White);
+        this.unhighlightedSpectreColor = theme.GetSyntaxHighlightingSpectreColor("text", Color.White);
     }
 
     internal async Task<IReadOnlyCollection<HighlightedSpan>> HighlightAsync(Document document)
@@ -50,7 +53,7 @@ internal sealed class SyntaxHighlighter
                 var highlight = classifications
                     .Select(classification => theme.GetSyntaxHighlightingAnsiColor(classification.ClassificationType))
                     .FirstOrDefault(themeColor => themeColor is not null)
-                    ?? unhighlightedColor;
+                    ?? unhighlightedAnsiColor;
                 return new HighlightedSpan(classifications.Key, highlight);
             })
             .ToList();
@@ -60,6 +63,9 @@ internal sealed class SyntaxHighlighter
         return highlighted;
     }
 
-    internal AnsiColor GetColor(string keyword) => theme.GetSyntaxHighlightingAnsiColor(keyword, unhighlightedColor);
-    internal bool TryGetColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingAnsiColor(keyword, out color);
+    internal AnsiColor GetAnsiColor(string keyword) => theme.GetSyntaxHighlightingAnsiColor(keyword, unhighlightedAnsiColor);
+    internal bool TryGetAnsiColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingAnsiColor(keyword, out color);
+
+    internal Color GetSpectreColor(string keyword) => theme.GetSyntaxHighlightingSpectreColor(keyword, unhighlightedSpectreColor);
+    internal bool TryGetSpectreColor(string keyword, out Color color) => theme.TryGetSyntaxHighlightingSpectreColor(keyword, out color);
 }

--- a/CSharpRepl.Services/SystemConsoleEx.cs
+++ b/CSharpRepl.Services/SystemConsoleEx.cs
@@ -1,0 +1,39 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using PrettyPrompt.Consoles;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace CSharpRepl.Services;
+
+public sealed class SystemConsoleEx : SystemConsole, IConsoleEx
+{
+    private readonly IAnsiConsole ansiConsole;
+
+    public SystemConsoleEx()
+    {
+        ansiConsole = AnsiConsole.Console;
+    }
+
+    public void WriteError(IRenderable renderable, string text)
+    {
+        if (IsErrorRedirected)
+        {
+            WriteError(text);
+        }
+        else
+        {
+            Write(renderable);
+        }
+    }
+
+    public Profile Profile => ansiConsole.Profile;
+    public IAnsiConsoleCursor Cursor => ansiConsole.Cursor;
+    public IAnsiConsoleInput Input => ansiConsole.Input;
+    public IExclusivityMode ExclusivityMode => ansiConsole.ExclusivityMode;
+    public RenderPipeline Pipeline => ansiConsole.Pipeline;
+    public void Clear(bool home) => ansiConsole.Clear(home);
+    public void Write(IRenderable renderable) => ansiConsole.Write(renderable);
+}

--- a/CSharpRepl.Services/SystemConsoleEx.cs
+++ b/CSharpRepl.Services/SystemConsoleEx.cs
@@ -8,26 +8,11 @@ using Spectre.Console.Rendering;
 
 namespace CSharpRepl.Services;
 
-public sealed class SystemConsoleEx : SystemConsole, IConsoleEx
+public sealed class SystemConsoleEx : IConsoleEx
 {
-    private readonly IAnsiConsole ansiConsole;
+    private readonly IAnsiConsole ansiConsole = AnsiConsole.Console;
 
-    public SystemConsoleEx()
-    {
-        ansiConsole = AnsiConsole.Console;
-    }
-
-    public void WriteError(IRenderable renderable, string text)
-    {
-        if (IsErrorRedirected)
-        {
-            WriteError(text);
-        }
-        else
-        {
-            Write(renderable);
-        }
-    }
+    public IConsole PrettyPromptConsole { get; } = new SystemConsole();
 
     public Profile Profile => ansiConsole.Profile;
     public IAnsiConsoleCursor Cursor => ansiConsole.Cursor;

--- a/CSharpRepl.Services/Theming/StyledString.cs
+++ b/CSharpRepl.Services/Theming/StyledString.cs
@@ -1,0 +1,99 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using CSharpRepl.Services.Extensions;
+using PrettyPrompt.Documents;
+using Spectre.Console;
+
+namespace CSharpRepl.Services.Theming;
+
+public readonly struct StyledString
+{
+    public static readonly StyledString Empty = new("");
+
+    private readonly List<StyledStringSegment> parts;
+
+    public int Length { get; }
+    public bool IsEmpty => parts.Count == 0;
+    public IReadOnlyList<StyledStringSegment> Parts => parts;
+
+    public StyledString(StyledStringSegment part)
+    {
+        if (part.Length > 0)
+        {
+            parts = new List<StyledStringSegment>(1) { part };
+            Length = part.Length;
+        }
+        else
+        {
+            parts = Empty.parts ?? new(0);
+        }
+    }
+
+    public StyledString(string part, Style? style = null)
+        : this(new StyledStringSegment(part, style))
+    { }
+
+    public StyledString(IEnumerable<StyledStringSegment> parts)
+    {
+        this.parts = new List<StyledStringSegment>();
+        int len = 0;
+        foreach (var part in parts)
+        {
+            if (part.Length > 0)
+            {
+                this.parts.Add(part);
+                len += part.Length;
+            }
+        }
+        Length = len;
+    }
+
+    public char FirstChar => parts[0].Text[0];
+    public char LastChar => parts[^1].Text[0];
+
+    /// <summary>
+    /// Retrieves a substring from this instance. The substring starts at a specified character position and has a specified length.
+    /// </summary>
+    public StyledString Substring(int startIndex, int length)
+    {
+        //formal argument validation will be done in Text.Substring(...)
+        Debug.Assert(startIndex >= 0 && startIndex <= Length);
+        Debug.Assert(length >= 0 && length - startIndex <= Length);
+
+        if (IsEmpty || length == 0) return Empty;
+        if (length - startIndex == Length) return this;
+
+        var resultParts = new List<StyledStringSegment>(parts.Count);
+        int i = 0;
+        foreach (var part in parts)
+        {
+            var partSpan = new TextSpan(i, part.Length);
+            if (partSpan.Overlap(startIndex, length).TryGet(out var newSpan))
+            {
+                resultParts.Add(new StyledStringSegment(part.Text.Substring(newSpan.Start - i, newSpan.Length), part.Style));
+            }
+            i += part.Length;
+        }
+
+        return new StyledString(resultParts);
+    }
+
+    public Paragraph ToParagraph()
+    {
+        var p = new Paragraph();
+        foreach (var part in parts)
+        {
+            p.Append(part.Text, part.Style);
+        }
+        return p;
+    }
+
+    public override string ToString() => string.Join("", parts);
+
+    public static implicit operator StyledString(string text) => new(new StyledStringSegment(text));
+    public static implicit operator StyledString(StyledStringSegment text) => new(text);
+}

--- a/CSharpRepl.Services/Theming/StyledStringBuilder.cs
+++ b/CSharpRepl.Services/Theming/StyledStringBuilder.cs
@@ -1,0 +1,58 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using Spectre.Console;
+
+namespace CSharpRepl.Services.Theming;
+
+public struct StyledStringBuilder
+{
+    private readonly List<StyledStringSegment> parts = new();
+
+    private int length;
+    public int Length => length;
+
+    public StyledStringBuilder()
+    { }
+
+    public StyledStringBuilder(StyledStringSegment text)
+    {
+        Add(text);
+    }
+
+    public StyledStringBuilder(string text, Style? style)
+    {
+        Add(new StyledStringSegment(text, style));
+    }
+
+    public StyledStringBuilder Append(string text, Style? style = null)
+    {
+        Add(new StyledStringSegment(text, style));
+        return this;
+    }
+
+    public StyledStringBuilder Append(char c, Style? style = null)
+    {
+        Add(new StyledStringSegment(c.ToString(), style));
+        return this;
+    }
+
+    public StyledStringBuilder Append(StyledString text)
+    {
+        foreach (var part in text.Parts)
+        {
+            Add(part);
+        }
+        return this;
+    }
+
+    private void Add(StyledStringSegment text)
+    {
+        parts.Add(text);
+        length += text.Length;
+    }
+
+    public StyledString ToStyledString() => new(parts);
+}

--- a/CSharpRepl.Services/Theming/StyledStringSegment.cs
+++ b/CSharpRepl.Services/Theming/StyledStringSegment.cs
@@ -1,0 +1,25 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Spectre.Console;
+
+namespace CSharpRepl.Services.Theming;
+
+public readonly struct StyledStringSegment
+{
+    public readonly string Text;
+    public readonly Style? Style;
+
+    public int Length => Text.Length;
+
+    public StyledStringSegment(string text, Style? style = null)
+    {
+        Text = text;
+        Style = style;
+    }
+
+    public override string ToString() => Text;
+
+    public static implicit operator StyledStringSegment(string text) => new(text, null);
+}

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Classification;
 using Newtonsoft.Json;
 using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.Theming;
 
@@ -86,7 +87,10 @@ public sealed class Theme
     public SyntaxHighlightingColor[] SyntaxHighlightingColors { get; }
 
     [JsonIgnore]
-    private readonly Dictionary<string, AnsiColor> syntaxHighlightingColorsDictionary;
+    private readonly Dictionary<string, AnsiColor> syntaxHighlightingAnsiColorsDictionary;
+
+    [JsonIgnore]
+    private readonly Dictionary<string, Color> syntaxHighlightingSpectreColorsDictionary;
 
     public Theme(
         string? selectedCompletionItemBackground,
@@ -101,10 +105,15 @@ public sealed class Theme
         SelectedTextBackground = selectedTextBackground;
 
         SyntaxHighlightingColors = syntaxHighlightingColors;
-        syntaxHighlightingColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToAnsiColor());
+        syntaxHighlightingAnsiColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToAnsiColor());
+        syntaxHighlightingSpectreColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToSpectreColor());
     }
 
-    public AnsiColor? GetSyntaxHighlightingColorOrDefault(string name) => TryGetSyntaxHighlightingColor(name, out var color) ? color : null;
-    public AnsiColor GetSyntaxHighlightingColorOrDefault(string name, AnsiColor defaultValue) => syntaxHighlightingColorsDictionary.GetValueOrDefault(name, defaultValue);
-    public bool TryGetSyntaxHighlightingColor(string name, out AnsiColor color) => syntaxHighlightingColorsDictionary.TryGetValue(name, out color);
+    public AnsiColor? GetSyntaxHighlightingAnsiColor(string name) => TryGetSyntaxHighlightingAnsiColor(name, out var color) ? color : null;
+    public AnsiColor GetSyntaxHighlightingAnsiColor(string name, AnsiColor defaultValue) => syntaxHighlightingAnsiColorsDictionary.GetValueOrDefault(name, defaultValue);
+    public bool TryGetSyntaxHighlightingAnsiColor(string name, out AnsiColor color) => syntaxHighlightingAnsiColorsDictionary.TryGetValue(name, out color);
+
+    public Color? GetSyntaxHighlightingSpectreColor(string name) => TryGetSyntaxHighlightingSpectreColor(name, out var color) ? color : null;
+    public Color GetSyntaxHighlightingSpectreColor(string name, Color defaultValue) => syntaxHighlightingSpectreColorsDictionary.GetValueOrDefault(name, defaultValue);
+    public bool TryGetSyntaxHighlightingSpectreColor(string name, out Color color) => syntaxHighlightingSpectreColorsDictionary.TryGetValue(name, out color);
 }

--- a/CSharpRepl.Services/Theming/ThemeColor.cs
+++ b/CSharpRepl.Services/Theming/ThemeColor.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace CSharpRepl.Services.Theming;
 
@@ -39,6 +40,16 @@ public readonly struct ThemeColor
         throw new ArgumentException($"Unknown recognized color '{Value}'. Expecting either a hexadecimal color of the format #RRGGBB or a standard ANSI color name");
     }
 
+    public Color ToSpectreColor()
+    {
+        if (TryParseSpectreColor(Value, out var color))
+        {
+            return color;
+        }
+
+        throw new ArgumentException($"Unknown recognized color '{Value}'. Expecting either a hexadecimal color of the format #RRGGBB or a standard ANSI color name");
+    }
+
     public static bool TryParseAnsiColor(string input, out AnsiColor result)
     {
         var span = input.AsSpan();
@@ -59,5 +70,101 @@ public readonly struct ThemeColor
 
         result = default;
         return false;
+    }
+
+    public static bool TryParseSpectreColor(string input, out Color result)
+    {
+        var span = input.AsSpan();
+        if (input.StartsWith('#') && span.Length == 7 &&
+            byte.TryParse(span.Slice(1, 2), NumberStyles.AllowHexSpecifier, null, out byte r) &&
+            byte.TryParse(span.Slice(3, 2), NumberStyles.AllowHexSpecifier, null, out byte g) &&
+            byte.TryParse(span.Slice(5, 2), NumberStyles.AllowHexSpecifier, null, out byte b))
+        {
+            result = new Color(r, g, b);
+            return true;
+        }
+
+        if (TryConvertAnsiColorToConsoleColor(input, out var consoleColor))
+        {
+            result = Color.FromConsoleColor(consoleColor);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static bool TryConvertAnsiColorToConsoleColor(string ansiColorName, out ConsoleColor result)
+    {
+        switch (ansiColorName)
+        {
+            case "Black":
+                result = ConsoleColor.Black;
+                return true;
+
+            case "Red":
+                result = ConsoleColor.DarkRed;
+                return true;
+
+            case "Green":
+                result = ConsoleColor.DarkGreen;
+                return true;
+
+            case "Yellow":
+                result = ConsoleColor.DarkYellow;
+                return true;
+
+            case "Blue":
+                result = ConsoleColor.DarkBlue;
+                return true;
+
+            case "Magenta":
+                result = ConsoleColor.DarkMagenta;
+                return true;
+
+            case "Cyan":
+                result = ConsoleColor.DarkCyan;
+                return true;
+
+            case "White":
+                result = ConsoleColor.Gray;
+                return true;
+
+            case "BrightBlack":
+                result = ConsoleColor.DarkGray;
+                return true;
+
+            case "BrightRed":
+                result = ConsoleColor.Red;
+                return true;
+
+            case "BrightGreen":
+                result = ConsoleColor.Green;
+                return true;
+
+            case "BrightYellow":
+                result = ConsoleColor.Yellow;
+                return true;
+
+            case "BrightBlue":
+                result = ConsoleColor.Blue;
+                return true;
+
+            case "BrightMagenta":
+                result = ConsoleColor.Magenta;
+                return true;
+
+            case "BrightCyan":
+                result = ConsoleColor.Cyan;
+                return true;
+
+            case "BrightWhite":
+                result = ConsoleColor.White;
+                return true;
+
+            default:
+                result = default;
+                return false;
+        };
     }
 }

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -14,10 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.3" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.45.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -62,7 +62,7 @@ public class CommandLineTests
         var result = Parse($"{flag} Data/theme.json");
         Assert.NotNull(result);
         Assert.Equal(41, result.Theme.SyntaxHighlightingColors.Length);
-        Assert.True(result.Theme.TryGetSyntaxHighlightingColor("struct name", out var color));
+        Assert.True(result.Theme.TryGetSyntaxHighlightingAnsiColor("struct name", out var color));
         Assert.Equal("Yellow", color.ToString());
     }
 
@@ -91,7 +91,7 @@ public class CommandLineTests
         Assert.NotNull(result);
 
         Assert.Equal(41, result.Theme.SyntaxHighlightingColors.Length);
-        Assert.True(result.Theme.TryGetSyntaxHighlightingColor("struct name", out var color));
+        Assert.True(result.Theme.TryGetSyntaxHighlightingAnsiColor("struct name", out var color));
         Assert.Equal("Yellow", color.ToString());
 
         Assert.Equal(new[] { "System.Linq", "System.Data", "Newtonsoft.Json" }, result.Usings);

--- a/CSharpRepl.Tests/CommandLineTests.cs
+++ b/CSharpRepl.Tests/CommandLineTests.cs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn.References;
-using System;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
@@ -1,4 +1,4 @@
-﻿// Method begins at RVA 0x2050
+﻿// Method begins at RVA 0x206c
 // Header size: 12
 // Code size: 14 (0xe)
 .maxstack 2

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
@@ -1,4 +1,4 @@
-﻿// Method begins at RVA 0x2050
+﻿// Method begins at RVA 0x2068
 // Header size: 12
 // Code size: 11 (0xb)
 .maxstack 2

--- a/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Debug.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Debug.il
@@ -2,6 +2,71 @@
 {
 } // end of class <Module>
 
+.class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
+    extends [System.Runtime]System.Attribute
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    // Methods
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        // Method begins at RVA 0x2050
+        // Header size: 1
+        // Code size: 8 (0x8)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+        IL_0006: nop
+        IL_0007: ret
+    } // end of method EmbeddedAttribute::.ctor
+
+} // end of class Microsoft.CodeAnalysis.EmbeddedAttribute
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.RefSafetyRulesAttribute
+    extends [System.Runtime]System.Attribute
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = (
+        01 00 02 00 00 00 02 00 54 02 0d 41 6c 6c 6f 77
+        4d 75 6c 74 69 70 6c 65 00 54 02 09 49 6e 68 65
+        72 69 74 65 64 00
+    )
+    // Fields
+    .field public initonly int32 Version
+
+    // Methods
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            int32 ''
+        ) cil managed
+    {
+        // Method begins at RVA 0x2059
+        // Header size: 1
+        // Code size: 15 (0xf)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+        IL_0006: nop
+        IL_0007: ldarg.0
+        IL_0008: ldarg.1
+        IL_0009: stfld int32 System.Runtime.CompilerServices.RefSafetyRulesAttribute::Version
+        IL_000e: ret
+    } // end of method RefSafetyRulesAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.RefSafetyRulesAttribute
+
 .class private auto ansi beforefieldinit Panda
     extends [System.Runtime]System.Object
 {
@@ -21,7 +86,7 @@
         .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
             01 00 00 00
         )
-        // Method begins at RVA 0x2050
+        // Method begins at RVA 0x2069
         // Header size: 1
         // Code size: 7 (0x7)
         .maxstack 8
@@ -39,7 +104,7 @@
         .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
             01 00 00 00
         )
-        // Method begins at RVA 0x2058
+        // Method begins at RVA 0x2071
         // Header size: 1
         // Code size: 8 (0x8)
         .maxstack 8
@@ -53,7 +118,7 @@
     .method public hidebysig specialname rtspecialname
         instance void .ctor () cil managed
     {
-        // Method begins at RVA 0x2061
+        // Method begins at RVA 0x207a
         // Header size: 1
         // Code size: 8 (0x8)
         .maxstack 8

--- a/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Release.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Release.il
@@ -2,6 +2,69 @@
 {
 } // end of class <Module>
 
+.class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
+    extends [System.Runtime]System.Attribute
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    // Methods
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        // Method begins at RVA 0x2050
+        // Header size: 1
+        // Code size: 7 (0x7)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+        IL_0006: ret
+    } // end of method EmbeddedAttribute::.ctor
+
+} // end of class Microsoft.CodeAnalysis.EmbeddedAttribute
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.RefSafetyRulesAttribute
+    extends [System.Runtime]System.Attribute
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = (
+        01 00 02 00 00 00 02 00 54 02 0d 41 6c 6c 6f 77
+        4d 75 6c 74 69 70 6c 65 00 54 02 09 49 6e 68 65
+        72 69 74 65 64 00
+    )
+    // Fields
+    .field public initonly int32 Version
+
+    // Methods
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            int32 ''
+        ) cil managed
+    {
+        // Method begins at RVA 0x2058
+        // Header size: 1
+        // Code size: 14 (0xe)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+        IL_0006: ldarg.0
+        IL_0007: ldarg.1
+        IL_0008: stfld int32 System.Runtime.CompilerServices.RefSafetyRulesAttribute::Version
+        IL_000d: ret
+    } // end of method RefSafetyRulesAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.RefSafetyRulesAttribute
+
 .class private auto ansi beforefieldinit Panda
     extends [System.Runtime]System.Object
 {
@@ -18,7 +81,7 @@
         .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
             01 00 00 00
         )
-        // Method begins at RVA 0x2050
+        // Method begins at RVA 0x2067
         // Header size: 1
         // Code size: 7 (0x7)
         .maxstack 8
@@ -36,7 +99,7 @@
         .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
             01 00 00 00
         )
-        // Method begins at RVA 0x2058
+        // Method begins at RVA 0x206f
         // Header size: 1
         // Code size: 8 (0x8)
         .maxstack 8
@@ -50,7 +113,7 @@
     .method public hidebysig specialname rtspecialname
         instance void .ctor () cil managed
     {
-        // Method begins at RVA 0x2061
+        // Method begins at RVA 0x2078
         // Header size: 1
         // Code size: 7 (0x7)
         .maxstack 8

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -2,12 +2,10 @@
 using System.IO;
 using System.Threading.Tasks;
 using CSharpRepl.Services;
-using CSharpRepl.Services.Disassembly;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
 using Microsoft.CodeAnalysis;
 using NSubstitute;
-using PrettyPrompt.Consoles;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -19,7 +19,7 @@ public class DisassemblerTests : IAsyncLifetime
 
     public DisassemblerTests()
     {
-        var console = Substitute.For<IConsole>();
+        var console = Substitute.For<IConsoleEx>();
         console.BufferWidth.Returns(200);
         this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());
     }

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -18,7 +18,7 @@ public class DisassemblerTests : IAsyncLifetime
     public DisassemblerTests()
     {
         var console = Substitute.For<IConsoleEx>();
-        console.BufferWidth.Returns(200);
+        console.PrettyPromptConsole.BufferWidth.Returns(200);
         this.services = new RoslynServices(console, new Configuration(), new TestTraceLogger());
     }
 

--- a/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
+++ b/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
@@ -1,9 +1,9 @@
-﻿using CSharpRepl.Services.Roslyn.References;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
-using Xunit;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using CSharpRepl.Services.Roslyn.References;
+using Xunit;
 
 namespace CSharpRepl.Tests;
 

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -21,7 +21,7 @@ public class EvaluationTests : IAsyncLifetime
 {
     private readonly RoslynServices services;
     private readonly StringBuilder stdout;
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
 
     public EvaluationTests()
     {

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -11,7 +11,6 @@ using CSharpRepl.Services;
 using CSharpRepl.Services.Dotnet;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
-using PrettyPrompt.Consoles;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/FakeConsole.cs
+++ b/CSharpRepl.Tests/FakeConsole.cs
@@ -26,7 +26,7 @@ internal static class FakeConsole
 {
     private static readonly Regex FormatStringSplit = new(@"({\d+}|{{|}}|.)", RegexOptions.Compiled);
 
-    public static (IConsoleEx console, StringBuilder stdout, StringBuilder stderr) CreateStubbedOutputAndError(int width = 100, int height = 100)
+    public static (FakeConsoleAbstract console, StringBuilder stdout, StringBuilder stderr) CreateStubbedOutputAndError(int width = 100, int height = 100)
     {
         var stub = Create(width, height);
         var stdout = new StringBuilder();
@@ -38,7 +38,7 @@ internal static class FakeConsole
         return (stub, stdout, stderr);
     }
 
-    public static (IConsoleEx console, StringBuilder stdout) CreateStubbedOutput(int width = 100, int height = 100)
+    public static (FakeConsoleAbstract console, StringBuilder stdout) CreateStubbedOutput(int width = 100, int height = 100)
     {
         var console = Create(width, height);
         var stdout = new StringBuilder();
@@ -47,7 +47,7 @@ internal static class FakeConsole
         return (console, stdout);
     }
 
-    public static IConsoleEx Create(int width = 100, int height = 100)
+    public static FakeConsoleAbstract Create(int width = 100, int height = 100)
     {
         var console = Substitute.For<FakeConsoleAbstract>();
         console.BufferWidth.Returns(width);
@@ -254,15 +254,15 @@ internal static class FakeConsole
 
 public abstract class FakeConsoleAbstract : IConsoleEx
 {
-    private readonly IAnsiConsole ansiConsole = new TestConsole();
+    public readonly TestConsole AnsiConsole = new();
 
     public abstract int CursorTop { get; }
     public abstract int BufferWidth { get; }
     public abstract int WindowHeight { get; }
     public abstract int WindowTop { get; }
     public abstract bool KeyAvailable { get; }
-    public abstract bool IsErrorRedirected { get; }
     public abstract bool CaptureControlC { get; set; }
+    public bool IsErrorRedirected => true;
 
     public abstract event ConsoleCancelEventHandler CancelKeyPress;
 
@@ -277,7 +277,17 @@ public abstract class FakeConsoleAbstract : IConsoleEx
     public abstract void WriteErrorLine(string? value);
     public abstract void WriteLine(string? value);
 
-    public abstract void WriteError(IRenderable renderable, string text);
+    public void WriteError(IRenderable renderable, string text)
+    {
+        if (IsErrorRedirected)
+        {
+            WriteError(text);
+        }
+        else
+        {
+            Write(renderable);
+        }
+    }
 
     //following implementations is needed because NSubstitute does not support ROS
     public void Write(ReadOnlySpan<char> value) => Write(value.ToString());
@@ -286,11 +296,11 @@ public abstract class FakeConsoleAbstract : IConsoleEx
     public void WriteLine(ReadOnlySpan<char> value) => WriteLine(value.ToString());
 
     //IAnsiConsole
-    public Profile Profile => ansiConsole.Profile;
-    public IAnsiConsoleCursor Cursor => ansiConsole.Cursor;
-    public IAnsiConsoleInput Input => ansiConsole.Input;
-    public IExclusivityMode ExclusivityMode => ansiConsole.ExclusivityMode;
-    public RenderPipeline Pipeline => ansiConsole.Pipeline;
-    public void Clear(bool home) => ansiConsole.Clear(home);
-    public void Write(IRenderable renderable) => ansiConsole.Write(renderable);
+    public Profile Profile => AnsiConsole.Profile;
+    public IAnsiConsoleCursor Cursor => AnsiConsole.Cursor;
+    public IAnsiConsoleInput Input => AnsiConsole.Input;
+    public IExclusivityMode ExclusivityMode => AnsiConsole.ExclusivityMode;
+    public RenderPipeline Pipeline => AnsiConsole.Pipeline;
+    public void Clear(bool home) => AnsiConsole.Clear(home);
+    public void Write(IRenderable renderable) => AnsiConsole.Write(renderable);
 }

--- a/CSharpRepl.Tests/FakeConsole.cs
+++ b/CSharpRepl.Tests/FakeConsole.cs
@@ -16,7 +16,6 @@ using CSharpRepl.Services;
 using NSubstitute;
 using NSubstitute.Core;
 using PrettyPrompt;
-using PrettyPrompt.Consoles;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using Spectre.Console.Testing;

--- a/CSharpRepl.Tests/PrettyPrinterTests.cs
+++ b/CSharpRepl.Tests/PrettyPrinterTests.cs
@@ -36,7 +36,7 @@ public class PrettyPrinterTests : IClassFixture<RoslynServicesFixture>
     {
         var result = await services.EvaluateAsync(input);
         var exception = ((EvaluationResult.Error)result).Exception;
-        var output = prettyPrinter.FormatObject(exception, displayDetails: true).Text;
+        var output = prettyPrinter.FormatObject(exception, displayDetails: true).ToString();
         Assert.Equal(expectedOutput.Replace("\n", NewLine), output);
     }
 
@@ -50,7 +50,7 @@ public class PrettyPrinterTests : IClassFixture<RoslynServicesFixture>
     {
         var result = await services.EvaluateAsync("+");
         var exception = ((EvaluationResult.Error)result).Exception;
-        var output = prettyPrinter.FormatObject(exception, detailedOutput).Text;
+        var output = prettyPrinter.FormatObject(exception, detailedOutput).ToString();
         Assert.Equal("(1,2): error CS1733: Expected expression", output);
     }
 
@@ -58,7 +58,7 @@ public class PrettyPrinterTests : IClassFixture<RoslynServicesFixture>
     [MemberData(nameof(FormatObjectInputs))]
     public void FormatObject_ObjectInput_PrintsOutput(object obj, bool showDetails, string expectedResult)
     {
-        var prettyPrinted = prettyPrinter.FormatObject(obj, showDetails).Text;
+        var prettyPrinted = prettyPrinter.FormatObject(obj, showDetails).ToString();
         Assert.Equal(expectedResult, prettyPrinted);
     }
 

--- a/CSharpRepl.Tests/ProgramTests.cs
+++ b/CSharpRepl.Tests/ProgramTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -16,7 +16,7 @@ namespace CSharpRepl.Tests;
 public class PromptConfigurationTests : IAsyncLifetime
 {
     private readonly RoslynServices services;
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly StringBuilder stdout;
 
     public PromptConfigurationTests()

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -15,7 +15,7 @@ namespace CSharpRepl.Tests;
 public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 {
     private readonly ReadEvalPrintLoop repl;
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly StringBuilder capturedOutput;
     private readonly StringBuilder capturedError;
     private readonly IPrompt prompt;

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -6,7 +6,6 @@ using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using NSubstitute;
 using PrettyPrompt;
-using PrettyPrompt.Consoles;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -46,8 +46,8 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 
         await repl.RunAsync(new Configuration());
 
-        console.Received().WriteLine(Arg.Is<string>(str => str.Contains("Welcome to the C# REPL")));
-        console.Received().WriteLine(Arg.Is<string>(str => str.Contains("Type C# at the prompt")));
+        Assert.Contains("Welcome to the C# REPL", console.AnsiConsole.Output);
+        Assert.Contains("Type C# at the prompt", console.AnsiConsole.Output);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 
         await repl.RunAsync(new Configuration());
 
-        console.Received().Clear();
+        ((IConsoleEx)console.Received()).Clear(true);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 
         await repl.RunAsync(new Configuration());
 
-        Assert.Contains("bonk!", capturedError.ToString());
+        Assert.Contains("bonk!", console.AnsiConsole.Output);
     }
 
     [Fact]

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CSharpRepl.PrettyPromptConfig;
@@ -14,7 +15,7 @@ namespace CSharpRepl.Tests;
 public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 {
     private readonly ReadEvalPrintLoop repl;
-    private readonly IConsoleEx console;
+    private readonly FakeConsoleAbstract console;
     private readonly StringBuilder capturedOutput;
     private readonly StringBuilder capturedError;
     private readonly IPrompt prompt;
@@ -76,7 +77,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 
         await repl.RunAsync(new Configuration());
 
-        console.Received().Write("8");
+        Assert.Equal("8", console.AnsiConsole.Lines.Last());
     }
 
     [Fact]
@@ -93,7 +94,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
             loadScript: @"var x = ""Hello World"";"
         ));
 
-        Assert.Contains(@"""Hello World""", capturedOutput.ToString());
+        Assert.Contains(@"""Hello World""", console.AnsiConsole.Output);
     }
 
     [Fact]
@@ -110,7 +111,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
             references: new[] { "Data/DemoLibrary.dll" }
         ));
 
-        Assert.Contains("30", capturedOutput.ToString());
+        Assert.Contains("30", console.AnsiConsole.Output);
     }
 
     [Fact]

--- a/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -11,7 +11,7 @@ namespace CSharpRepl.Tests;
 
 public sealed class RoslynServicesFixture : IAsyncLifetime
 {
-    public IConsoleEx ConsoleStub { get; }
+    public FakeConsoleAbstract ConsoleStub { get; }
     public StringBuilder CapturedConsoleOutput { get; }
     public StringBuilder CapturedConsoleError { get; }
     public IPrompt PromptStub { get; }

--- a/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -12,7 +12,7 @@ namespace CSharpRepl.Tests;
 
 public sealed class RoslynServicesFixture : IAsyncLifetime
 {
-    public IConsole ConsoleStub { get; }
+    public IConsoleEx ConsoleStub { get; }
     public StringBuilder CapturedConsoleOutput { get; }
     public StringBuilder CapturedConsoleError { get; }
     public IPrompt PromptStub { get; }

--- a/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -1,11 +1,10 @@
-﻿using CSharpRepl.Services;
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using NSubstitute;
 using PrettyPrompt;
-using PrettyPrompt.Consoles;
-using System;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -25,7 +25,6 @@ public partial class RoslynServicesTests : IAsyncLifetime, IClassFixture<RoslynS
 
     public RoslynServicesTests(RoslynServicesFixture fixture)
     {
-        var (console, _) = FakeConsole.CreateStubbedOutput();
         this.services = fixture.RoslynServices;
     }
 
@@ -143,13 +142,23 @@ public class RoslynServices_REPL_Tests
         Assert.Contains("18", stdout.ToString());
     }
 
-    [Fact]
-    public async Task IncompleteStatement_CustomKeyBindings()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IncompleteStatement_CustomKeyBindings(bool isErrorRedirected)
     {
         var (console, repl, configuration, _, stderr) = await InitAsync(GetCustomKeyBindingsConfiguration());
+        console.PrettyPromptConsole.IsErrorRedirected = isErrorRedirected;
         console.StubInput($"5 +{Control}{Enter}exit{Control}{Enter}");
         await repl.RunAsync(configuration);
-        Assert.Contains("Expected expression", stderr.ToString());
+        if (isErrorRedirected)
+        {
+            Assert.Contains("Expected expression", stderr.ToString()); 
+        }
+        else
+        {
+            Assert.Contains("Expected expression", console.AnsiConsole.Output);
+        }
     }
 
     [Fact]
@@ -160,20 +169,22 @@ public class RoslynServices_REPL_Tests
         // because the completion window would open on the closing quote and commit on the closing parenthesis.
         // It happens quite often e.g. inside an if statement with parentheses.
         var (console, repl, configuration, _, _) = await InitAsync(GetCustomKeyBindingsConfiguration());
+        console.PrettyPromptConsole.IsErrorRedirected = true; // -> errors will go to PrettyPromptConsole
         console.StubInput($@"{{ Console.WriteLine(""Hello""); }}{Control}{Enter}exit{Control}{Enter}");
         await repl.RunAsync(configuration);
-        console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
-        console.DidNotReceive().WriteError(Arg.Any<string>());
+        console.PrettyPromptConsole.DidNotReceive().WriteErrorLine(Arg.Any<string>());
+        console.PrettyPromptConsole.DidNotReceive().WriteError(Arg.Any<string>());
     }
 
     [Fact]
     public async Task UsingStatement_CanBeCompleted()
     {
         var (console, repl, configuration, _, _) = await InitAsync();
+        console.PrettyPromptConsole.IsErrorRedirected = true; // -> errors will go to PrettyPromptConsole
         console.StubInput($@"using Syst{Tab};{Enter}exit{Enter}");
         await repl.RunAsync(configuration);
-        console.DidNotReceive().WriteErrorLine(Arg.Any<string>());
-        console.DidNotReceive().WriteError(Arg.Any<string>());
+        console.PrettyPromptConsole.DidNotReceive().WriteErrorLine(Arg.Any<string>());
+        console.PrettyPromptConsole.DidNotReceive().WriteError(Arg.Any<string>());
     }
 
     [Theory]
@@ -206,7 +217,7 @@ public class RoslynServices_REPL_Tests
         var (console, stdout, stderr) = FakeConsole.CreateStubbedOutputAndError();
         configuration ??= new Configuration();
         var services = new RoslynServices(console, configuration, new TestTraceLogger());
-        var prompt = new Prompt(console: console, callbacks: new CSharpReplPromptCallbacks(console, services, configuration), configuration: new PromptConfiguration(keyBindings: configuration.KeyBindings));
+        var prompt = new Prompt(console: console.PrettyPromptConsole, callbacks: new CSharpReplPromptCallbacks(console, services, configuration), configuration: new PromptConfiguration(keyBindings: configuration.KeyBindings));
         var repl = new ReadEvalPrintLoop(services, prompt, console);
         await services.WarmUpAsync(Array.Empty<string>());
         return (console, repl, configuration, stdout, stderr);

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -201,7 +201,7 @@ public class RoslynServices_REPL_Tests
         }
     }
 
-    private static async Task<(IConsole Console, ReadEvalPrintLoop Repl, Configuration Configuration, StringBuilder StdOut, StringBuilder StdErr)> InitAsync(Configuration? configuration = null)
+    private static async Task<(IConsoleEx Console, ReadEvalPrintLoop Repl, Configuration Configuration, StringBuilder StdOut, StringBuilder StdErr)> InitAsync(Configuration? configuration = null)
     {
         var (console, stdout, stderr) = FakeConsole.CreateStubbedOutputAndError();
         configuration ??= new Configuration();

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using CSharpRepl.PrettyPromptConfig;
@@ -182,7 +183,7 @@ public class RoslynServices_REPL_Tests
         var (console, repl, configuration, _, _) = await InitAsync();
         console.StubInput(input);
         await repl.RunAsync(configuration);
-        console.Received().Write(output);
+        Assert.Equal(output, console.AnsiConsole.Lines.Last());
     }
 
     public static IEnumerable<object[]> EnumerateCompletionDoesNotInterfereData()
@@ -200,7 +201,7 @@ public class RoslynServices_REPL_Tests
         }
     }
 
-    private static async Task<(IConsoleEx Console, ReadEvalPrintLoop Repl, Configuration Configuration, StringBuilder StdOut, StringBuilder StdErr)> InitAsync(Configuration? configuration = null)
+    private static async Task<(FakeConsoleAbstract Console, ReadEvalPrintLoop Repl, Configuration Configuration, StringBuilder StdOut, StringBuilder StdErr)> InitAsync(Configuration? configuration = null)
     {
         var (console, stdout, stderr) = FakeConsole.CreateStubbedOutputAndError();
         configuration ??= new Configuration();

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -10,7 +10,6 @@ using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
 using NSubstitute;
 using PrettyPrompt;
-using PrettyPrompt.Consoles;
 using Xunit;
 
 using static System.ConsoleKey;
@@ -90,7 +89,7 @@ public partial class RoslynServicesTests : IAsyncLifetime, IClassFixture<RoslynS
 
     [InlineData("\"abc\".ToString()", true, "abc")]
     [InlineData("\"abc\".ToString();", false, null)]
-    
+
     [InlineData("object o = null; o?.ToString()", true, null)]
     [InlineData("object o = null; o?.ToString();", false, null)]
 

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -40,6 +40,6 @@ public class ScriptArgumentTests
         var printStatement = await services.EvaluateAsync("Print(DateTime.MinValue)");
 
         Assert.IsType<EvaluationResult.Success>(printStatement);
-        Assert.Equal("[1/1/0001 12:00:00 AM]" + Environment.NewLine, stdOut.ToString());
+        Assert.Equal("[1/1/0001 12:00:00 AM]\n", console.AnsiConsole.Output);
     }
 }

--- a/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -1,8 +1,8 @@
-﻿using CSharpRepl.Services;
+﻿using System;
+using System.Threading.Tasks;
+using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/StyledStringTests.cs
+++ b/CSharpRepl.Tests/StyledStringTests.cs
@@ -1,0 +1,130 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Theming;
+using Spectre.Console;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+public class StyledStringTests
+{
+    [Fact]
+    public void SubstringSimple()
+    {
+        var redStyle = new Style(foreground: Color.Red);
+        foreach (var style in new[] { null, redStyle })
+        {
+            var text = new StyledString("abcd", style);
+
+            var subtext = text.Substring(0, 4);
+            Assert.Equal("abcd", subtext.ToString());
+            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Equal(style, subtext.Parts[0].Style);
+
+            subtext = text.Substring(0, 2);
+            Assert.Equal("ab", subtext.ToString());
+            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Equal(style, subtext.Parts[0].Style);
+
+            subtext = text.Substring(1, 2);
+            Assert.Equal("bc", subtext.ToString());
+            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Equal(style, subtext.Parts[0].Style);
+
+            subtext = text.Substring(2, 2);
+            Assert.Equal("cd", subtext.ToString());
+            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Equal(style, subtext.Parts[0].Style);
+
+            subtext = text.Substring(2, 0);
+            Assert.Equal("", subtext.ToString());
+            Assert.Equal(0, subtext.Parts.Count);
+        }
+    }
+
+    [Fact]
+    public void SubstringComplex()
+    {
+        var redStyle = new Style(foreground: Color.Red);
+        var blueStyle = new Style(foreground: Color.Blue);
+        var text = new StyledString(new[] { new StyledStringSegment("ab", redStyle), new StyledStringSegment("cd", null), new StyledStringSegment("ef", blueStyle) });
+
+        var subtext = text.Substring(0, 6);
+        Assert.Equal("abcdef", subtext.ToString());
+        Assert.Equal(3, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+        Assert.Equal(blueStyle, subtext.Parts[2].Style);
+
+        subtext = text.Substring(0, 5);
+        Assert.Equal("abcde", subtext.ToString());
+        Assert.Equal(3, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+        Assert.Equal(blueStyle, subtext.Parts[2].Style);
+
+        subtext = text.Substring(0, 4);
+        Assert.Equal("abcd", subtext.ToString());
+        Assert.Equal(2, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+
+        subtext = text.Substring(0, 3);
+        Assert.Equal("abc", subtext.ToString());
+        Assert.Equal(2, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+
+        subtext = text.Substring(0, 2);
+        Assert.Equal("ab", subtext.ToString());
+        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+
+        subtext = text.Substring(0, 1);
+        Assert.Equal("a", subtext.ToString());
+        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+
+        ///////////////////////////////////////////////////////////////////////
+
+        subtext = text.Substring(1, 5);
+        Assert.Equal("bcdef", subtext.ToString());
+        Assert.Equal(3, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+        Assert.Equal(blueStyle, subtext.Parts[2].Style);
+
+        subtext = text.Substring(2, 4);
+        Assert.Equal("cdef", subtext.ToString());
+        Assert.Equal(2, subtext.Parts.Count);
+        Assert.Null(subtext.Parts[0].Style);
+        Assert.Equal(blueStyle, subtext.Parts[1].Style);
+
+        subtext = text.Substring(3, 3);
+        Assert.Equal("def", subtext.ToString());
+        Assert.Equal(2, subtext.Parts.Count);
+        Assert.Null(subtext.Parts[0].Style);
+        Assert.Equal(blueStyle, subtext.Parts[1].Style);
+
+        subtext = text.Substring(4, 2);
+        Assert.Equal("ef", subtext.ToString());
+        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Equal(blueStyle, subtext.Parts[0].Style);
+
+        subtext = text.Substring(5, 1);
+        Assert.Equal("f", subtext.ToString());
+        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Equal(blueStyle, subtext.Parts[0].Style);
+
+        ///////////////////////////////////////////////////////////////////////
+
+        subtext = text.Substring(1, 4);
+        Assert.Equal("bcde", subtext.ToString());
+        Assert.Equal(3, subtext.Parts.Count);
+        Assert.Equal(redStyle, subtext.Parts[0].Style);
+        Assert.Null(subtext.Parts[1].Style);
+        Assert.Equal(blueStyle, subtext.Parts[2].Style);
+    }
+}

--- a/CSharpRepl.Tests/SymbolExplorerTests.cs
+++ b/CSharpRepl.Tests/SymbolExplorerTests.cs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
+using System.Threading.Tasks;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.SymbolExploration;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl.Tests/SyntaxHighlightingTests.cs
+++ b/CSharpRepl.Tests/SyntaxHighlightingTests.cs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Microsoft.CodeAnalysis.Text;
-using CSharpRepl.Services;
-using CSharpRepl.Services.Roslyn;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
-using System;
 
 namespace CSharpRepl.Tests;
 

--- a/CSharpRepl.Tests/TraceLoggerTests.cs
+++ b/CSharpRepl.Tests/TraceLoggerTests.cs
@@ -1,8 +1,8 @@
-﻿using CSharpRepl.Logging;
-using CSharpRepl.Services.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using CSharpRepl.Logging;
+using CSharpRepl.Services.Logging;
 using Xunit;
 
 namespace CSharpRepl.Tests;

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.0.1" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
   </ItemGroup>

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -189,7 +189,7 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         {
             case EvaluationResult.Success success:
                 var ilCode = success.ReturnValue.ToString();
-                var output = Prompt.RenderAnsiOutput(ilCode, Array.Empty<FormatSpan>(), console.BufferWidth);
+                var output = Prompt.RenderAnsiOutput(ilCode, Array.Empty<FormatSpan>(), console.PrettyPromptConsole.BufferWidth);
                 return new KeyPressCallbackResult(text, output);
             case EvaluationResult.Error err:
                 return new KeyPressCallbackResult(text, AnsiColor.Red.GetEscapeSequence() + err.Exception.Message + AnsiEscapeCodes.Reset);

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -30,11 +30,11 @@ namespace CSharpRepl.PrettyPromptConfig;
 /// </summary>
 internal class CSharpReplPromptCallbacks : PromptCallbacks
 {
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
     private readonly RoslynServices roslyn;
     private readonly Configuration configuration;
 
-    public CSharpReplPromptCallbacks(IConsole console, RoslynServices roslyn, Configuration configuration)
+    public CSharpReplPromptCallbacks(IConsoleEx console, RoslynServices roslyn, Configuration configuration)
     {
         this.console = console;
         this.roslyn = roslyn;
@@ -152,7 +152,7 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         }
 
         static KeyPress NewLineWithIndentation(int indentation) =>
-            new KeyPress(ConsoleKey.Insert.ToKeyInfo('\0', shift: true), "\n" + new string('\t', indentation));
+            new(ConsoleKey.Insert.ToKeyInfo('\0', shift: true), "\n" + new string('\t', indentation));
     }
 
     protected override Task<bool> ConfirmCompletionCommit(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
@@ -181,7 +181,7 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
     protected override Task<(IReadOnlyList<OverloadItem>, int ArgumentIndex)> GetOverloadsAsync(string text, int caret, CancellationToken cancellationToken)
         => roslyn.GetOverloadsAsync(text, caret, cancellationToken);
 
-    private static async Task<KeyPressCallbackResult?> Disassemble(RoslynServices roslyn, string text, IConsole console, bool debugMode)
+    private static async Task<KeyPressCallbackResult?> Disassemble(RoslynServices roslyn, string text, IConsoleEx console, bool debugMode)
     {
         var result = await roslyn.ConvertToIntermediateLanguage(text, debugMode);
 

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -148,7 +148,7 @@ internal static class CommandLine
             if (!r.Children.Any()) return;
 
             string frameworkValue = r.GetValueOrDefault<string>() ?? string.Empty;
-            if(!SharedFramework.SupportedFrameworks.Any(f => frameworkValue.StartsWith(f, StringComparison.OrdinalIgnoreCase)))
+            if (!SharedFramework.SupportedFrameworks.Any(f => frameworkValue.StartsWith(f, StringComparison.OrdinalIgnoreCase)))
             {
                 r.ErrorMessage = "Unrecognized --framework value";
             }
@@ -165,7 +165,7 @@ internal static class CommandLine
             .Build()
             .Parse(parseArgs);
 
-        if(!File.Exists(configFilePath))
+        if (!File.Exists(configFilePath))
         {
             ConfigurationFile.CreateDefaultConfigurationFile(configFilePath, availableCommands, ignoreCommands: new[] { Help, Version, Configure });
         }

--- a/CSharpRepl/ConfigurationFile.cs
+++ b/CSharpRepl/ConfigurationFile.cs
@@ -45,7 +45,7 @@ internal static class ConfigurationFile
         try
         {
             var editorName = GetEnvironmentVariable("EDITOR");
-            if(editorName is null)
+            if (editorName is null)
             {
                 var vsCodeLocationProcess = Process.Start(new ProcessStartInfo
                 {

--- a/CSharpRepl/Logging/NullLogger.cs
+++ b/CSharpRepl/Logging/NullLogger.cs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Logging;
 using System;
 using System.Collections.Generic;
+using CSharpRepl.Services.Logging;
 
 namespace CSharpRepl.Logging;
 

--- a/CSharpRepl/Logging/TraceLogger.cs
+++ b/CSharpRepl/Logging/TraceLogger.cs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using CSharpRepl.Services.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CSharpRepl.Services.Logging;
 
 namespace CSharpRepl.Logging;
 

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -26,15 +26,15 @@ internal static class Program
 {
     internal static async Task<int> Main(string[] args)
     {
+        Console.InputEncoding = Encoding.UTF8;
+        Console.OutputEncoding = Encoding.UTF8;
+
         var console = new SystemConsoleEx();
         var appStorage = CreateApplicationStorageDirectory();
         var configFile = Path.Combine(appStorage, "config.rsp");
 
         if (!TryParseArguments(args, configFile, out var config))
             return ExitCodes.ErrorParseArguments;
-
-        if (config.UseUnicode)
-            Console.OutputEncoding = Encoding.UTF8;
 
         if (config.OutputForEarlyExit.Text is not null)
         {

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -14,6 +14,7 @@ using CSharpRepl.Services.Logging;
 using CSharpRepl.Services.Roslyn;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
+using Spectre.Console;
 
 namespace CSharpRepl;
 
@@ -25,7 +26,7 @@ internal static class Program
 {
     internal static async Task<int> Main(string[] args)
     {
-        var console = new SystemConsole();
+        var console = new SystemConsoleEx();
         var appStorage = CreateApplicationStorageDirectory();
         var configFile = Path.Combine(appStorage, "config.rsp");
 
@@ -104,7 +105,7 @@ internal static class Program
         return TraceLogger.Create($"csharprepl-tracelog-{DateTime.UtcNow:yyyy-MM-dd}.txt");
     }
 
-    private static (Prompt? prompt, int exitCode) InitializePrompt(SystemConsole console, string appStorage, RoslynServices roslyn, Configuration config)
+    private static (Prompt? prompt, int exitCode) InitializePrompt(IConsoleEx console, string appStorage, RoslynServices roslyn, Configuration config)
     {
         try
         {
@@ -118,7 +119,8 @@ internal static class Program
                    completionItemDescriptionPaneBackground: config.Theme.GetCompletionItemDescriptionPaneBackground(),
                    selectedCompletionItemBackground: config.Theme.GetSelectedCompletionItemBackgroundColor(),
                    selectedTextBackground: config.Theme.GetSelectedTextBackground(),
-                   tabSize: config.TabSize));
+                   tabSize: config.TabSize),
+               console: console);
             return (prompt, ExitCodes.Success);
         }
         catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 87", StringComparison.Ordinal))

--- a/CSharpRepl/Program.cs
+++ b/CSharpRepl/Program.cs
@@ -29,7 +29,7 @@ internal static class Program
         Console.InputEncoding = Encoding.UTF8;
         Console.OutputEncoding = Encoding.UTF8;
 
-        var console = new SystemConsoleEx();
+        IConsoleEx console = new SystemConsoleEx();
         var appStorage = CreateApplicationStorageDirectory();
         var configFile = Path.Combine(appStorage, "config.rsp");
 
@@ -120,7 +120,7 @@ internal static class Program
                    selectedCompletionItemBackground: config.Theme.GetSelectedCompletionItemBackgroundColor(),
                    selectedTextBackground: config.Theme.GetSelectedTextBackground(),
                    tabSize: config.TabSize),
-               console: console);
+               console: console.PrettyPromptConsole);
             return (prompt, ExitCodes.Success);
         }
         catch (InvalidOperationException ex) when (ex.Message.EndsWith("error code: 87", StringComparison.Ordinal))

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -23,9 +23,9 @@ internal sealed class ReadEvalPrintLoop
 {
     private readonly RoslynServices roslyn;
     private readonly IPrompt prompt;
-    private readonly IConsole console;
+    private readonly IConsoleEx console;
 
-    public ReadEvalPrintLoop(RoslynServices roslyn, IPrompt prompt, IConsole console)
+    public ReadEvalPrintLoop(RoslynServices roslyn, IPrompt prompt, IConsoleEx console)
     {
         this.roslyn = roslyn;
         this.prompt = prompt;
@@ -83,7 +83,7 @@ internal sealed class ReadEvalPrintLoop
         }
     }
 
-    private static async Task Preload(RoslynServices roslyn, IConsole console, Configuration config)
+    private static async Task Preload(RoslynServices roslyn, IConsoleEx console, Configuration config)
     {
         bool hasReferences = config.References.Count > 0;
         bool hasLoadScript = config.LoadScript is not null;
@@ -109,7 +109,7 @@ internal sealed class ReadEvalPrintLoop
         }
     }
 
-    private static async Task PrintAsync(RoslynServices roslyn, IConsole console, EvaluationResult result, bool displayDetails)
+    private static async Task PrintAsync(RoslynServices roslyn, IConsoleEx console, EvaluationResult result, bool displayDetails)
     {
         switch (result)
         {

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -12,6 +12,7 @@ using CSharpRepl.Services.Roslyn.Scripting;
 using PrettyPrompt;
 using PrettyPrompt.Consoles;
 using PrettyPrompt.Highlighting;
+using Spectre.Console;
 
 namespace CSharpRepl;
 
@@ -117,16 +118,15 @@ internal sealed class ReadEvalPrintLoop
                 if (ok.ReturnValue.HasValue)
                 {
                     var formatted = await roslyn.PrettyPrintAsync(ok.ReturnValue.Value, displayDetails);
-                    console.WriteLine(formatted);
+                    console.Write(formatted.ToParagraph());
                 }
-                else
-                {
-                    console.WriteLine("");
-                }
+                console.WriteLine();
                 break;
             case EvaluationResult.Error err:
                 var formattedError = await roslyn.PrettyPrintAsync(err.Exception, displayDetails);
-                console.WriteErrorLine(formattedError);
+
+                console.WriteError(formattedError.ToParagraph(), formattedError.ToString());
+                console.WriteLine();
                 break;
             case EvaluationResult.Cancelled:
                 console.WriteErrorLine(


### PR DESCRIPTION
Allows using Spectre.Console for output rendering.

- Loading theme colors also to Spectre Color.
- StyledString/StyledStringSegment/StyledStringBuilder (Spectre analogues of FormattedString)
- IConsoleEx (implements both PrettyPrompt IConsole and Spectre IAnsiConsole).
- Rewritten object formatter from FormattedString to StyledString.
- Upgrade of nuget packages.