### PR TITLE
Add SourceFileResolver to support intellisense for csx files

### DIFF
--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -81,7 +81,8 @@ public sealed partial class RoslynServices
             this.compilationOptions = new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: referenceService.Usings.Select(u => u.Name.ToString()),
-                allowUnsafe: true
+                allowUnsafe: true,
+                sourceReferenceResolver: new SourceFileResolver(new[] { Environment.CurrentDirectory}, Environment.CurrentDirectory)
             );
 
             // the script runner is used to actually execute the scripts, and the workspace manager


### PR DESCRIPTION
Closes #248

By ensuring the CSharpCompilationOptions (that are passed to the WorkspaceManager's Project instances) have a SourceReferenceResolver implementation, the types are made available to our autocompletion service. We're just using the out-of-the-box implementation from roslyn (the SourceFileResolver).