### PR TITLE
Move 'multiple nuspec' detection logic earlier

### DIFF
--- a/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
+++ b/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
@@ -149,6 +149,7 @@ internal sealed class NugetPackageInstaller
                 return;
         }
 
+        CheckAndFixMultipleNuspecFilesExistance(installedPath);
         var reader = new PackageFolderReader(installedPath);
         var collection = new ContentItemCollection();
         collection.Load(await reader.GetFilesAsync(cancellationToken));
@@ -190,7 +191,6 @@ internal sealed class NugetPackageInstaller
             aggregatedReferences[packageIdentity] = dlls;
         }
 
-        CheckAndFixMultipleNuspecFilesExistance(installedPath);
         var dependencyGroup =
             (await reader.GetPackageDependenciesAsync(cancellationToken))
             .FirstOrDefault(g => g.TargetFramework == selectedFramework);


### PR DESCRIPTION
We currently have the following workaround for multiple nuspecs that differ only by case:

https://github.com/waf/CSharpRepl/blob/35cc2b7ea54153894021d6d7e44285a71de391ac/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs#L288-L294

Not totally sure under what circumstances a package can get into this state. However, in #259 we're currently seeing it when we're trying to read a package's supported frameworks, so we need to move this check earlier to handle it.