### PR TITLE
Custom object formatters

### DIFF
--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -62,11 +62,10 @@ internal sealed class AutoCompleteService
             if (item.Tags.Length > 0)
             {
                 var classification = RoslynExtensions.TextTagToClassificationTypeName(item.Tags.First());
-                if (classification is not null &&
-                    highlighter.TryGetAnsiColor(classification, out var color))
+                if (highlighter.TryGetFormat(classification, out var format))
                 {
                     var prefix = GetCompletionItemSymbolPrefix(classification, configuration.UseUnicode);
-                    return new FormattedString($"{prefix}{text}", new FormatSpan(prefix.Length, text.Length, new ConsoleFormat(Foreground: color)));
+                    return new FormattedString($"{prefix}{text}", new FormatSpan(prefix.Length, text.Length, format));
                 }
             }
             return text;
@@ -115,10 +114,9 @@ internal sealed class AutoCompleteService
         foreach (var taggedText in description.TaggedParts)
         {
             var classification = RoslynExtensions.TextTagToClassificationTypeName(taggedText.Tag);
-            if (classification is not null &&
-                highlighter.TryGetAnsiColor(classification, out var color))
+            if (highlighter.TryGetFormat(classification, out var format))
             {
-                stringBuilder.Append(taggedText.Text, new FormatSpan(0, taggedText.Text.Length, new ConsoleFormat(Foreground: color)));
+                stringBuilder.Append(taggedText.Text, new FormatSpan(0, taggedText.Text.Length, format));
             }
             else
             {

--- a/CSharpRepl.Services/Extensions/MiscExtensions.cs
+++ b/CSharpRepl.Services/Extensions/MiscExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace CSharpRepl.Services.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CSharpRepl.Services.Extensions;
 
 internal static class MiscExtensions
 {
@@ -14,6 +16,21 @@ internal static class MiscExtensions
         {
             value = default;
             return false;
+        }
+    }
+
+    public static bool TryGet<T>(this T? nullableValue, [MaybeNullWhen(false)] out T value)
+        where T : class
+    {
+        if (nullableValue is null)
+        {
+            value = null;
+            return false;
+        }
+        else
+        {
+            value = nullableValue;
+            return true;
         }
     }
 }

--- a/CSharpRepl.Services/Roslyn/CustomObjectFormatters/CustomObjectFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/CustomObjectFormatters/CustomObjectFormatter.cs
@@ -1,0 +1,45 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using CSharpRepl.Services.Theming;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+
+namespace CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+
+internal interface ICustomObjectFormatter
+{
+    bool IsApplicable(object? value);
+    StyledString Format(object? value, int level, CommonObjectFormatter.Visitor visitor);
+}
+
+internal abstract class CustomObjectFormatter : ICustomObjectFormatter
+{
+    public bool IsApplicable(object? value)
+    {
+        if (value is null) return true;
+        return value.GetType().IsAssignableTo(Type);
+    }
+
+    public abstract Type Type { get; }
+
+    StyledString ICustomObjectFormatter.Format(object? value, int level, CommonObjectFormatter.Visitor visitor)
+    {
+        if (value is null) return new StyledString("null", visitor.SyntaxHighlighter.KeywordStyle);
+        return Format(value, level, visitor);
+    }
+
+    protected abstract StyledString Format(object value, int level, CommonObjectFormatter.Visitor visitor);
+}
+
+internal abstract class CustomObjectFormatter<T> : CustomObjectFormatter
+    where T : notnull
+{
+    public override Type Type => typeof(T);
+
+    protected override StyledString Format(object value, int level, CommonObjectFormatter.Visitor visitor)
+        => Format((T)value, level, visitor);
+
+    public abstract StyledString Format(T value, int level, CommonObjectFormatter.Visitor visitor);
+}

--- a/CSharpRepl.Services/Roslyn/CustomObjectFormatters/MethodInfoFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/CustomObjectFormatters/MethodInfoFormatter.cs
@@ -1,0 +1,97 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Linq;
+using System.Reflection;
+using CSharpRepl.Services.Theming;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+
+namespace CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+
+internal class MethodInfoFormatter : CustomObjectFormatter<MethodInfo>
+{
+    public static readonly MethodInfoFormatter Instance = new();
+
+    private MethodInfoFormatter() { }
+
+    public override StyledString Format(MethodInfo value, int level, CommonObjectFormatter.Visitor visitor)
+    {
+        var methodNameStyle = visitor.SyntaxHighlighter.GetStyle(ClassificationTypeNames.MethodName);
+        var typeFormatter = TypeFormatter.InstanceWithForcedUsageOfLanguageKeywords;
+
+        var sb = new StyledStringBuilder();
+        if (level == 0)
+        {
+            var modifiers = string.Join(" ", ReflectionHelpers.GetModifiers(value));
+            sb.Append(modifiers, visitor.SyntaxHighlighter.KeywordStyle)
+              .Append(' ');
+            AppendReturnType(level + 1).Append(' ');
+
+            sb.Append(value.Name, methodNameStyle);
+
+            if (value.IsGenericMethod)
+            {
+                sb.Append('<');
+                foreach (var a in value.GetGenericArguments())
+                {
+                    sb.Append(typeFormatter.Format(a, level, visitor));
+                }
+                sb.Append('>');
+            }
+
+            sb.Append('(');
+            var parameters = value.GetParameters();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var p = parameters[i];
+                sb.Append(typeFormatter.Format(p.ParameterType, level, visitor))
+                  .Append(' ')
+                  .Append(p.Name);
+                if (i != parameters.Length - 1) sb.Append(", ");
+            }
+            sb.Append(')');
+        }
+        else if (level == 1)
+        {
+            AppendReturnType(level + 1).Append(' ');
+
+            sb.Append(value.Name.Split('.').Last(), methodNameStyle);
+
+            if (value.IsGenericMethod)
+            {
+                sb.Append('<');
+                foreach (var a in value.GetGenericArguments())
+                {
+                    sb.Append(typeFormatter.Format(a, level + 1, visitor));
+                }
+                sb.Append('>');
+            }
+
+            sb.Append('(');
+            var parameters = value.GetParameters();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var p = parameters[i];
+                sb.Append(typeFormatter.Format(p.ParameterType, level + 1, visitor));
+                if (i != parameters.Length - 1) sb.Append(", ");
+            }
+            sb.Append(')');
+        }
+        else
+        {
+            sb.Append(value.Name.Split('.').Last(), methodNameStyle);
+        }
+
+        return sb.ToStyledString();
+
+        StyledStringBuilder AppendReturnType(int level)
+        {
+            return
+                value.ReturnType == typeof(void) ?
+                sb.Append(new StyledString("void", visitor.SyntaxHighlighter.KeywordStyle)) :
+                sb.Append(typeFormatter.Format(value.ReturnType, level, visitor));
+        }
+    }
+}

