### PR TITLE
Fix navigate to source for generic types

### DIFF
--- a/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
+++ b/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
@@ -77,7 +77,7 @@ internal sealed class SymbolExplorer
             .Select(t => assemblyReader.GetTypeDefinition(t))
             .FirstOrDefault(t =>
                 assemblyReader.GetString(t.Namespace) == symbolAtPosition.ContainingNamespace.ToDisplayString()
-                && assemblyReader.GetString(t.Name) == (symbolAtPosition.ContainingType?.Name ?? symbolAtPosition.Name)
+                && assemblyReader.GetString(t.Name) == (symbolAtPosition.ContainingType?.Name ?? symbolAtPosition.MetadataName)
             );
 
         using var debugSymbolLoader = new DebugSymbolLoader(assemblyFilePath);
@@ -155,6 +155,15 @@ internal sealed class SymbolExplorer
         );
 
     private static SequencePointRange? FindMethod(MetadataReader symbolReader, MetadataReader assemblyReader, TypeDefinition type, IMethodSymbol method) =>
+        FindSequencePoint(
+            symbolReader,
+            type.GetMethods(),
+            m => assemblyReader.GetMethodDefinition(m),
+            m => assemblyReader.GetString(m.Name) == method.Name,
+            m => m
+        );
+
+    private static SequencePointRange? FindConstructor(MetadataReader symbolReader, MetadataReader assemblyReader, TypeDefinition type, IMethodSymbol method) =>
         FindSequencePoint(
             symbolReader,
             type.GetMethods(),

--- a/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
+++ b/CSharpRepl.Services/SymbolExploration/SymbolExplorer.cs
@@ -163,15 +163,6 @@ internal sealed class SymbolExplorer
             m => m
         );
 
-    private static SequencePointRange? FindConstructor(MetadataReader symbolReader, MetadataReader assemblyReader, TypeDefinition type, IMethodSymbol method) =>
-        FindSequencePoint(
-            symbolReader,
-            type.GetMethods(),
-            m => assemblyReader.GetMethodDefinition(m),
-            m => assemblyReader.GetString(m.Name) == method.Name,
-            m => m
-        );
-
     private static SequencePointRange? FindProperty(MetadataReader symbolReader, MetadataReader assemblyReader, TypeDefinition type, IPropertySymbol method) =>
         FindSequencePoint(
             symbolReader,

--- a/CSharpRepl.Tests/SymbolExplorerTests.cs
+++ b/CSharpRepl.Tests/SymbolExplorerTests.cs
@@ -43,9 +43,9 @@ public class SymbolExplorerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetGenericSymbolAtIndex_ClassInSourceLinkedAssembly_ReturnsSourceLinkUrl()
+    public async Task GetSymbolAtIndex_GenericTypeInSourceLinkedAssembly_ReturnsSourceLinkUrl()
     {
-        // should return a string like https://www.github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Console/src/System/Console.cs
+        // should return a string like https://www.github.com/dotnet/runtime/blob/1381d5ebd2ab1f292848d5b19b80cf71ac332508/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
         var symbol = await services.GetSymbolAtIndexAsync(@"List<string>", "Li".Length);
 
         Assert.StartsWith("https://www.github.com/dotnet/runtime/", symbol.Url);

--- a/CSharpRepl.Tests/SymbolExplorerTests.cs
+++ b/CSharpRepl.Tests/SymbolExplorerTests.cs
@@ -43,6 +43,16 @@ public class SymbolExplorerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetGenericSymbolAtIndex_ClassInSourceLinkedAssembly_ReturnsSourceLinkUrl()
+    {
+        // should return a string like https://www.github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Console/src/System/Console.cs
+        var symbol = await services.GetSymbolAtIndexAsync(@"List<string>", "Li".Length);
+
+        Assert.StartsWith("https://www.github.com/dotnet/runtime/", symbol.Url);
+        Assert.EndsWith("List.cs", symbol.Url);
+    }
+
+    [Fact]
     public async Task GetSymbolAtIndex_MethodInSourceLinkedAssembly_ReturnsSourceLinkUrl()
     {
         // should return a string like https://www.github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Console/src/System/Console.cs#L635-L636


### PR DESCRIPTION
The previous logic was looking up types by name, but not including the generic parameter arity (e.g. for `List<T>` it was looking for `List` as opposed to <code>List`1</code>