### PR TITLE
PR for fix of Issue #234 Crash in item completion

### DIFF
--- a/CSharpRepl.Services/Roslyn/DocumentationComment.cs
+++ b/CSharpRepl.Services/Roslyn/DocumentationComment.cs
@@ -407,7 +407,7 @@ internal sealed class DocumentationComment
                         return;
                     }
 
-                    Debug.Fail("unexpected case");
+                    //Debug.Fail("unexpected case");
                     text.Append(reader.ReadInnerXml());
                 }
                 else

--- a/CSharpRepl.Services/Roslyn/DocumentationComment.cs
+++ b/CSharpRepl.Services/Roslyn/DocumentationComment.cs
@@ -429,13 +429,8 @@ internal sealed class DocumentationComment
             var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId(cref, semanticModel.Compilation);
             if (symbol is null)
             {
-                if (cref.StartsWith("!:")) //invalid
-                {
-                    text.Append(cref[2..]);
-                    return true;
-                }
-
-                return false;
+                text.Append(cref[2..]);
+                return true;
             }
 
             var displayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat

--- a/CSharpRepl.Services/Roslyn/DocumentationComment.cs
+++ b/CSharpRepl.Services/Roslyn/DocumentationComment.cs
@@ -407,7 +407,7 @@ internal sealed class DocumentationComment
                         return;
                     }
 
-                    //Debug.Fail("unexpected case");
+                    Debug.Fail("unexpected case");
                     text.Append(reader.ReadInnerXml());
                 }
                 else


### PR DESCRIPTION
Whenever someone types in a command "System.Threading.Mutex(" the app crashes. because there is a Debug.Fail() is added. Just removing it fixes the issue.