### PR TITLE
use InternalsVisibleTo msbuild item

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -49,9 +49,7 @@
 
 
 	<ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-    <_Parameter1>CSharpRepl.Tests</_Parameter1>
-    </AssemblyAttribute>
+    <InternalsVisibleTo Include="CSharpRepl.Tests" />
   </ItemGroup>
 
 

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -35,9 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-    <_Parameter1>CSharpRepl.Tests</_Parameter1>
-    </AssemblyAttribute>
+    <InternalsVisibleTo Include="CSharpRepl.Tests" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
use InternalsVisibleTo MSBuild item to simplify `InternalsVisibleToAttribute`

Use InternalsVisibleTo to generate the attribute

- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#internalsvisibleto