### PR TITLE
Move .NET Runtime detection so failures don't crash the REPL

### DIFF
--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -6,11 +6,9 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using CSharpRepl.Services.Dotnet;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 
@@ -20,14 +18,6 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
 {
     private readonly DotnetBuilder builder;
     private readonly IConsoleEx console;
-
-    static SolutionFileMetadataResolver()
-    {
-        if (!MSBuildLocator.IsRegistered)
-        {
-            _ = MSBuildLocator.RegisterDefaults();
-        }
-    }
 
     public SolutionFileMetadataResolver(DotnetBuilder builder, IConsoleEx console)
     {

--- a/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
+++ b/CSharpRepl.Services/Roslyn/References/DotNetInstallationLocator.cs
@@ -8,6 +8,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Runtime.InteropServices;
 using CSharpRepl.Services.Logging;
+using Microsoft.Build.Locator;
 
 namespace CSharpRepl.Services.Roslyn.References;
 
@@ -42,6 +43,7 @@ internal sealed class DotNetInstallationLocator
         this.io = io;
         this.dotnetRuntimePath = dotnetRuntimePath;
         this.userProfilePath = userProfilePath;
+        _ = LocateMsBuild(logger);
     }
 
     /// <summary>
@@ -83,6 +85,21 @@ internal sealed class DotNetInstallationLocator
         }
 
         return (referencePath, implementationPath);
+    }
+
+    private static VisualStudioInstance? LocateMsBuild(ITraceLogger logger)
+    {
+        try
+        {
+            var msbuild = MSBuildLocator.RegisterDefaults();
+            logger.Log($"Discovered dotnet version {msbuild.Name} {msbuild.Version} at {msbuild.MSBuildPath}.");
+            return msbuild;
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.Log($"ERROR: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -77,13 +77,14 @@ public sealed partial class RoslynServices
         this.Initialization = Task.Run(() =>
         {
             logger.Log("Starting background initialization");
+
             this.referenceService = new AssemblyReferenceService(config, logger);
 
             this.compilationOptions = new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: referenceService.Usings.Select(u => u.Name?.ToString()).WhereNotNull(),
                 allowUnsafe: true,
-                sourceReferenceResolver: new SourceFileResolver(new[] { Environment.CurrentDirectory}, Environment.CurrentDirectory)
+                sourceReferenceResolver: new SourceFileResolver(new[] { Environment.CurrentDirectory }, Environment.CurrentDirectory)
             );
 
             // the script runner is used to actually execute the scripts, and the workspace manager


### PR DESCRIPTION
See #268, if [MSBuildLocator](https://github.com/microsoft/MSBuildLocator/) fails to find dotnet, we currently hard crash. MSBuildLocator isn't required for basic REPL usage; it's only used when loading csproj or SLN files into the REPL. Move this so it doesn't crash the REPL, and also add some trace logging for better debugging when this does happen.