### PR TITLE
Add initial proof-of-concept for OpenAI autocomplete

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.6" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.4" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionApiClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionApiClient.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Completion.OpenAI.ChatCompletionApi;
+
+/// <summary>
+/// Issue an API call to the "Chat Completion" API (GPT-series models)
+/// </summary>
+internal sealed class ChatCompletionApiClient : IOpenAIClient
+{
+    private readonly HttpClient httpClient;
+    private readonly JsonSerializerOptions jsonSerializerOptions;
+    private readonly OpenAIConfiguration configuration;
+    private const int CharacterToTokenEstimate = 3;
+
+    public bool EmitLeadingNewline => true;
+
+    public ChatCompletionApiClient(HttpClient httpClient, JsonSerializerOptions jsonSerializerOptions, OpenAIConfiguration configuration)
+    {
+        this.httpClient = httpClient;
+        this.jsonSerializerOptions = jsonSerializerOptions;
+        this.configuration = configuration;
+    }
+
+    public Task<HttpResponseMessage> IssueRequestAsync(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken)
+    {
+        int previousSubmissionCount;
+        int maxTokens = 0;
+        for (previousSubmissionCount = 5; maxTokens <= 0 || previousSubmissionCount == 0; previousSubmissionCount--)
+        {
+            maxTokens = 4097
+                - configuration.Prompt.Length / CharacterToTokenEstimate
+                - submissions.TakeLast(previousSubmissionCount).Sum(s => s.Length) / CharacterToTokenEstimate
+                - code.Length / CharacterToTokenEstimate;
+        }
+
+        if (maxTokens <= 0)
+        {
+            throw new OpenAIException("Prompt context exceeded! Too much code to send to OpenAI.");
+        }
+
+        var request = new ChatCompletionRequest
+        {
+            Model = configuration.Model,
+            Messages = new[] { new Message("system", configuration.Prompt), }
+                .Concat(submissions.TakeLast(previousSubmissionCount).Select(submission => new Message("user", submission)))
+                .Append(new Message("user", code))
+                .ToArray(),
+            MaxTokens = maxTokens,
+            Temperature = configuration.Temperature,
+            TopProbability = configuration.TopProbability,
+            Stream = true,
+            User = "CSharpRepl"
+        };
+
+        return httpClient.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", request, jsonSerializerOptions, cancellationToken);
+    }
+
+    public string? ParseLineToCompletion(string line) =>
+        JsonSerializer.Deserialize<ChatCompletionResponse>(line)?.Choices.FirstOrDefault()?.Delta?.Content;
+}

--- a/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionApiClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionApiClient.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -16,7 +22,7 @@ internal sealed class ChatCompletionApiClient : IOpenAIClient
     private readonly HttpClient httpClient;
     private readonly JsonSerializerOptions jsonSerializerOptions;
     private readonly OpenAIConfiguration configuration;
-    private const int CharacterToTokenEstimate = 3;
+    private const int CharacterToTokenEstimate = 2;
 
     public bool EmitLeadingNewline => true;
 

