### PR TITLE
Initial support for evaluating piped input from stdin

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -51,6 +51,7 @@ public sealed class Configuration
     public FormattedString Prompt { get; }
     public bool UseUnicode { get; }
     public bool UsePrereleaseNugets { get; }
+    public bool StreamPipedInput { get; set; }
     public string? LoadScript { get; }
     public string[] LoadScriptArgs { get; }
     public FormattedString OutputForEarlyExit { get; }
@@ -70,6 +71,7 @@ public sealed class Configuration
         string promptMarkup = PromptDefault,
         bool useUnicode = false,
         bool usePrereleaseNugets = false,
+        bool streamPipedInput = false,
         int tabSize = 4,
         string? loadScript = null,
         string[]? loadScriptArgs = null,
@@ -129,6 +131,7 @@ public sealed class Configuration
 
         UseUnicode = useUnicode;
         UsePrereleaseNugets = usePrereleaseNugets;
+        StreamPipedInput = streamPipedInput;
         TabSize = tabSize;
         LoadScript = loadScript;
         LoadScriptArgs = loadScriptArgs ?? Array.Empty<string>();

--- a/CSharpRepl.Services/IConsoleEx.cs
+++ b/CSharpRepl.Services/IConsoleEx.cs
@@ -76,4 +76,6 @@ public interface IConsoleEx : IAnsiConsole
             WriteLine(text);
         }
     }
+
+    string? ReadLine();
 }

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -84,7 +84,6 @@ public sealed partial class RoslynServices
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: referenceService.Usings.Select(u => u.Name?.ToString()).WhereNotNull(),
                 allowUnsafe: true,
-                optimizationLevel: OptimizationLevel.Release,
                 sourceReferenceResolver: new SourceFileResolver(new[] { Environment.CurrentDirectory }, Environment.CurrentDirectory)
             );
 

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -84,6 +84,7 @@ public sealed partial class RoslynServices
                 OutputKind.DynamicallyLinkedLibrary,
                 usings: referenceService.Usings.Select(u => u.Name?.ToString()).WhereNotNull(),
                 allowUnsafe: true,
+                optimizationLevel: OptimizationLevel.Release,
                 sourceReferenceResolver: new SourceFileResolver(new[] { Environment.CurrentDirectory }, Environment.CurrentDirectory)
             );
 

--- a/CSharpRepl.Services/SystemConsoleEx.cs
+++ b/CSharpRepl.Services/SystemConsoleEx.cs
@@ -5,6 +5,7 @@
 using PrettyPrompt.Consoles;
 using Spectre.Console;
 using Spectre.Console.Rendering;
+using System;
 
 namespace CSharpRepl.Services;
 
@@ -20,5 +21,8 @@ public sealed class SystemConsoleEx : IConsoleEx
     public IExclusivityMode ExclusivityMode => ansiConsole.ExclusivityMode;
     public RenderPipeline Pipeline => ansiConsole.Pipeline;
     public void Clear(bool home) => ansiConsole.Clear(home);
+
     public void Write(IRenderable renderable) => ansiConsole.Write(renderable);
+
+    public string? ReadLine() => Console.ReadLine();
 }

--- a/CSharpRepl.Tests/FakeConsole.cs
+++ b/CSharpRepl.Tests/FakeConsole.cs
@@ -271,6 +271,8 @@ public abstract class FakeConsoleAbstract : IConsoleEx
 
     public void Clear(bool home) => AnsiConsole.Clear(home);
     public void Write(IRenderable renderable) => AnsiConsole.Write(renderable);
+
+    public virtual string? ReadLine() => string.Empty;
 }
 
 public abstract class FakePrettyPromptConsoleAbstract : IConsole

