### PR TITLE
Fix nuget loading issue when referencing csproj/sln files

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <!-- when upgrading nuget, make sure you check the SkipCopyOfHostDlls in CSharpRepl and test '#load' for solutions -->
     <PackageReference Include="NuGet.PackageManagement" Version="6.5.0" />
   </ItemGroup>
 

--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using CSharpRepl.Services.Dotnet;

--- a/CSharpRepl.Services/Theming/Theme.cs
+++ b/CSharpRepl.Services/Theming/Theme.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis.Classification;
-using Newtonsoft.Json;
 using PrettyPrompt.Highlighting;
 using Spectre.Console;
 

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -40,6 +40,26 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <!--
+    We shouldn't package the Nuget.* DLLs, but should instead have them loaded from the runtime sdk.
+    https://github.com/microsoft/qsharp-compiler/issues/1470
+    https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dc
+  -->
+  <Target AfterTargets="AfterResolveReferences" Name="SkipCopyOfHostDlls">
+    <ItemGroup>
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.common\6.5.0\lib\netstandard2.0\NuGet.Common.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.configuration\6.5.0\lib\netstandard2.0\NuGet.Configuration.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.dependencyresolver.core\6.5.0\lib\net5.0\NuGet.DependencyResolver.Core.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.frameworks\6.5.0\lib\netstandard2.0\NuGet.Frameworks.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.librarymodel\6.5.0\lib\netstandard2.0\NuGet.LibraryModel.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging.core\6.5.0\lib\net5.0\NuGet.Packaging.Core.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.packaging\6.5.0\lib\net5.0\NuGet.Packaging.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.projectmodel\6.5.0\lib\net5.0\NuGet.ProjectModel.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.protocol\6.5.0\lib\net5.0\NuGet.Protocol.dll" />
+      <RuntimeCopyLocalItems Remove="$(NuGetPackageRoot)nuget.versioning\6.5.0\lib\netstandard2.0\NuGet.Versioning.dll" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- Include README here so it shows up in the nuget.org page -->
     <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
Closes #246. Prior research on #191.

Because msbuild ships its own nuget libraries, and these libraries are higher versions than are publicly available on nuget, we run into loading issues when trying to build csproj files from within csharprepl. I think what's happening here is that msbuild tries to load its nuget libraries, but the nuget libraries in the running csharprepl application are loaded instead.

Fix is to not copy-local the nuget libraries in our application, and instead rely on them being loaded from the SDK.