### PR TITLE
Remove completionItemDescriptionPaneBackground from Visual Studio Dark Theme

### DIFF
--- a/CSharpRepl/themes/VisualStudio_Dark.json
+++ b/CSharpRepl/themes/VisualStudio_Dark.json
@@ -1,7 +1,7 @@
 {
   "selectedCompletionItemBackground": "#3C3C3C",
   "completionBoxBorderColor": "#909090",
-  "completionItemDescriptionPaneBackground": "#282828",
+  "completionItemDescriptionPaneBackground": null,
   "selectedTextBackground": "#143D66",
   "syntaxHighlightingColors": [
     {


### PR DESCRIPTION
Because we specify an RGB color for the `completionItemDescriptionPaneBackground`, it looks a bit funny if the terminal's background color is not exactly that RGB color. We already do not specify it for e.g. the completion menu.

Before this change, notice how the background color of the text in the completion details is different than the background color of the main completion menu (it's very subtle):

![image](https://github.com/waf/CSharpRepl/assets/97195/2a3cecf3-5070-46c6-8966-9e0cf2121cb1)

After this change, the two menus are the same color:

![image](https://github.com/waf/CSharpRepl/assets/97195/0d9ad491-1713-44be-b588-400eef15b07a)

@kindermannhubert maybe you'd like to check if you agree with this change. Possibly it won't affect you if your terminal background is already `#282828`.