### PR TITLE
Attempt to fix race condition in tests.

### DIFF
--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -20,15 +20,18 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
     private readonly DotnetBuilder builder;
     private readonly IConsoleEx console;
 
-    public SolutionFileMetadataResolver(DotnetBuilder builder, IConsoleEx console)
+    static SolutionFileMetadataResolver()
     {
-        this.builder = builder;
-        this.console = console;
-
         if (!MSBuildLocator.IsRegistered)
         {
             _ = MSBuildLocator.RegisterDefaults();
         }
+    }
+
+    public SolutionFileMetadataResolver(DotnetBuilder builder, IConsoleEx console)
+    {
+        this.builder = builder;
+        this.console = console;
     }
 
     public override bool CanResolve(string reference) =>


### PR DESCRIPTION
Run dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
Build started 1/3/2023 9:24:30 AM.
     1>Project "D:\a\CSharpRepl\CSharpRepl\CSharpRepl.sln" on node 1 (VSTest target(s)).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Debug|Any CPU".
Test run for D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Tests\bin\Debug\net7.0\CSharpRepl.Tests.dll (.NETCoreApp,Version=v7.0)
Microsoft (R) Test Execution Command Line Tool Version 17.4.0 (x[6](https://github.com/waf/CSharpRepl/actions/runs/3828276141/jobs/6513681107#step:6:7)4)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:11.28]     CSharpRepl.Tests.CompletionTests.Complete_GetDescriptionAfterDot [FAIL]
[xUnit.net 00:00:11.29]     CSharpRepl.Tests.CompletionTests.Complete_GetDescriptionForShorterCompletion [FAIL]
[xUnit.net 00:00:11.29]     CSharpRepl.Tests.CompletionTests.Complete_SyntaxHighlight_CachesAreIsolated [FAIL]
[xUnit.net 00:00:11.29]     CSharpRepl.Tests.CompletionTests.Complete_GivenLinq_ReturnsCompletions [FAIL]
[xUnit.net 00:00:11.29]     CSharpRepl.Tests.CompletionTests.Complete_GivenCode_ReturnsCompletions [FAIL]
  Failed CSharpRepl.Tests.CompletionTests.Complete_GetDescriptionAfterDot [1 ms]
  Error Message:
   System.InvalidOperationException : Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
This dependency arises from when a method is just-in-time compiled, so if it breaks even if the reference to a Microsoft.Build type has not been executed.
For more details, see aka.ms/RegisterMSBuildLocator
Loaded MSBuild assemblies: 
  Stack Trace:
     at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String[] msbuildSearchPaths)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String msbuildPath)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at CSharpRepl.Services.Roslyn.MetadataResolvers.SolutionFileMetadataResolver..ctor(DotnetBuilder builder, IConsoleEx console) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\MetadataResolvers\SolutionFileMetadataResolver.cs:line 30
   at CSharpRepl.Services.Roslyn.Scripting.ScriptRunner..ctor(WorkspaceManager workspaceManager, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsoleEx console, Configuration configuration) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\Scripting\ScriptRunner.cs:line 49
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass16_1.<.ctor>b__1() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 84
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass30_0.<<WarmUpAsync>b__0>d.MoveNext() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 336
--- End of stack trace from previous location ---
  Failed CSharpRepl.Tests.CompletionTests.Complete_GetDescriptionForShorterCompletion [1 ms]
  Error Message:
   System.InvalidOperationException : Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
This dependency arises from when a method is just-in-time compiled, so if it breaks even if the reference to a Microsoft.Build type has not been executed.
For more details, see aka.ms/RegisterMSBuildLocator
Loaded MSBuild assemblies: 
  Stack Trace:
     at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String[] msbuildSearchPaths)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String msbuildPath)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at CSharpRepl.Services.Roslyn.MetadataResolvers.SolutionFileMetadataResolver..ctor(DotnetBuilder builder, IConsoleEx console) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\MetadataResolvers\SolutionFileMetadataResolver.cs:line 30
   at CSharpRepl.Services.Roslyn.Scripting.ScriptRunner..ctor(WorkspaceManager workspaceManager, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsoleEx console, Configuration configuration) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\Scripting\ScriptRunner.cs:line 49
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass16_1.<.ctor>b__1() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 84
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass30_0.<<WarmUpAsync>b__0>d.MoveNext() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 336
--- End of stack trace from previous location ---
  Failed CSharpRepl.Tests.CompletionTests.Complete_SyntaxHighlight_CachesAreIsolated [1 ms]
  Error Message:
   System.InvalidOperationException : Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
