### PR TITLE
Add DOTNET_ROOT to .NET SDK error message

### DIFF
--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -77,7 +77,8 @@ internal sealed class DotNetInstallationLocator
             throw new InvalidOperationException(
                 "Could not determine the .NET SDK to use. Please install the latest .NET SDK installer from https://dotnet.microsoft.com/download" + Environment.NewLine
                 + $@"Tried to find {version} with reference assemblies in ""{referenceAssemblyRoot}"" and implementation assemblies in ""{implementationAssemblyRoot}""." + Environment.NewLine
-                + $@"Also tried falling back to ""{referencePath}"" and ""{implementationPath}"""
+                + $@"Also tried falling back to ""{referencePath}"" and ""{implementationPath}""" + Environment.NewLine
+                + "If you've installed .NET in a different directory, please set it in the DOTNET_ROOT environment variable."
             );
         }
 


### PR DESCRIPTION
Closes #245.

Related to https://github.com/waf/CSharpRepl/pull/250 which I decided didn't have much benefit over the current way of doing things. Neither way "automatically" worked when DOTNET_ROOT was not set, so we'll just require DOTNET_ROOT to be set. Mention it in the error message to point users in the right direction.