### PR TITLE
Update "NuGet.*" packages to 6.8.1 (CVE-2024-0057)

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -32,19 +32,19 @@
 	https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188
 	-->
   <ItemGroup>
-		<PackageReference Include="NuGet.PackageManagement" Version="6.8.0" />
-		<PackageReference Include="NuGet.Common" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Commands" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Credentials" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Configuration" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.DependencyResolver.Core" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Frameworks" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.LibraryModel" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging.Core" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.ProjectModel" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Protocol" Version="6.8.0" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Versioning" Version="6.8.0" PrivateAssets="all" />
+		<PackageReference Include="NuGet.PackageManagement" Version="6.8.1" />
+		<PackageReference Include="NuGet.Common" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Commands" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Credentials" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Configuration" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.DependencyResolver.Core" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.LibraryModel" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Packaging.Core" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Packaging" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.ProjectModel" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Protocol" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Versioning" Version="6.8.1" PrivateAssets="all" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
This PR addresses a critical vulnerability identified in [**NuGet.Packaging** 6.8.0](https://www.nuget.org/packages/NuGet.Packaging/6.8.0). See [CVE-2024-0057, “NuGet Client Security Feature Bypass Vulnerability”](https://github.com/advisories/GHSA-68w7-72jg-6qpp) for more information.

To be on the conservative side, I've updated all **NuGet.*** packages to the next patch version 6.8.1 that's not flagged.