--- a/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionRequest.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionRequest.cs
@@ -1,0 +1,136 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Text.Json.Serialization;
+
+namespace CSharpRepl.Services.Completion.OpenAI.ChatCompletionApi;
+
+/// <summary>
+/// OpenAI Completion request - data for HTTP POST.
+/// Creates a completion for the provided prompt and parameters.
+/// https://platform.openai.com/docs/api-reference/completions/create
+/// </summary>
+internal sealed class ChatCompletionRequest
+{
+    /// <summary>
+    /// ID of the model to use. You can use the List models API to see all of your available models, or see our Model overview for descriptions of them.
+    /// </summary>
+    [JsonPropertyName("model")]
+    public required string Model { get; set; }
+
+    /// <summary>
+    /// The messages to generate chat completions for, in the chat format.
+    /// </summary>
+    [JsonPropertyName("messages")]
+    public required Message[] Messages { get; set; }
+
+    /// <summary>
+    /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more
+    /// random, while lower values like 0.2 will make it more focused and deterministic.
+    /// We generally recommend altering this or top_p but not both.
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public double? Temperature { get; set; }
+
+    /// <summary>
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the
+    /// results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10%
+    /// probability mass are considered. We generally recommend altering this or temperature but not both.
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public double? TopProbability { get; set; }
+
+    /// <summary>
+    /// How many completions to generate for each prompt.
+    /// Note: Because this parameter generates many completions, it can quickly consume your token quota.
+    /// Use carefully and ensure that you have reasonable settings for max_tokens and stop.
+    /// </summary>
+    [JsonPropertyName("n")]
+    public int? NCompletions { get; set; }
+
+    /// <summary>
+    /// Whether to stream back partial progress. If set, tokens will be sent as data-only server-sent
+    /// events as they become available, with the stream terminated by a data: [DONE] message.
+    /// </summary>
+    [JsonPropertyName("stream")]
+    public bool? Stream { get; set; }
+
+    /// <summary>
+    /// Up to 4 sequences where the API will stop generating further tokens. The returned text will not
+    /// contain the stop sequence.
+    /// </summary>
+    [JsonPropertyName("stop")]
+    public string[]? Stop { get; set; }
+
+    /// <summary>
+    /// The maximum number of tokens to generate in the completion.
+    /// The token count of your prompt plus max_tokens cannot exceed the model's context length.
+    /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
+    /// </summary>
+    [JsonPropertyName("max_tokens")]
+    public int? MaxTokens { get; set; }
+
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in
+    /// the text so far, increasing the model's likelihood to talk about new topics.
+    /// </summary>
+    [JsonPropertyName("presence_penalty")]
+    public int? PresencePenalty { get; set; }
+
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency
+    /// in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+    /// </summary>
+    [JsonPropertyName("frequency_penalty")]
+    public int? FrequencyPenalty { get; set; }
+
+    /// <summary>
+    /// Include the log probabilities on the logprobs most likely tokens, as well the chosen tokens.
+    /// For example, if logprobs is 5, the API will return a list of the 5 most likely tokens. The API
+    /// will always return the logprob of the sampled token, so there may be up to logprobs+1 elements
+    /// in the response.
+    ///
+    /// The maximum value for logprobs is 5. If you need more than this, please contact us through our
+    /// Help center and describe your use case.
+    /// </summary>
+    [JsonPropertyName("logprobs")]
+    public int? LogProbabilities { get; set; }
+
+    /// <summary>
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    ///
+    /// Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an
+    /// associated bias value from -100 to 100. You can use this tokenizer tool (which works for both
+    /// GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits
+    /// generated by the model prior to sampling. The exact effect will vary per model, but values
+    /// between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100
+    /// should result in a ban or exclusive selection of the relevant token.
+    ///
+    /// As an example, you can pass {"50256": -100} to prevent the <|endoftext|> token from being generated.
+    /// </summary>
+    [JsonPropertyName("logit_bias")]
+    public int? LogitBias { get; set; }
+
+    /// <summary>
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </summary>
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+}
+
+public sealed class Message
+{
+    public Message(string? role, string? content)
+    {
+        Role = role;
+        Content = content;
+    }
+
+    [JsonPropertyName("role")]
+    public string? Role { get; set; }
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionResponse.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/ChatCompletionApi/ChatCompletionResponse.cs
@@ -1,0 +1,45 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Text.Json.Serialization;
+
+namespace CSharpRepl.Services.Completion.OpenAI.ChatCompletionApi;
+
+public sealed class ChatCompletionResponse
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("choices")]
+    public required Choice[] Choices { get; set; }
+
+    [JsonPropertyName("object")]
+    public string? Object { get; set; }
+
+    [JsonPropertyName("created")]
+    public int Created { get; set; }
+
+    [JsonPropertyName("model")]
+    public string? Model { get; set; }
+
+    public sealed class Choice
+    {
+        [JsonPropertyName("delta")]
+        public required Delta Delta { get; set; }
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+        [JsonPropertyName("finish_reason")]
+        public string? FinishReason { get; set; }
+    }
+
+    public sealed class Delta
+    {
+        [JsonPropertyName("role")]
+        public string? Role { get; set; }
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+    }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionApiClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionApiClient.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Completion.OpenAI.CompletionApi;
+
+/// <summary>
+/// Issue an API call to the "Completion" API
+/// </summary>
+internal sealed class CompletionApiClient : IOpenAIClient
+{
+    private readonly HttpClient httpClient;
+    private readonly JsonSerializerOptions jsonSerializerOptions;
+    private readonly OpenAIConfiguration configuration;
+    private const int CharacterToTokenEstimate = 3;
+
+    public CompletionApiClient(HttpClient httpClient, JsonSerializerOptions jsonSerializerOptions, OpenAIConfiguration configuration)
+    {
+        this.httpClient = httpClient;
+        this.jsonSerializerOptions = jsonSerializerOptions;
+        this.configuration = configuration;
+    }
+
+    /// <summary>
+    /// By default, send 5 history entries to the API as context. However, if that's too long and we end up exceeding our token count, reduce the context.
+    /// </summary>
+    public Task<HttpResponseMessage> IssueRequestAsync(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken)
+    {
+        string currentCodePrefix = code[..caret];
+        string currentCodeSuffix = code[caret..];
+        string prompt = "";
+        int maxTokens = 0;
+        for (int previousSubmissionContextCount = 5; maxTokens <= 0 || previousSubmissionContextCount == 0; previousSubmissionContextCount--)
+        {
+            prompt = configuration.Prompt + "\n" + string.Join("\n", submissions.TakeLast(previousSubmissionContextCount)) + "\n" + currentCodePrefix;
+            maxTokens = 4097
+                - prompt.Length / CharacterToTokenEstimate
+                - currentCodeSuffix.Length / CharacterToTokenEstimate;
+        }
+
+        if (maxTokens <= 0)
+        {
+            throw new OpenAIException("Prompt context exceeded! Too much code to send to OpenAI.");
+        }
+
+        var request = new CompletionRequest
+        {
+            Model = configuration.Model,
+            Prompt = prompt,
+            Suffix = currentCodeSuffix,
+            MaxTokens = maxTokens,
+            Temperature = configuration.Temperature,
+            TopProbability = configuration.TopProbability,
+            Stream = true,
+            User = "CSharpRepl"
+        };
+
+        return httpClient.PostAsJsonAsync("https://api.openai.com/v1/completions", request, jsonSerializerOptions, cancellationToken);
+    }
+
+    public string? ParseLineToCompletion(string line) =>
+        JsonSerializer.Deserialize<CompletionResponse>(line)?.Choices.FirstOrDefault()?.Text;
+}