--- a/CSharpRepl.Services/Roslyn/CustomObjectFormatters/ReflectionHelpers.cs
+++ b/CSharpRepl.Services/Roslyn/CustomObjectFormatters/ReflectionHelpers.cs
@@ -1,0 +1,26 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+
+internal static class ReflectionHelpers
+{
+    public static IEnumerable<string> GetModifiers(MethodInfo methodInfo)
+    {
+        if (methodInfo.IsPrivate) yield return "private";
+        else if (methodInfo.IsFamily) yield return "protected";
+        else if (methodInfo.IsFamilyOrAssembly) yield return "protected internal";
+        else if (methodInfo.IsFamilyAndAssembly) yield return "private protected";
+        else if (methodInfo.IsAssembly) yield return "internal";
+        else if (methodInfo.IsPublic) yield return "public";
+
+        if (methodInfo.IsStatic) yield return "static";
+
+        if (methodInfo.IsAbstract) yield return "abstract";
+        else if (methodInfo.IsVirtual) yield return "virtual";
+    }
+}

--- a/CSharpRepl.Services/Roslyn/CustomObjectFormatters/TypeFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/CustomObjectFormatters/TypeFormatter.cs
@@ -1,0 +1,32 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using CSharpRepl.Services.Theming;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+
+namespace CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+
+internal class TypeFormatter : CustomObjectFormatter<Type>
+{
+    public static readonly TypeFormatter Instance = new(forceUsageOfLanguageKeywords: false);
+    public static readonly TypeFormatter InstanceWithForcedUsageOfLanguageKeywords = new(forceUsageOfLanguageKeywords: true);
+
+    private readonly bool forceUsageOfLanguageKeywords;
+
+    private TypeFormatter(bool forceUsageOfLanguageKeywords)
+    {
+        this.forceUsageOfLanguageKeywords = forceUsageOfLanguageKeywords;
+    }
+
+    public override StyledString Format(Type value, int level, CommonObjectFormatter.Visitor visitor)
+    {
+        return visitor.TypeNameFormatter.FormatTypeName(
+            value,
+            new CommonTypeNameFormatterOptions(
+                arrayBoundRadix: visitor.TypeNameOptions.ArrayBoundRadix,
+                showNamespaces: level == 0,
+                useLanguageKeywords: forceUsageOfLanguageKeywords || level > 0));
+    }
+}

