### PR TITLE
Fix CSX loading using relative paths from command line

### DIFF
--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -61,6 +61,7 @@ internal sealed class ScriptRunner
         );
         this.scriptOptions = ScriptOptions.Default
             .WithMetadataResolver(metadataResolver)
+            .WithSourceResolver(compilationOptions.SourceReferenceResolver)
             .WithReferences(referenceAssemblyService.LoadedImplementationAssemblies)
             .WithAllowUnsafe(compilationOptions.AllowUnsafe)
             .WithLanguageVersion(LanguageVersion.Preview)

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -120,6 +120,24 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
     }
 
     [Fact]
+    public async Task RunAsync_LoadScriptByFilePath_RunsScript()
+    {
+        prompt
+            .ReadLineAsync()
+            .Returns(
+                new PromptResult(true, "exit", default)
+            );
+
+        await repl.RunAsync(new Configuration(
+            loadScript: "#load \"Data\\LoadScript.csx\""
+        ));
+
+        Assert.DoesNotContain("Exception", console.AnsiConsole.Output);
+        Assert.DoesNotContain("CS1504", console.AnsiConsole.Output);
+        Assert.DoesNotContain("Could not find file", console.AnsiConsole.Output);
+    }
+
+    [Fact]
     public async Task RunAsync_Reference_AddsReference()
     {
         prompt

--- a/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -129,7 +129,7 @@ public class ReadEvalPrintLoopTests : IClassFixture<RoslynServicesFixture>
             );
 
         await repl.RunAsync(new Configuration(
-            loadScript: "#load \"Data\\LoadScript.csx\""
+            loadScript: "#load \"Data/LoadScript.csx\""
         ));
 
         Assert.DoesNotContain("Exception", console.AnsiConsole.Output);


### PR DESCRIPTION
We are configuring the correct working directory in the C# compilation options, but we need to pass this down the the script runner's SourceReferenceResolver roslyn integration point.

Fixes #310