### PR TITLE
Upgrade nuget packages, including PrettyPrompt

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.431901" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.8" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.9" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
     <PackageReference Include="System.IO.Abstractions" Version="19.2.29" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -14,13 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.0.8" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.9" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.47.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.0.8" />
+    <PackageReference Include="PrettyPrompt" Version="4.0.9" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Upgrade PrettyPrompt to get [fixes in 4.0.9](https://github.com/waf/PrettyPrompt/blob/main/CHANGELOG.md#release-409).

The only other nuget upgrades in this PR are testing related (xunit and Microsoft.NET.Test.Sdk).