--- a/CSharpRepl.Services/Roslyn/DocumentationComment.cs
+++ b/CSharpRepl.Services/Roslyn/DocumentationComment.cs
@@ -438,17 +438,16 @@ internal sealed class DocumentationComment
                 return false;
             }
 
-            var format = SymbolDisplayFormat.MinimallyQualifiedFormat
+            var displayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat
                 .RemoveMemberOptions(SymbolDisplayMemberOptions.IncludeType)
                 .RemoveKindOptions(SymbolDisplayKindOptions.IncludeMemberKeyword);
-            foreach (var part in symbol.ToDisplayParts(format))
+            foreach (var part in symbol.ToDisplayParts(displayFormat))
             {
                 var partText = part.ToString();
                 var classification = RoslynExtensions.SymbolDisplayPartKindToClassificationTypeName(part.Kind);
-                if (classification is not null &&
-                    highlighter.TryGetAnsiColor(classification, out var color))
+                if (highlighter.TryGetFormat(classification, out var format))
                 {
-                    text.Append(partText, new ConsoleFormat(color));
+                    text.Append(partText, format);
                 }
                 else
                 {

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.CSharp.Scripting.Hosting/CSharpPrimitiveFormatter.cs
@@ -21,8 +21,8 @@ internal class CSharpPrimitiveFormatter : CommonPrimitiveFormatter
 
     public CSharpPrimitiveFormatter(SyntaxHighlighter highlighter)
     {
-        numericLiteralFormat = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.NumericLiteral));
-        stringLiteralFormat = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.StringLiteral));
+        numericLiteralFormat = highlighter.GetStyle(ClassificationTypeNames.NumericLiteral);
+        stringLiteralFormat = highlighter.GetStyle(ClassificationTypeNames.StringLiteral);
         NullLiteral = new StyledStringSegment("null", highlighter.KeywordStyle);
         this.highlighter = highlighter;
     }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Builder.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Builder.cs
@@ -6,6 +6,7 @@
 
 using System;
 using CSharpRepl.Services.Theming;
+using Spectre.Console;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -68,7 +69,7 @@ internal abstract partial class CommonObjectFormatter
             _sb.Append(ellipsis);
         }
 
-        public void Append(char c, int count = 1)
+        public void Append(char c, int count = 1, Style style = null)
         {
             if (CurrentRemaining < 0)
             {
@@ -79,7 +80,7 @@ internal abstract partial class CommonObjectFormatter
 
             for (int i = 0; i < length; i++)
             {
-                _sb.Append(c);
+                _sb.Append(c, style);
             }
 
             if (!_suppressEllipsis && length < count)
@@ -87,6 +88,9 @@ internal abstract partial class CommonObjectFormatter
                 AppendEllipsis();
             }
         }