--- a/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionApiClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionApiClient.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -16,7 +22,8 @@ internal sealed class CompletionApiClient : IOpenAIClient
     private readonly HttpClient httpClient;
     private readonly JsonSerializerOptions jsonSerializerOptions;
     private readonly OpenAIConfiguration configuration;
-    private const int CharacterToTokenEstimate = 3;
+    private const int CharacterToTokenEstimate = 2;
+    private const int TokenLength = 4090; // a bit under to give us some leeway
 
     public CompletionApiClient(HttpClient httpClient, JsonSerializerOptions jsonSerializerOptions, OpenAIConfiguration configuration)
     {
@@ -37,7 +44,7 @@ internal sealed class CompletionApiClient : IOpenAIClient
         for (int previousSubmissionContextCount = 5; maxTokens <= 0 || previousSubmissionContextCount == 0; previousSubmissionContextCount--)
         {
             prompt = configuration.Prompt + "\n" + string.Join("\n", submissions.TakeLast(previousSubmissionContextCount)) + "\n" + currentCodePrefix;
-            maxTokens = 4097
+            maxTokens = TokenLength
                 - prompt.Length / CharacterToTokenEstimate
                 - currentCodeSuffix.Length / CharacterToTokenEstimate;
         }

--- a/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionRequest.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionRequest.cs
@@ -1,0 +1,147 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Text.Json.Serialization;
+
+namespace CSharpRepl.Services.Completion.OpenAI.CompletionApi;
+
+/// <summary>
+/// OpenAI Completion request - data for HTTP POST.
+/// Creates a completion for the provided prompt and parameters.
+/// https://platform.openai.com/docs/api-reference/completions/create
+/// </summary>
+internal sealed class CompletionRequest
+{
+    /// <summary>
+    /// ID of the model to use. You can use the List models API to see all of your available models, or see our Model overview for descriptions of them.
+    /// </summary>
+    [JsonPropertyName("model")]
+    public required string Model { get; set; }
+
+    /// <summary>
+    /// The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
+    /// Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the
+    /// model will generate as if from the beginning of a new document.
+    /// </summary>
+    [JsonPropertyName("prompt")]
+    public string? Prompt { get; set; }
+
+    /// <summary>
+    /// The suffix that comes after a completion of inserted text.
+    /// </summary>
+    [JsonPropertyName("suffix")]
+    public string? Suffix { get; set; }
+
+    /// <summary>
+    /// The maximum number of tokens to generate in the completion.
+    /// The token count of your prompt plus max_tokens cannot exceed the model's context length.
+    /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
+    /// </summary>
+    [JsonPropertyName("max_tokens")]
+    public int? MaxTokens { get; set; }
+
+    /// <summary>
+    /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more
+    /// random, while lower values like 0.2 will make it more focused and deterministic.
+    /// We generally recommend altering this or top_p but not both.
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public double? Temperature { get; set; }
+
+    /// <summary>
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the
+    /// results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10%
+    /// probability mass are considered. We generally recommend altering this or temperature but not both.
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public double? TopProbability { get; set; }
+
+    /// <summary>
+    /// How many completions to generate for each prompt.
+    /// Note: Because this parameter generates many completions, it can quickly consume your token quota.
+    /// Use carefully and ensure that you have reasonable settings for max_tokens and stop.
+    /// </summary>
+    [JsonPropertyName("n")]
+    public int? NCompletions { get; set; }
+
+    /// <summary>
+    /// Whether to stream back partial progress. If set, tokens will be sent as data-only server-sent
+    /// events as they become available, with the stream terminated by a data: [DONE] message.
+    /// </summary>
+    [JsonPropertyName("stream")]
+    public bool? Stream { get; set; }
+
+    /// <summary>
+    /// Include the log probabilities on the logprobs most likely tokens, as well the chosen tokens.
+    /// For example, if logprobs is 5, the API will return a list of the 5 most likely tokens. The API
+    /// will always return the logprob of the sampled token, so there may be up to logprobs+1 elements
+    /// in the response.
+    ///
+    /// The maximum value for logprobs is 5. If you need more than this, please contact us through our
+    /// Help center and describe your use case.
+    /// </summary>
+    [JsonPropertyName("logprobs")]
+    public int? LogProbabilities { get; set; }
+
+    /// <summary>
+    /// Echo back the prompt in addition to the completion
+    /// </summary>
+    [JsonPropertyName("echo")]
+    public bool? Echo { get; set; }
+
+    /// <summary>
+    /// Up to 4 sequences where the API will stop generating further tokens. The returned text will not
+    /// contain the stop sequence.
+    /// </summary>
+    [JsonPropertyName("stop")]
+    public string[]? Stop { get; set; }
+
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in
+    /// the text so far, increasing the model's likelihood to talk about new topics.
+    /// </summary>
+    [JsonPropertyName("presence_penalty")]
+    public int? PresencePenalty { get; set; }
+
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency
+    /// in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+    /// </summary>
+    [JsonPropertyName("frequency_penalty")]
+    public int? FrequencyPenalty { get; set; }
+
+    /// <summary>
+    /// Generates best_of completions server-side and returns the "best" (the one with the highest log
+    /// probability per token). Results cannot be streamed. When used with n, best_of controls the number
+    /// of candidate completions and n specifies how many to return – best_of must be greater than n.
+    ///
+    /// Note: Because this parameter generates many completions, it can quickly consume your token quota.
+    /// Use carefully and ensure that you have reasonable settings for max_tokens and stop.
+    /// </summary>
+    [JsonPropertyName("best_of")]
+    public int? BestOf { get; set; }
+
+    /// <summary>
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    ///
+    /// Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an
+    /// associated bias value from -100 to 100. You can use this tokenizer tool (which works for both
+    /// GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits
+    /// generated by the model prior to sampling. The exact effect will vary per model, but values
+    /// between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100
+    /// should result in a ban or exclusive selection of the relevant token.
+    ///
+    /// As an example, you can pass {"50256": -100} to prevent the <|endoftext|> token from being generated.
+    /// </summary>
+    [JsonPropertyName("logit_bias")]
+    public int? LogitBias { get; set; }
+
+    /// <summary>
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </summary>
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionResponse.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/CompletionApi/CompletionResponse.cs
@@ -1,0 +1,63 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Text.Json.Serialization;
+
+namespace CSharpRepl.Services.Completion.OpenAI.CompletionApi;
+
+public sealed class CompletionResponse
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("choices")]
+    public required Choice[] Choices { get; set; }
+
+    [JsonPropertyName("object")]
+    public string? Object { get; set; }
+
+    [JsonPropertyName("created")]
+    public int Created { get; set; }
+
+    [JsonPropertyName("model")]
+    public string? Model { get; set; }
+
+    public class Choice
+    {
+        [JsonPropertyName("text")]
+        public required string Text { get; set; }
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+        [JsonPropertyName("logprobs")]
+        public object? LogProbs { get; set; }
+        [JsonPropertyName("finish_reason")]
+        public string? FinishReason { get; set; }
+    }
+}
+
+/// <summary>
+/// Root of the error response from the OpenAI Completion API
+/// </summary>
+public sealed class ErrorResponse
+{
+    [JsonPropertyName("error")]
+    public required ApiError Error { get; set; }
+
+    /// <summary>
+    /// Error object returned from the OpenAI Completion API
+    /// </summary>
+    public class ApiError
+    {
+        [JsonPropertyName("message")]
+        public required string Message { get; set; }
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+        [JsonPropertyName("param")]
+        public string? Param { get; set; }
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+    }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/IOpenAIClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/IOpenAIClient.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Services.Completion.OpenAI;
+internal interface IOpenAIClient
+{
+    Task<HttpResponseMessage> IssueRequestAsync(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken);
+
+    string? ParseLineToCompletion(string line);
+
+    bool EmitLeadingNewline => false;
+
+    public void CheckMaxTokensAndThrow(int maxTokens)
+    {
+    }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/IOpenAIClient.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/IOpenAIClient.cs
@@ -1,9 +1,16 @@
-﻿using System.Collections.Generic;
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace CSharpRepl.Services.Completion.OpenAI;
+
 internal interface IOpenAIClient
 {
     Task<HttpResponseMessage> IssueRequestAsync(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken);
@@ -11,8 +18,4 @@ internal interface IOpenAIClient
     string? ParseLineToCompletion(string line);
 
     bool EmitLeadingNewline => false;
-
-    public void CheckMaxTokensAndThrow(int maxTokens)
-    {
-    }
 }

--- a/CSharpRepl.Services/Completion/OpenAI/OpenAICompleteService.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/OpenAICompleteService.cs
@@ -62,7 +62,7 @@ public class OpenAICompleteService
         }
 
         var (inputStream, error) = await CallOpenAIAsync(submissions, code, caret, cancellationToken).ConfigureAwait(false);
-        if (error is not null)
+        if (error is not null || inputStream is null)
         {
             yield return $"// Error calling OpenAI:\n {error}";
             yield break;

--- a/CSharpRepl.Services/Completion/OpenAI/OpenAICompleteService.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/OpenAICompleteService.cs
@@ -1,0 +1,146 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CSharpRepl.Services.Completion.OpenAI.ChatCompletionApi;
+using CSharpRepl.Services.Completion.OpenAI.CompletionApi;
+
+namespace CSharpRepl.Services.Completion.OpenAI;
+
+/// <summary>
+/// Call the OpenAI API to get C# completions. Requires an OpenAI API token (which can be purchased from OpenAI).
+/// </summary>
+public class OpenAICompleteService
+{
+    public const int DefaultHistoryEntryCount = 5;
+    public const double DefaultTemperature = 0.1;
+    public const string DefaultModel = "text-davinci-003";
+    public const string DefaultPrompt = "// Complete the following C# code that will be run in a REPL. Prefer functions, statements, and expressions instead of a full program and do not include any namespace declarations. Do not comment what the code prints. Any plain-text, english answers must be in a C# comment.";
+    public const string ApiKeyEnvironmentVariableName = "OPENAI_API_KEY";
+
+    private readonly IOpenAIClient? client; // null if no Open AI API key is available.
+
+    public OpenAICompleteService(OpenAIConfiguration configuration, HttpMessageHandler? httpMessageHandler = null)
+    {
+        if (configuration is null || string.IsNullOrEmpty(configuration.ApiKey))
+        {
+            return;
+        }
+
+        var httpClient = httpMessageHandler is null ? new HttpClient() : new HttpClient(httpMessageHandler);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configuration.ApiKey);
+        var jsonSerializerOptions = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+        };
+        this.client = configuration.Model.StartsWith("gpt", StringComparison.InvariantCultureIgnoreCase)
+            ? new ChatCompletionApiClient(httpClient, jsonSerializerOptions, configuration)
+            : new CompletionApiClient(httpClient, jsonSerializerOptions, configuration);
+    }
+
+    public static string? ApiKey =>
+        Environment.GetEnvironmentVariable(ApiKeyEnvironmentVariableName, EnvironmentVariableTarget.Process)
+        ?? Environment.GetEnvironmentVariable(ApiKeyEnvironmentVariableName, EnvironmentVariableTarget.User);
+
+    public async IAsyncEnumerable<string> CompleteAsync(IReadOnlyList<string> submissions, string code, int caret, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (client is null)
+        {
+            yield break;
+        }
+
+        var (inputStream, error) = await CallOpenAIAsync(submissions, code, caret, cancellationToken).ConfigureAwait(false);
+        if (error is not null)
+        {
+            yield return $"// Error calling OpenAI:\n {error}";
+            yield break;
+        }
+
+        if (client.EmitLeadingNewline && code.Length == caret && caret > 0 && code[caret - 1] != '\n')
+        {
+            // GPT models are "conversational" and assume their output is on a newline after the input, without actually returning a newline.
+            // The davinci models don't have this limitation and don't need the newline.
+            yield return "\n";
+        }
+
+        // because we sent "stream: true" in the API request, the completions are streamed back to us.
+        using var reader = new StreamReader(inputStream);
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) != null)
+        {
+            line = line?.Trim();
+            if (string.IsNullOrEmpty(line))
+            {
+                continue;
+            }
+            else if (line.StartsWith("data: "))
+            {
+                line = line.Substring("data: ".Length);
+            }
+            else if (line.StartsWith("{")) // not actually streaming a response, assume it's an error. Theoretically this shouldn't happen for HTTP 200, but handle it anyway.
+            {
+                await ThrowOpenAIException(reader, line, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (line == "[DONE]")
+            {
+                yield break;
+            }
+            else if (!string.IsNullOrWhiteSpace(line))
+            {
+                var completion = client.ParseLineToCompletion(line);
+                if (!string.IsNullOrEmpty(completion))
+                {
+                    yield return completion.Replace("\t", "    ");
+                }
+            }
+        }
+    }
+
+    private async Task<(Stream?, string? error)> CallOpenAIAsync(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken)
+    {
+        // convert exception to tuple because we're called by an iterator, and C# doesn't support 'yield break' when catching exceptions.
+        try
+        {
+            var response = await IssueApiRequestAndEnsureSuccessful(submissions, code, caret, cancellationToken).ConfigureAwait(false);
+            var inputStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return (inputStream, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
+    private async Task<HttpResponseMessage> IssueApiRequestAndEnsureSuccessful(IReadOnlyList<string> submissions, string code, int caret, CancellationToken cancellationToken)
+    {
+        var response = await client!.IssueRequestAsync(submissions, code, caret, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new OpenAIException(await response.Content.ReadAsStringAsync(cancellationToken));
+        }
+
+        return response;
+    }
+
+    private static async Task ThrowOpenAIException(StreamReader reader, string? line, CancellationToken cancellationToken)
+    {
+        var restOfMessage = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        var completeMessage = line + restOfMessage;
+        var error = JsonSerializer.Deserialize<ErrorResponse>(completeMessage);
+        throw new OpenAIException(error?.Error.Message ?? "Unknown response from OpenAI API: " + completeMessage);
+    }
+}

--- a/CSharpRepl.Services/Completion/OpenAI/OpenAIException.cs
+++ b/CSharpRepl.Services/Completion/OpenAI/OpenAIException.cs
@@ -1,0 +1,19 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+
+namespace CSharpRepl.Services.Completion.OpenAI;
+
+/// <summary>
+/// An exception that represents an error from the OpenAI API.
+/// </summary>
+internal class OpenAIException : Exception
+{
+    public OpenAIException() { }
+    public OpenAIException(string? message) : base(message) { }
+    public OpenAIException(string? message, Exception? innerException) : base(message, innerException) { }
+}

--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -78,7 +78,7 @@ public sealed class Configuration
         string[]? newLineKeyPatterns = null,
         string[]? submitPromptKeyPatterns = null,
         string[]? submitPromptDetailedKeyPatterns = null,
-        OpenAIConfiguration openAIConfiguration = null)
+        OpenAIConfiguration? openAIConfiguration = null)
     {
         References = references?.ToHashSet() ?? new HashSet<string>();
         Usings = usings?.ToHashSet() ?? new HashSet<string>();

--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -54,6 +54,7 @@ public sealed class Configuration
     public string? LoadScript { get; }
     public string[] LoadScriptArgs { get; }
     public FormattedString OutputForEarlyExit { get; }
+    public OpenAIConfiguration OpenAIConfiguration { get; }
     public int TabSize { get; }
 
     public KeyBindings KeyBindings { get; }
@@ -76,7 +77,8 @@ public sealed class Configuration
         string[]? triggerCompletionListKeyPatterns = null,
         string[]? newLineKeyPatterns = null,
         string[]? submitPromptKeyPatterns = null,
-        string[]? submitPromptDetailedKeyPatterns = null)
+        string[]? submitPromptDetailedKeyPatterns = null,
+        OpenAIConfiguration openAIConfiguration = null)
     {
         References = references?.ToHashSet() ?? new HashSet<string>();
         Usings = usings?.ToHashSet() ?? new HashSet<string>();
@@ -131,7 +133,7 @@ public sealed class Configuration
         LoadScript = loadScript;
         LoadScriptArgs = loadScriptArgs ?? Array.Empty<string>();
         OutputForEarlyExit = outputForEarlyExit;
-
+        OpenAIConfiguration = openAIConfiguration;
         var triggerCompletionList =
             triggerCompletionListKeyPatterns?.Any() == true
             ? ParseKeyPressPatterns(triggerCompletionListKeyPatterns)
@@ -228,4 +230,24 @@ public sealed class Configuration
             return false;
         }
     }
