### PR TITLE
Minor fix to clean up warnings in unit test project

### DIFF
--- a/CSharpRepl.Tests/RoslynServicesTests.Overloads.cs
+++ b/CSharpRepl.Tests/RoslynServicesTests.Overloads.cs
@@ -271,7 +271,7 @@ public partial class RoslynServicesOverloadsTests : IAsyncLifetime, IClassFixtur
         Assert.True(result.Overloads.Count == 1);
         Assert.Equal(0, result.ArgumentIndex);
         Assert.Contains("List", result.Overloads[0].Signature.Text);
-        Assert.Equal(1, result.Overloads[0].Parameters.Count);
+        Assert.Single(result.Overloads[0].Parameters);
         Assert.Equal("T", result.Overloads[0].Parameters[0].Name);
     }
 
@@ -301,7 +301,7 @@ public partial class RoslynServicesOverloadsTests : IAsyncLifetime, IClassFixtur
         Assert.Equal(0, result.ArgumentIndex);
         var overload = result.Overloads[0];
         Assert.Contains("M", overload.Signature.Text);
-        Assert.Equal(1, overload.Parameters.Count);
+        Assert.Single(overload.Parameters);
         Assert.Equal("i", overload.Parameters[0].Name);
     }
 

--- a/CSharpRepl.Tests/StyledStringTests.cs
+++ b/CSharpRepl.Tests/StyledStringTests.cs
@@ -20,27 +20,27 @@ public class StyledStringTests
 
             var subtext = text.Substring(0, 4);
             Assert.Equal("abcd", subtext.ToString());
-            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Single(subtext.Parts);
             Assert.Equal(style, subtext.Parts[0].Style);
 
             subtext = text.Substring(0, 2);
             Assert.Equal("ab", subtext.ToString());
-            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Single(subtext.Parts);
             Assert.Equal(style, subtext.Parts[0].Style);
 
             subtext = text.Substring(1, 2);
             Assert.Equal("bc", subtext.ToString());
-            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Single(subtext.Parts);
             Assert.Equal(style, subtext.Parts[0].Style);
 
             subtext = text.Substring(2, 2);
             Assert.Equal("cd", subtext.ToString());
-            Assert.Equal(1, subtext.Parts.Count);
+            Assert.Single(subtext.Parts);
             Assert.Equal(style, subtext.Parts[0].Style);
 
             subtext = text.Substring(2, 0);
             Assert.Equal("", subtext.ToString());
-            Assert.Equal(0, subtext.Parts.Count);
+            Assert.Empty(subtext.Parts);
         }
     }
 
@@ -79,12 +79,12 @@ public class StyledStringTests
 
         subtext = text.Substring(0, 2);
         Assert.Equal("ab", subtext.ToString());
-        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Single(subtext.Parts);
         Assert.Equal(redStyle, subtext.Parts[0].Style);
 
         subtext = text.Substring(0, 1);
         Assert.Equal("a", subtext.ToString());
-        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Single(subtext.Parts);
         Assert.Equal(redStyle, subtext.Parts[0].Style);
 
         ///////////////////////////////////////////////////////////////////////
@@ -110,12 +110,12 @@ public class StyledStringTests
 
         subtext = text.Substring(4, 2);
         Assert.Equal("ef", subtext.ToString());
-        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Single(subtext.Parts);
         Assert.Equal(blueStyle, subtext.Parts[0].Style);
 
         subtext = text.Substring(5, 1);
         Assert.Equal("f", subtext.ToString());
-        Assert.Equal(1, subtext.Parts.Count);
+        Assert.Single(subtext.Parts);
         Assert.Equal(blueStyle, subtext.Parts[0].Style);
 
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Noticed some code warnings in build output of the `main` branch. This cleans them up.