+
+        public void Append(string str, int start = 0, int count = Int32.MaxValue, Style style = null)
+            => Append(new StyledString(str, style), start, count);
 
         public void Append(StyledString str, int start = 0, int count = Int32.MaxValue)
         {

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Exceptions.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Exceptions.cs
@@ -10,7 +10,6 @@ using System.Text.RegularExpressions;
 using CSharpRepl.Services.SyntaxHighlighting;
 using CSharpRepl.Services.Theming;
 using Microsoft.CodeAnalysis.Classification;
-using Spectre.Console;
 
 namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
@@ -103,22 +102,22 @@ file class CommonObjectFormatterException
                 if (string.IsNullOrEmpty(method.SubMethod) && !method.IsLambda)
                     builder.Append("new ", highlighter.KeywordStyle);
 
-                CommonObjectFormatterException.AppendType(builder, method.DeclaringType, highlighter);
+                AppendType(builder, method.DeclaringType, highlighter);
             }
             else if (method.Name == ".cctor")
             {
                 builder.Append("static ", highlighter.KeywordStyle);
-                CommonObjectFormatterException.AppendType(builder, method.DeclaringType, highlighter);
+                AppendType(builder, method.DeclaringType, highlighter);
             }
             else
             {
                 var builderLengthBefore = builder.Length;
-                CommonObjectFormatterException.AppendType(builder, method.DeclaringType, highlighter);
+                AppendType(builder, method.DeclaringType, highlighter);
                 if (builderLengthBefore < builder.Length) builder.Append(".");
 
                 if (method.Name != null)
                 {
-                    builder.Append(method.Name, new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.MethodName)));
+                    builder.Append(method.Name, highlighter.GetStyle(ClassificationTypeNames.MethodName));
                 }
             }
         }
@@ -227,7 +226,7 @@ file class CommonObjectFormatterException
             if (!string.IsNullOrEmpty(parameter.Name))
             {
                 sb.Append(" ")
-                  .Append(parameter.Name, new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.ParameterName)));
+                  .Append(parameter.Name, highlighter.GetStyle(ClassificationTypeNames.ParameterName));
             }
 
             return sb;
@@ -315,7 +314,7 @@ file class CommonObjectFormatterException
                 {
                     if (options.IncludeGenericParameterNames)
                     {
-                        builder.Append(type.Name, new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.TypeParameterName)));
+                        builder.Append(type.Name, highlighter.GetStyle(ClassificationTypeNames.TypeParameterName));
                     }
                 }
                 else

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.FormattedMember.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.FormattedMember.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
 internal abstract partial class CommonObjectFormatter
 {
-    private sealed partial class Visitor
+    internal sealed partial class Visitor
     {
         private readonly struct FormattedMember
         {

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonObjectFormatter.Visitor.cs
@@ -485,8 +485,8 @@ internal abstract partial class CommonObjectFormatter
                     {
                         var classification = RoslynExtensions.MemberTypeToClassificationTypeName(member.MemberType);
                         var prefix = AutoCompleteService.GetCompletionItemSymbolPrefix(classification, _config.UseUnicode);
-                        var color = _syntaxHighlighter.GetSpectreColor(classification);
-                        name = new StyledString(new StyledStringSegment[] { prefix, new StyledStringSegment(member.Name, new Style(foreground: color)) });
+                        var style = _syntaxHighlighter.GetStyle(classification);
+                        name = new StyledString(new StyledStringSegment[] { prefix, new StyledStringSegment(member.Name, style) });
                     }
                     else
                     {

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatter.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatter.cs
@@ -40,10 +40,10 @@ internal abstract partial class CommonTypeNameFormatter
     public static Style GetTypeStyle(Type type, SyntaxHighlighter highlighter)
     {
         Style format;
-        if (type.IsValueType) format = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.StructName));
-        else if (type.IsInterface) format = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.InterfaceName));
-        else if (type.IsSubclassOf(typeof(Delegate))) format = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.DelegateName));
-        else format = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.ClassName));
+        if (type.IsValueType) format = highlighter.GetStyle(ClassificationTypeNames.StructName);
+        else if (type.IsInterface) format = highlighter.GetStyle(ClassificationTypeNames.InterfaceName);
+        else if (type.IsSubclassOf(typeof(Delegate))) format = highlighter.GetStyle(ClassificationTypeNames.DelegateName);
+        else format = highlighter.GetStyle(ClassificationTypeNames.ClassName);
         return format;
     }
 
