### PR TITLE
Upgrade nuget packages

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -15,13 +15,13 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.431901" />
     <PackageReference Include="PrettyPrompt" Version="4.1.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.87" />
+    <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
 
@@ -32,19 +32,19 @@
 	https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188
 	-->
   <ItemGroup>
-		<PackageReference Include="NuGet.PackageManagement" Version="6.8.1" />
-		<PackageReference Include="NuGet.Common" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Commands" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Credentials" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Configuration" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.DependencyResolver.Core" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Frameworks" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.LibraryModel" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging.Core" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.ProjectModel" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Protocol" Version="6.8.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Versioning" Version="6.8.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.PackageManagement" Version="6.9.1" />
+		<PackageReference Include="NuGet.Common" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Commands" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Credentials" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Configuration" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.DependencyResolver.Core" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Frameworks" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.LibraryModel" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Packaging.Core" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Packaging" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.ProjectModel" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Protocol" Version="6.9.1" PrivateAssets="all" />
+		<PackageReference Include="NuGet.Versioning" Version="6.9.1" PrivateAssets="all" />
 	</ItemGroup>
 
 

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -14,25 +14,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-		Use a preview of Test SDK 17.9.0 to get the fix where they remove the older nuget.framework references.
-    These references mess with out DLL loading since they're older than what we reference.
-		-->
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23503-02" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="PrettyPrompt" Version="4.1.1" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.48.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.87" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="20.0.15" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,15 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-tools">
+      <package pattern="Microsoft.SymbolStore" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -13,6 +13,7 @@
     </packageSource>
     <packageSource key="dotnet-tools">
       <package pattern="Microsoft.SymbolStore" />
+      <package pattern="Microsoft.FileFormats" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Set up package source mapping as well as a nuget upgrade. Preparing for dependabot integration.

We can also get rid of the `dotnet-libraries` source. It was used to get System.CommandLine prerelease packages, but those prerelease packages are now on nuget.org