### PR TITLE
Add dynamic key binding references to help text

### DIFF
--- a/CSharpRepl.Services/Extensions/KeyExtensions.cs
+++ b/CSharpRepl.Services/Extensions/KeyExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using PrettyPrompt.Consoles;
+
+namespace CSharpRepl.Services.Extensions;
+
+public static class KeyExtensions
+{
+    private static string GetStringValue(this KeyPressPattern pattern)
+    {
+        if (pattern.Key != default)
+        {
+            return pattern.Modifiers == default
+                ? $"{pattern.Key}"
+                : $"{pattern.Modifiers.GetStringValue()}+{pattern.Key}";
+        }
+
+        return $"{pattern.Character}";
+    }
+
+    private static string GetStringValue(this ConsoleModifiers modifiers)
+    {
+        var values = Enum.GetValues<ConsoleModifiers>()
+            .Where(x => modifiers.HasFlag(x))
+            .OrderByDescending(x => x)
+            .Select(x => x.ToString());
+        return string.Join("+", values);
+    }
+
+    public static string GetStringValue(this KeyPressPatterns patterns)
+        => patterns.DefinedPatterns!.First().GetStringValue();
+}

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -50,6 +50,28 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
         Assert.Contains("Type C# at the prompt", console.AnsiConsole.Output);
     }
 
+    [Theory]
+    [InlineData("Control+Tab", "Control+Enter", "Control+Shift+Enter")]
+    [InlineData("Enter", "Control+A", "Control+Shift+A")]
+    [InlineData("º", "¶", "ç")]
+    public async Task RunAsync_HelpCommand_ShowsPassedKeyBindings(string submitKeyPattern, string submitDetailedKeyPattern, string newLineKeyPattern)
+    {
+        prompt
+            .ReadLineAsync()
+            .Returns(
+                new PromptResult(true, "help", default),
+                new PromptResult(true, "exit", default)
+            );
+        
+        await repl.RunAsync(new Configuration(submitPromptKeyPatterns: new[] {submitKeyPattern},
+            submitPromptDetailedKeyPatterns: new[] {submitDetailedKeyPattern}, newLineKeyPatterns:  new[] {newLineKeyPattern}));
+
+        Assert.Contains(submitKeyPattern, console.AnsiConsole.Output);
+        Assert.Contains(submitDetailedKeyPattern, console.AnsiConsole.Output);
+        Assert.Contains(newLineKeyPattern, console.AnsiConsole.Output);
+    }
+
+
     [Fact]
     public async Task RunAsync_ClearCommand_ClearsScreen()
     {
@@ -62,7 +84,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
 
         await repl.RunAsync(new Configuration());
 
-        ((IConsoleEx)console.Received()).Clear(true);
+        ((IConsoleEx) console.Received()).Clear(true);
     }
 
     [Fact]
@@ -108,7 +130,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
             );
 
         await repl.RunAsync(new Configuration(
-            references: new[] { "Data/DemoLibrary.dll" }
+            references: new[] {"Data/DemoLibrary.dll"}
         ));
 
         Assert.Contains("30", console.AnsiConsole.Output);

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.PrettyPromptConfig;
 using CSharpRepl.Services;
+using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Formatting;
 using CSharpRepl.Services.Roslyn.Scripting;
@@ -61,7 +62,7 @@ internal sealed class ReadEvalPrintLoop
                 if (commandText == "clear") { console.Clear(); continue; }
                 if (new[] { "help", "#help", "?" }.Contains(commandText))
                 {
-                    PrintHelp();
+                    PrintHelp(config.KeyBindings, config.SubmitPromptDetailedKeys);
                     continue;
                 }
 
@@ -142,18 +143,23 @@ internal sealed class ReadEvalPrintLoop
         }
     }
 
-    private void PrintHelp()
+
+    private void PrintHelp(KeyBindings keyBindings, KeyPressPatterns submitPromptDetailedKeys)
     {
+        var newLineBindingName = keyBindings.NewLine.GetStringValue();
+        var submitPromptName = keyBindings.SubmitPrompt.GetStringValue();
+        var submitPromptDetailedName = submitPromptDetailedKeys.GetStringValue();
+        
         console.WriteLine(
-$@"
+            $@"
 More details and screenshots are available at
 https://github.com/waf/CSharpRepl/blob/main/README.md
 
 Evaluating Code
 ===============
-Type C# at the prompt and press {Underline("Enter")} to run it. The result will be printed.
-{Underline("Ctrl+Enter")} will also run the code, but show detailed member info / stack traces.
-{Underline("Shift+Enter")} will insert a newline, to support multiple lines of input.
+Type C# at the prompt and press {Underline(submitPromptName)} to run it. The result will be printed.
+{Underline(submitPromptDetailedName)} will also run the code, but show detailed member info / stack traces.
+{Underline(newLineBindingName)} will insert a newline, to support multiple lines of input.
 If the code isn't a complete statement, pressing Enter will insert a newline.
 
 Adding References


### PR DESCRIPTION
Add dynamic key binding references to help text
The help text in the REPL has been updated to dynamically display the key bindings configured by the user.

Fix for https://github.com/waf/CSharpRepl/issues/124