@@ -63,7 +63,7 @@ internal abstract partial class CommonTypeNameFormatter
 
         if (type.IsGenericParameter)
         {
-            return new StyledString(type.Name, new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.TypeParameterName)));
+            return new StyledString(type.Name, highlighter.GetStyle(ClassificationTypeNames.TypeParameterName));
         }
 
         if (type.IsArray)
@@ -92,7 +92,7 @@ internal abstract partial class CommonTypeNameFormatter
                 null;
             namespaceParts ??= Array.Empty<string>();
 
-            var namespaceStyle = new Style(foreground: highlighter.GetSpectreColor(ClassificationTypeNames.NamespaceName));
+            var namespaceStyle = highlighter.GetStyle(ClassificationTypeNames.NamespaceName);
             for (int i = 0; i < namespaceParts.Length; i++)
             {
                 sb.Append(namespaceParts[i], namespaceStyle);

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatterOptions.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/CommonTypeNameFormatterOptions.cs
@@ -6,12 +6,14 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting;
 
 internal readonly struct CommonTypeNameFormatterOptions
 {
-    public int ArrayBoundRadix { get; }
-    public bool ShowNamespaces { get; }
+    public readonly int ArrayBoundRadix;
+    public readonly bool ShowNamespaces;
+    public readonly bool UseLanguageKeywords;
 
-    public CommonTypeNameFormatterOptions(int arrayBoundRadix, bool showNamespaces)
+    public CommonTypeNameFormatterOptions(int arrayBoundRadix, bool showNamespaces, bool useLanguageKeywords = true)
     {
         ArrayBoundRadix = arrayBoundRadix;
         ShowNamespaces = showNamespaces;
+        UseLanguageKeywords = useLanguageKeywords;
     }
 }

--- a/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/ObjectFormatterHelpers.cs
+++ b/CSharpRepl.Services/Roslyn/Microsoft.CodeAnalysis.Scripting.Hosting/ObjectFormatterHelpers.cs
@@ -18,7 +18,7 @@ using TypeInfo = System.Reflection.TypeInfo;
 
 internal static class ObjectFormatterHelpers
 {
-    internal static readonly object VoidValue = new object();
+    internal static readonly object VoidValue = new();
 
     internal const int NumberRadixDecimal = 10;
     internal const int NumberRadixHexadecimal = 16;

--- a/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
+++ b/CSharpRepl.Services/Roslyn/OverloadItemGenerator.cs
@@ -66,8 +66,7 @@ internal class OverloadItemGenerator
         {
             var partText = part.ToString();
             var classification = RoslynExtensions.SymbolDisplayPartKindToClassificationTypeName(part.Kind);
-            if (classification is not null &&
-                highlighter.TryGetAnsiColor(classification, out var color))
+            if (highlighter.TryGetAnsiColor(classification, out var color))
             {
                 bool bold = false;
                 if (currentArgumentSpan.Length > 0 &&

--- a/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/SyntaxHighlighter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.Services.Theming;
@@ -63,12 +64,40 @@ internal sealed class SyntaxHighlighter
         return highlighted;
     }
 
-    internal AnsiColor GetAnsiColor(string keyword) => theme.GetSyntaxHighlightingAnsiColor(keyword, unhighlightedAnsiColor);
-    internal bool TryGetAnsiColor(string keyword, out AnsiColor color) => theme.TryGetSyntaxHighlightingAnsiColor(keyword, out color);
+    public AnsiColor GetAnsiColor(string? classification) => theme.GetSyntaxHighlightingAnsiColor(classification, unhighlightedAnsiColor);
+    public bool TryGetAnsiColor(string? classification, out AnsiColor color) => theme.TryGetSyntaxHighlightingAnsiColor(classification, out color);
+    public ConsoleFormat GetFormat(string? classification) => new(Foreground: GetAnsiColor(classification));
+    public bool TryGetFormat(string? classification, out ConsoleFormat format)
+    {
+        if (theme.TryGetSyntaxHighlightingAnsiColor(classification, out var color))
+        {
+            format = new ConsoleFormat(Foreground: color);
+            return true;
+        }
+        else
+        {
+            format = ConsoleFormat.None;
+            return false;
+        }
+    }
 
-    internal Color GetSpectreColor(string keyword) => theme.GetSyntaxHighlightingSpectreColor(keyword, unhighlightedSpectreColor);
-    internal bool TryGetSpectreColor(string keyword, out Color color) => theme.TryGetSyntaxHighlightingSpectreColor(keyword, out color);
+    public Color GetSpectreColor(string? classification) => theme.GetSyntaxHighlightingSpectreColor(classification, unhighlightedSpectreColor);
+    public bool TryGetSpectreColor(string? classification, out Color color) => theme.TryGetSyntaxHighlightingSpectreColor(classification, out color);
+    public Style GetStyle(string? classification) => new(foreground: GetSpectreColor(classification));
+    public bool TryGetStyle(string? classification, [NotNullWhen(true)] out Style? style)
+    {
+        if (theme.TryGetSyntaxHighlightingSpectreColor(classification, out var color))
+        {
+            style = new Style(foreground: color);
+            return true;
+        }
+        else
+        {
+            style = null;
+            return false;
+        }
+    }
 
-    public Style KeywordStyle => new(foreground: GetSpectreColor(ClassificationTypeNames.Keyword));
-    public ConsoleFormat KeywordFormat => new(Foreground: GetAnsiColor(ClassificationTypeNames.Keyword));
+    public Style KeywordStyle => GetStyle(ClassificationTypeNames.Keyword);
+    public ConsoleFormat KeywordFormat => GetFormat(ClassificationTypeNames.Keyword);
 }

--- a/CSharpRepl.Services/Theming/StyledStringBuilder.cs
+++ b/CSharpRepl.Services/Theming/StyledStringBuilder.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
 using System.Collections.Generic;
 using Spectre.Console;
 
@@ -30,6 +31,11 @@ public sealed class StyledStringBuilder
         }
     }
 
+    //string has implicit conversion to Style which is not desirable here
+    [Obsolete("Do not use this overload. You need to pass Style object and not string implicitly parsed to Style.")]
+    public StyledStringBuilder(string? text, string style)
+        => throw new NotSupportedException();
+
     public StyledStringBuilder Append(string? text, Style? style = null)
     {
         if (text != null)
@@ -38,6 +44,11 @@ public sealed class StyledStringBuilder
         }
         return this;
     }