--- a/CSharpRepl.Tests/PipedInputEvaluatorTests.cs
+++ b/CSharpRepl.Tests/PipedInputEvaluatorTests.cs
@@ -1,0 +1,62 @@
+﻿using CSharpRepl.Services.Roslyn;
+using NSubstitute;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+[Collection(nameof(RoslynServices))]
+public class PipedInputEvaluatorTests : IClassFixture<RoslynServicesFixture>
+{
+    private readonly FakeConsoleAbstract console;
+    private readonly RoslynServices roslyn;
+    private readonly PipedInputEvaluator pipedInputEvaluator;
+
+    public PipedInputEvaluatorTests(RoslynServicesFixture fixture)
+    {
+        this.console = fixture.ConsoleStub;
+        this.roslyn = fixture.RoslynServices;
+        this.pipedInputEvaluator = new PipedInputEvaluator(console, roslyn);
+    }
+
+    [Fact]
+    public async Task EvaluateCollectedPipeInputAsync_FullyCollectsInput_ThenEvaluatesInput()
+    {
+        // verify we're collecting the input entirely before evaluating it. If we evaluated it line by line,
+        // the following program would have an error because the if(false) { ... } would be evaluated as a
+        // complete statement, and the "else" would be a syntax error.
+        console.ReadLine().Returns(
+            "if(false)",
+            "{",
+            "    Console.WriteLine(\"true\");",
+            "}",
+            "else",
+            "{",
+            "    Console.WriteLine(\"false\");",
+            "}",
+            null // end of piped input
+        );
+        var result = await this.pipedInputEvaluator.EvaluateCollectedPipeInputAsync();
+
+        Assert.Equal(ExitCodes.Success, result);
+    }
+
+    [Fact]
+    public async Task EvaluateStreamingPipeInputAsync_StreamsInput_EvaluatesCompleteStatements()
+    {
+        // in this mode, we want to read input line by line, group them into complete statements, and then
+        // evaluate the complete statement. If we just did line-by-line then the below input would cause a
+        // syntax error on the standalone `if(true)`
+        console.ReadLine().Returns(
+            "if(true)",
+            "{",
+            "    Console.WriteLine(\"true\");",
+            "}",
+            "Console.WriteLine(\"false\");",
+            null // end of piped input
+        );
+        var result = await this.pipedInputEvaluator.EvaluateStreamingPipeInputAsync();
+
+        Assert.Equal(ExitCodes.Success, result);
+    }
+}

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -28,7 +28,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
         this.capturedError = fixture.CapturedConsoleError;
         this.prompt = fixture.PromptStub;
         this.services = fixture.RoslynServices;
-        this.repl = new ReadEvalPrintLoop(services, prompt, console);
+        this.repl = new ReadEvalPrintLoop(console, services, prompt);
     }
 
     [Theory]

--- a/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -334,7 +334,7 @@ public partial class RoslynServices_REPL_Tests : IAsyncLifetime, IClassFixture<R
         configuration ??= new Configuration();
 
         var prompt = new Prompt(console: console.PrettyPromptConsole, callbacks: new CSharpReplPromptCallbacks(console, services, configuration), configuration: new PromptConfiguration(keyBindings: configuration.KeyBindings));
-        var repl = new ReadEvalPrintLoop(services, prompt, console);
+        var repl = new ReadEvalPrintLoop(console, services, prompt);
         await services.WarmUpAsync(Array.Empty<string>());
         return (console, repl, configuration, stdout, stderr);
     }

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -82,6 +82,11 @@ internal static class CommandLine
         description: "Allows prerelease NuGet versions when searching for the latest package version."
     );
 
