### PR TITLE
Bump dependencies -- new roslyn libs and decompiler

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -7,23 +7,23 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.6.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageReference Include="PrettyPrompt" Version="4.0.7" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.26" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.2.29" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <!-- when upgrading nuget, make sure you check the SkipCopyOfHostDlls in CSharpRepl and test '#load' for solutions -->
-    <PackageReference Include="NuGet.PackageManagement" Version="6.5.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -14,21 +14,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="PrettyPrompt" Version="4.0.7" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.46.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.26" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.47.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bump dependencies.

- Major new version of `ICSharpCode.Decompiler` adds support for additional C# language features in csharprepl's "Show IL" feature.
- New `Microsoft.CodeAnalysis` (roslyn) minor version as well as other minor version bumps

The test project has a very major bump in Coverlet from v3 to v6 -- so might be a bit of CI tweaking on this PR.