+
+    //string has implicit conversion to Style which is not desirable here
+    [Obsolete("Do not use this overload. You need to pass Style object and not string implicitly parsed to Style.")]
+    public StyledStringBuilder Append(string? text, string style)
+        => throw new NotSupportedException();
 
     public StyledStringBuilder Append(char c, Style? style = null)
     {

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -109,11 +109,35 @@ public sealed class Theme
         syntaxHighlightingSpectreColorsDictionary = syntaxHighlightingColors.ToDictionary(c => c.Name, c => new ThemeColor(c.Foreground).ToSpectreColor());
     }
 
-    public AnsiColor? GetSyntaxHighlightingAnsiColor(string name) => TryGetSyntaxHighlightingAnsiColor(name, out var color) ? color : null;
-    public AnsiColor GetSyntaxHighlightingAnsiColor(string name, AnsiColor defaultValue) => syntaxHighlightingAnsiColorsDictionary.GetValueOrDefault(name, defaultValue);
-    public bool TryGetSyntaxHighlightingAnsiColor(string name, out AnsiColor color) => syntaxHighlightingAnsiColorsDictionary.TryGetValue(name, out color);
+    public AnsiColor? GetSyntaxHighlightingAnsiColor(string? classification)
+        => TryGetSyntaxHighlightingAnsiColor(classification, out var color) ? color : null;
 