This dependency arises from when a method is just-in-time compiled, so if it breaks even if the reference to a Microsoft.Build type has not been executed.
For more details, see aka.ms/RegisterMSBuildLocator
Loaded MSBuild assemblies: 
  Stack Trace:
     at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String[] msbuildSearchPaths)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String msbuildPath)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at CSharpRepl.Services.Roslyn.MetadataResolvers.SolutionFileMetadataResolver..ctor(DotnetBuilder builder, IConsoleEx console) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\MetadataResolvers\SolutionFileMetadataResolver.cs:line 30
   at CSharpRepl.Services.Roslyn.Scripting.ScriptRunner..ctor(WorkspaceManager workspaceManager, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsoleEx console, Configuration configuration) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\Scripting\ScriptRunner.cs:line 49
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass16_1.<.ctor>b__1() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 84
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass30_0.<<WarmUpAsync>b__0>d.MoveNext() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 336
--- End of stack trace from previous location ---
  Failed CSharpRepl.Tests.CompletionTests.Complete_GivenLinq_ReturnsCompletions [1 ms]
  Error Message:
   System.InvalidOperationException : Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
This dependency arises from when a method is just-in-time compiled, so if it breaks even if the reference to a Microsoft.Build type has not been executed.
For more details, see aka.ms/RegisterMSBuildLocator
Loaded MSBuild assemblies: 
  Stack Trace:
     at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String[] msbuildSearchPaths)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String msbuildPath)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at CSharpRepl.Services.Roslyn.MetadataResolvers.SolutionFileMetadataResolver..ctor(DotnetBuilder builder, IConsoleEx console) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\MetadataResolvers\SolutionFileMetadataResolver.cs:line 30
   at CSharpRepl.Services.Roslyn.Scripting.ScriptRunner..ctor(WorkspaceManager workspaceManager, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsoleEx console, Configuration configuration) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\Scripting\ScriptRunner.cs:line 49
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass16_1.<.ctor>b__1() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 84
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass30_0.<<WarmUpAsync>b__0>d.MoveNext() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 336
--- End of stack trace from previous location ---
  Failed CSharpRepl.Tests.CompletionTests.Complete_GivenCode_ReturnsCompletions [1 ms]
  Error Message:
   System.InvalidOperationException : Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
This dependency arises from when a method is just-in-time compiled, so if it breaks even if the reference to a Microsoft.Build type has not been executed.
For more details, see aka.ms/RegisterMSBuildLocator
Loaded MSBuild assemblies: 
  Stack Trace:
     at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String[] msbuildSearchPaths)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(String msbuildPath)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at CSharpRepl.Services.Roslyn.MetadataResolvers.SolutionFileMetadataResolver..ctor(DotnetBuilder builder, IConsoleEx console) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\MetadataResolvers\SolutionFileMetadataResolver.cs:line 30
   at CSharpRepl.Services.Roslyn.Scripting.ScriptRunner..ctor(WorkspaceManager workspaceManager, CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, IConsoleEx console, Configuration configuration) in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\Scripting\ScriptRunner.cs:line 49
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass16_1.<.ctor>b__1() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 84
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at CSharpRepl.Services.Roslyn.RoslynServices.<>c__DisplayClass30_0.<<WarmUpAsync>b__0>d.MoveNext() in D:\a\CSharpRepl\CSharpRepl\CSharpRepl.Services\Roslyn\RoslynServices.cs:line 336
--- End of stack trace from previous location ---

Failed!  - Failed:     5, Passed:   226, Skipped:     0, Total:   231, Duration: 4 m 29 s - CSharpRepl.Tests.dll (net[7](https://github.com/waf/CSharpRepl/actions/runs/3828276141/jobs/6513681107#step:6:8).0)
     1>Done Building Project "D:\a\CSharpRepl\CSharpRepl\CSharpRepl.sln" (VSTest target(s)) -- FAILED.

Build FAILED.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:04:[43](https://github.com/waf/CSharpRepl/actions/runs/3828276141/jobs/6513681107#step:6:44).01
Error: Process completed with exit code 1.