+}
+
+public class OpenAIConfiguration
+{
+    public OpenAIConfiguration(string? apiKey, string prompt, string model, int historyCount, double? temperature, double? topProbability)
+    {
+        ApiKey = apiKey;
+        Prompt = prompt;
+        Model = model;
+        HistoryCount = historyCount;
+        Temperature = temperature;
+        TopProbability = topProbability;
+    }
+
+    public string? ApiKey { get; }
+    public string Prompt { get; }
+    public string Model { get; }
+    public int HistoryCount { get; }
+    public double? Temperature { get; }
+    public double? TopProbability { get; }
 }

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -171,6 +171,21 @@ public sealed partial class RoslynServices
         return prettyPrinter.FormatException(obj, level);
     }
 
+    public async Task<IReadOnlyList<string>> GetPreviousSubmissionsAsync()
+    {
+        await Initialization.ConfigureAwait(false);
+        var texts = await Task.WhenAll(
+            workspaceManager
+                .GetPreviousDocuments()
+                .Skip(1) // skip warmup
+                .Select(d => d.GetTextAsync())
+        );
+        return texts
+            .Select(t => t.ToString().Replace("\r\n", "\n"))
+            .Where(text => !string.IsNullOrEmpty(text))
+            .ToList();
+    }
+
     public async Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteAsync(string text, int caret)
     {
         if (!Initialization.IsCompleted)

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -92,6 +92,12 @@ internal sealed class WorkspaceManager
         this.CurrentDocument = document;
     }
 