-    public Color? GetSyntaxHighlightingSpectreColor(string name) => TryGetSyntaxHighlightingSpectreColor(name, out var color) ? color : null;
-    public Color GetSyntaxHighlightingSpectreColor(string name, Color defaultValue) => syntaxHighlightingSpectreColorsDictionary.GetValueOrDefault(name, defaultValue);
-    public bool TryGetSyntaxHighlightingSpectreColor(string name, out Color color) => syntaxHighlightingSpectreColorsDictionary.TryGetValue(name, out color);
+    public AnsiColor GetSyntaxHighlightingAnsiColor(string? classification, AnsiColor defaultValue)
+        => classification is null ? default : syntaxHighlightingAnsiColorsDictionary.GetValueOrDefault(classification, defaultValue);
+
+    public bool TryGetSyntaxHighlightingAnsiColor(string? classification, out AnsiColor color)
+    {
+        if (classification is null)
+        {
+            color = default;
+            return false;
+        }
+        return syntaxHighlightingAnsiColorsDictionary.TryGetValue(classification, out color);
+    }
+
+    public Color? GetSyntaxHighlightingSpectreColor(string? classification)
+        => TryGetSyntaxHighlightingSpectreColor(classification, out var color) ? color : null;
+
+    public Color GetSyntaxHighlightingSpectreColor(string? classification, Color defaultValue)
+        => classification is null ? default : syntaxHighlightingSpectreColorsDictionary.GetValueOrDefault(classification, defaultValue);
+
+    public bool TryGetSyntaxHighlightingSpectreColor(string? classification, out Color color)
+    {
+        if (classification is null)
+        {
+            color = default;
+            return false;
+        }
+        return syntaxHighlightingSpectreColorsDictionary.TryGetValue(classification, out color);
+    }
 }

--- a/CSharpRepl.Tests/CustomObjectFormatters/MethodInfoFormatterTests.cs
+++ b/CSharpRepl.Tests/CustomObjectFormatters/MethodInfoFormatterTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+public class MethodInfoFormatterTests
+{
+    private readonly TestFormatter formatter = TestFormatter.Create();
+
+    [Theory]
+    [MemberData(nameof(ParseStyleData))]
+    public void ExceptionCallstack(MethodInfo value, string expectedOutput_0, string expectedOutput_1, string expectedOutput_2)
+    {
+        Assert.Equal(expectedOutput_0, formatter.Format(MethodInfoFormatter.Instance, value, level: 0));
+        Assert.Equal(expectedOutput_1, formatter.Format(MethodInfoFormatter.Instance, value, level: 1));
+        Assert.Equal(expectedOutput_2, formatter.Format(MethodInfoFormatter.Instance, value, level: 2));
+    }
+
+    public static IEnumerable<object[]> ParseStyleData
+    {
+        get
+        {
+            Func<string, NumberStyles, IFormatProvider, int> intParse = int.Parse;
+            yield return new object[]
+            {
+                intParse.Method,
+                "public static int Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider provider)",
+                "int Parse(string, NumberStyles, IFormatProvider)",
+                "Parse"
+            };
+
+            yield return new object[]
+            {
+                typeof(Enum)
+                    .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                    .Single(m => m is { Name: "TryParse", IsGenericMethod: true } && m.GetParameters() is [{ ParameterType.Name: "ReadOnlySpan`1" }, { }]),
+                "public static bool TryParse<TEnum>(System.ReadOnlySpan<char> value, TEnum& result)",
+                "bool TryParse<TEnum>(ReadOnlySpan<char>, TEnum&)",
+                "TryParse"
+            };
+
+            yield return new object[]
+            {
+                typeof(TestClass)
+                    .GetMethod($"CSharpRepl.Tests.MethodInfoFormatterTests.ITestInterface.M", BindingFlags.Instance | BindingFlags.NonPublic),
+                "private virtual void CSharpRepl.Tests.MethodInfoFormatterTests.ITestInterface.M()",
+                "void M()",
+                "M"
+            };
+        }
+    }
+
+    private class TestClass : ITestInterface
+    {
+        void ITestInterface.M() { }
+    }
+
+    private interface ITestInterface
+    {
+        void M();
+    }
+}