+    private static readonly Option<bool> StreamPipedInput = new(
+        aliases: new[] { "--streamPipedInput" },
+        description: "If input is piped via stdin, evaluate it line by line instead of in one batch."
+    );
+
     private static readonly Option<bool> Trace = new(
         aliases: new[] { "--trace" },
         description: "Produce a trace file in the current directory, for CSharpRepl bug reports."
@@ -187,7 +192,8 @@ internal static class CommandLine
 
         var availableCommands = new RootCommand("C# REPL")
         {
-            References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, UseUnicode, UsePrereleaseNugets, Trace, Version, Help, TabSize,
+            References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, UseUnicode, UsePrereleaseNugets,
+            StreamPipedInput, Trace, Version, Help, TabSize,
             OpenAIApiKey, OpenAIPrompt, OpenAIModel, OpenAIHistoryCount, OpenAITemperature, OpenAITopProbability,
             TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings, Configure
         };
@@ -227,6 +233,7 @@ internal static class CommandLine
             promptMarkup: commandLine.GetValueForOption(Prompt) ?? Configuration.PromptDefault,
             useUnicode: commandLine.GetValueForOption(UseUnicode),
             usePrereleaseNugets: commandLine.GetValueForOption(UsePrereleaseNugets),
+            streamPipedInput: commandLine.GetValueForOption(StreamPipedInput),
             tabSize: commandLine.GetValueForOption(TabSize),
             trace: commandLine.GetValueForOption(Trace),
             triggerCompletionListKeyPatterns: commandLine.GetValueForOption(TriggerCompletionListKeyBindings),
@@ -354,6 +361,7 @@ internal static class CommandLine
             $"  [green]--prompt[/]:                                   {Prompt.Description}" + NewLine +
             $"  [green]--useUnicode[/]:                               {UseUnicode.Description}" + NewLine +
             $"  [green]--usePrereleaseNugets[/]:                      {UsePrereleaseNugets.Description}" + NewLine +
+            $"  [green]--streamPipedInput[/]:                         {StreamPipedInput.Description}" + NewLine +
             $"  [green]--tabSize[/] [cyan]<width>[/]:                          {TabSize.Description}" + NewLine +
             NewLine +
             $"  Key Bindings" + NewLine +

--- a/CSharpRepl/PipedInputEvaluator.cs
+++ b/CSharpRepl/PipedInputEvaluator.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+
+namespace CSharpRepl;
+
+/// <summary>
+/// CSharpRepl is predominantly an interactive repl, but also supports input being piped to the executable.
+/// This class handles the piped non-interactive input mode.
+/// </summary>
+internal sealed class PipedInputEvaluator
+{
+    private readonly IConsoleEx console;
+    private readonly RoslynServices roslyn;
+
+    public PipedInputEvaluator(IConsoleEx console, RoslynServices roslyn)
+    {
+        this.console = console;
+        this.roslyn = roslyn;
+    }
+
+    /// <summary>
+    /// When we're receiving pipe input, evaluate the input as it streams in.
+    /// </summary>
+    /// <returns>exit / error code</returns>
+    public async Task<int> EvaluateStreamingPipeInputAsync()
+    {
+        // input could be piped forever, so don't read all the input and then evaluate it in one go.
+        // instead, read the input line by line until we have a completed statement, then evaluate that.
+
+        var statement = new StringBuilder();
+        string? inputLine;
+        while((inputLine = console.ReadLine()) is not null)
+        {
+            // batch input into a complete statement
+            statement.AppendLine(inputLine);
+            string input = statement.ToString();
+            if (!await roslyn.IsTextCompleteStatementAsync(input))
+            {
+                continue;
+            }
+            statement.Clear();
+
+            // evaluate complete statement.
+            var result = await roslyn.EvaluateAsync(input);
+            if (result is not EvaluationResult.Success)
+            {
+                return ErrorCode(result);
+            }
+        }
+
+        return ExitCodes.Success;
+    }
+
+    /// <summary>
+    /// Reads all input from stdin in one go, and evaluates it and returns.
+    /// Could block forever if input never ends.
+    /// </summary>
+    /// <returns>exit / error code</returns>
+    public async Task<int> EvaluateCollectedPipeInputAsync()
+    {
+        var input = new StringBuilder();
+        string? line;
+        while ((line = console.ReadLine()) is not null)
+        {
+            input.AppendLine(line);
+        }
+
+        var result = await roslyn.EvaluateAsync(input.ToString());
+        return result is EvaluationResult.Success
+            ? ExitCodes.Success
+            : ErrorCode(result);
+    }
+
+    private int ErrorCode(EvaluationResult result)
+    {
+        switch (result)
+        {
+            case EvaluationResult.Error err:
+                console.WriteErrorLine(err.Exception.Message);
+                return err.Exception.HResult;
+            case EvaluationResult.Cancelled:
+                return ExitCodes.ErrorCancelled;
+            default:
+                throw new InvalidOperationException("Unhandled EvaluationResult type");
+        }
+    }
+}

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -23,15 +23,15 @@ namespace CSharpRepl;
 /// </summary>
 internal sealed class ReadEvalPrintLoop
 {
+    private readonly IConsoleEx console;
     private readonly RoslynServices roslyn;
     private readonly IPrompt prompt;
-    private readonly IConsoleEx console;
 
-    public ReadEvalPrintLoop(RoslynServices roslyn, IPrompt prompt, IConsoleEx console)
+    public ReadEvalPrintLoop(IConsoleEx console, RoslynServices roslyn, IPrompt prompt)
     {
+        this.console = console;
         this.roslyn = roslyn;
         this.prompt = prompt;
-        this.console = console;
     }
 
     public async Task RunAsync(Configuration config)


### PR DESCRIPTION
Adds support for csharprepl to evaluate piped input. By default, it reads all input available and then executes it. 

Alternatively, there's a `--streamPipedInput` flag that instructs csharprepl to evaluate the input in a streaming mode, so it reads line by line and evaluates complete statements.