+    public IReadOnlyList<Document> GetPreviousDocuments()
+    {
+        var documents = workspace.CurrentSolution.Projects.SelectMany(project => project.Documents).ToList();
+        return documents;
+    }
+
     private static Solution EmptyProjectAndDocumentChangeset(
         Solution solution,
         IReadOnlyCollection<MetadataReference> references,

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.6" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.46.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.4" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.46.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/CSharpRepl.Tests/FakeConsole.cs
+++ b/CSharpRepl.Tests/FakeConsole.cs
@@ -152,7 +152,8 @@ internal static class FakeConsole
                     if (isPlaceholder)
                     {
                         var formatArgument = input.GetArgument(int.Parse(key.Value.Trim('{', '}')));
-                        modifiersPressed = AppendFormatStringArgument(list, key, modifiersPressed, formatArgument);
+                        var modifier = AppendFormatStringArgument(list, key, modifiersPressed, formatArgument);
+                        modifiersPressed = modifier == 0 ? 0 : modifiersPressed | modifier;
                     }
                     else if (isEscapedBrace)
                     {

--- a/CSharpRepl.Tests/FakeHttp.cs
+++ b/CSharpRepl.Tests/FakeHttp.cs
@@ -1,0 +1,45 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CSharpRepl.Tests;
+
+using RequestMatcher = Func<string, bool>;
+
+internal class FakeHttp : HttpMessageHandler, IEnumerable<(RequestMatcher, (HttpStatusCode, string))>
+{
+    private List<(RequestMatcher requestMatcher, (HttpStatusCode status, string content) response)> mockResponses = new();
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var content = await request.Content.ReadAsStringAsync(cancellationToken);
+        var response = mockResponses.First(r => r.requestMatcher(content)).response;
+        return new HttpResponseMessage(response.status)
+        {
+            Content = new StringContent(response.content, Encoding.UTF8, "application/json")
+        };
+    }
+
+    public void Add(RequestMatcher requestMatcher, HttpStatusCode statusCode, string content)
+    {
+        mockResponses.Add((requestMatcher, (statusCode, content)));
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        ((IEnumerable)mockResponses).GetEnumerator();
+
+    public IEnumerator<(RequestMatcher, (HttpStatusCode, string))> GetEnumerator() =>
+        ((IEnumerable<(RequestMatcher, (HttpStatusCode, string))>)mockResponses).GetEnumerator();
+}

--- a/CSharpRepl.Tests/OpenAICompletionTests.cs
+++ b/CSharpRepl.Tests/OpenAICompletionTests.cs
@@ -1,0 +1,105 @@
+﻿#region License Header
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#endregion
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using CSharpRepl.PrettyPromptConfig;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using PrettyPrompt;
+using Xunit;
+using static System.ConsoleKey;
+using static System.ConsoleModifiers;
+
+namespace CSharpRepl.Tests;
+
+[Collection(nameof(RoslynServices))]
+public class OpenAICompletionTests : IAsyncLifetime, IClassFixture<RoslynServicesFixture>
+{
+    private readonly FakeConsoleAbstract console;
+    private readonly RoslynServices services;
+    private readonly FakeHttp http;
+
+    public OpenAICompletionTests(RoslynServicesFixture fixture)
+    {
+        var (console, _) = FakeConsole.CreateStubbedOutput();
+        this.console = console;
+        this.services = fixture.RoslynServices;
+        this.http = new FakeHttp();
+    }
+
+    public Task InitializeAsync() => services.WarmUpAsync(Array.Empty<string>());
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Complete_GivenCode_ReturnsCompletions()
+    {
+        console.StubInput($@"Console.WriteLine({Control}{Alt}{Spacebar}{Enter}");
+
+        this.http.Add(
+            req => req.Contains("Console.WriteLine("),
+            HttpStatusCode.OK,
+            """
+            data: {"choices": [{"text": "\"yay!\")"}], "id":"", "object": "", "created": 0, "model": ""}
+            data: [DONE]
+            """
+        );
+
+        var response = await GetPromptWithOpenAIModel("text-davinci-003").ReadLineAsync();
+
+        Assert.Equal("""Console.WriteLine("yay!")""", response.Text);
+    }
+
+    [Fact]
+    public async Task ChatComplete_GivenCode_ReturnsCompletions()
+    {
+        console.StubInput($@"// if you're happy and you know it clap your hands{Control}{Alt}{Spacebar}{Enter}");
+
+        this.http.Add(
+            req => req.Contains("clap your hands"),
+            HttpStatusCode.OK,
+            """
+            data: {"choices": [{"delta": {"role": "assistant"}}], "id":"" }
+            data: {"choices": [{"delta": {"content": "// claps hands"}}], "id":"" }
+            data: [DONE]
+            """
+        );
+
+        var response = await GetPromptWithOpenAIModel("gpt3.5-turbo").ReadLineAsync();
+
+        Assert.Equal("// if you're happy and you know it clap your hands" + Environment.NewLine + "// claps hands", response.Text);
+    }
+
+    [Theory]
+    [InlineData("text-davinci-003")]
+    [InlineData("gpt3.5-turbo")]
+    public async Task Complete_ExternalError_DoesNotCrash(string model)
+    {
+        console.StubInput($@"Console.WriteLine({Control}{Alt}{Spacebar}{Enter}");
+
+        this.http.Add(
+            req => req.Contains("Console.WriteLine("),
+            HttpStatusCode.InternalServerError,
+            """
+            {"error": {"message": "Transmogrifier broken."} }
+            """
+        );
+
+        var response = await GetPromptWithOpenAIModel(model).ReadLineAsync();
+
+        Assert.Contains("Console.WriteLine(// Error calling OpenAI", response.Text);
+    }
+
+    private Prompt GetPromptWithOpenAIModel(string modelName)
+    {
+        var configuration = new Configuration(openAIConfiguration:
+            new OpenAIConfiguration(apiKey: "abc123", prompt: "complete with c#", model: modelName, historyCount: 5, temperature: 0.1, topProbability: null)
+        );
+        var promptCallbacks = new CSharpReplPromptCallbacks(console, services, configuration, http);
+        return new Prompt(console: console.PrettyPromptConsole, callbacks: promptCallbacks, configuration: new PromptConfiguration(keyBindings: configuration.KeyBindings));
+    }
+}

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.0.4" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
   </ItemGroup>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.0.5" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.6" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
The basic end-to-end feature is working. Still needs tests and some code cleanup.

Defaults to using the text-davinci models, though this is configurable with the command line / config file. The GPT models are also supported (both the Completion and ChatCompletion APIs are implemented in this PR).

All users need to do to get started is to set the `OPENAI_API_KEY` environment variable, and press Ctrl-Alt-Space to invoke the completion.


https://user-images.githubusercontent.com/97195/227731903-3cc44343-dd1b-4673-a3d7-a65011a2848c.mp4