--- a/CSharpRepl.Tests/CustomObjectFormatters/TestFormatter.cs
+++ b/CSharpRepl.Tests/CustomObjectFormatters/TestFormatter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+using CSharpRepl.Services.SyntaxHighlighting;
+using CSharpRepl.Services.Theming;
+using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.Extensions.Caching.Memory;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+internal class TestFormatter : CSharpObjectFormatterImpl
+{
+    private readonly Visitor visitor;
+
+    public TestFormatter(SyntaxHighlighter highlighter, Configuration config)
+        : base(highlighter, config)
+    {
+        var options = new PrintOptions();
+        visitor = new Visitor(this, TypeNameFormatter, GetInternalBuilderOptions(options), GetPrimitiveOptions(options), GetTypeNameOptions(options), options.MemberDisplayFormat, highlighter, config);
+    }
+
+    public string Format(ICustomObjectFormatter formatter, object value, int level)
+    {
+        Assert.True(formatter.IsApplicable(value));
+        return formatter.Format(value, level, visitor).ToString();
+    }
+
+    public static TestFormatter Create() => new(
+        new SyntaxHighlighter(
+            new MemoryCache(new MemoryCacheOptions()),
+            new Theme(null, null, null, null, Array.Empty<SyntaxHighlightingColor>())),
+        new Configuration());
+}

--- a/CSharpRepl.Tests/CustomObjectFormatters/TypeFormatterTests.cs
+++ b/CSharpRepl.Tests/CustomObjectFormatters/TypeFormatterTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using CSharpRepl.Services.Roslyn.CustomObjectFormatters;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+public class TypeFormatterTests
+{
+    private readonly TestFormatter formatter = TestFormatter.Create();
+
+    [Theory]
+    [InlineData(typeof(int), "System.Int32", "int")]
+    [InlineData(typeof(List<int>), "System.Collections.Generic.List<System.Int32>", "List<int>")]
+    [InlineData(typeof(Dictionary<int, List<Enum>>), "System.Collections.Generic.Dictionary<System.Int32, System.Collections.Generic.List<System.Enum>>", "Dictionary<int, List<Enum>>")]
+    public void ExceptionCallstack(Type value, string expectedOutput_0, string expectedOutput_1)
+    {
+        Assert.Equal(expectedOutput_0, formatter.Format(TypeFormatter.Instance, value, level: 0));
+        Assert.Equal(expectedOutput_1, formatter.Format(TypeFormatter.Instance, value, level: 1));
+    }
+}


### PR DESCRIPTION
Resolves #210.

We can now implement custom object formatters (CSharpRepl.Services\Roslyn\CustomObjectFormatters).

This PR implements:
1. API for simple adding of new formatters.
2. Custom formatters are aware of the level in the object tree for which formatting is requested (objects in root should have more details than those more nested).
3. Custom `Type` and `MethodInfo` formatter.
4. Unit tests for new custom formatters.
5. Improvements of general type name formatting in `CommonTypeNameFormatter`.

E.g. formatting of:
`typeof(int)`

OLD:
![image](https://user-images.githubusercontent.com/11704036/211121480-42b80411-d994-45e7-b21c-fbd53d44606f.png)

NEW:
![image](https://user-images.githubusercontent.com/11704036/211121554-2d86c117-d228-42c2-a8c6-c5507c546adb.png)
