### PR TITLE
Set default culture for compile error messages

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -170,7 +170,7 @@ public sealed class Configuration
             submitPrompt,
             triggerOverloadList: new(new KeyPressPattern('('), new KeyPressPattern('['), new KeyPressPattern(','), new KeyPressPattern('<')));
 
-        Culture = string.IsNullOrWhiteSpace(cultureName) ? CultureInfo.CurrentCulture : CultureInfo.GetCultureInfo(cultureName, true);
+        Culture = string.IsNullOrWhiteSpace(cultureName) ? CultureInfo.CurrentUICulture : CultureInfo.GetCultureInfo(cultureName, true);
     }
 
     public CultureInfo Culture { get; }


### PR DESCRIPTION
Ensure that if the user has their "UI Culture" set to a language, we use that language for compiler error messages (emitted by CSharpScript).

We don't actually have any API for doing this with roslyn that I could find. Instead, through trial and error, by setting `CultureInfo.DefaultThreadCurrentCulture` to the UI Culture, we can get CSharpScript to emit errors in the language of the UI culture.

Note that setting `CultureInfo.DefaultThreadCurrentUICulture` didn't fix it; it needs to be `CultureInfo.DefaultThreadCurrentCulture`.

Closes #312.