### PR TITLE
Make completion cancellable and handle REPL keywords

### DIFF
--- a/CSharpRepl.Services/Completion/AutoCompleteService.cs
+++ b/CSharpRepl.Services/Completion/AutoCompleteService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.SyntaxHighlighting;
@@ -35,7 +36,7 @@ internal sealed class AutoCompleteService
         this.configuration = configuration;
     }
 
-    public async Task<CompletionItemWithDescription[]> Complete(Document document, string text, int caret)
+    public async Task<CompletionItemWithDescription[]> Complete(Document document, string text, int caret, CancellationToken cancellationToken)
     {
         var cacheKey = CacheKeyPrefix + document.Name + text + caret;
         if (text != string.Empty && cache.Get<CompletionItemWithDescription[]>(cacheKey) is CompletionItemWithDescription[] cached)
@@ -47,7 +48,7 @@ internal sealed class AutoCompleteService
         try
         {
             var completions = await completionService
-                .GetCompletionsAsync(document, caret)
+                .GetCompletionsAsync(document, caret, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var completionsWithDescriptions = completions?.ItemsList

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -192,13 +192,13 @@ public sealed partial class RoslynServices
             .ToList();
     }
 
-    public async Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteAsync(string text, int caret)
+    public async Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteAsync(string text, int caret, CancellationToken cancellationToken = default)
     {
         if (!Initialization.IsCompleted)
             return [];
 
         var document = workspaceManager.CurrentDocument.WithText(SourceText.From(text));
-        return await autocompleteService.Complete(document, text, caret).ConfigureAwait(false);
+        return await autocompleteService.Complete(document, text, caret, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SymbolResult> GetSymbolAtIndexAsync(string text, int caret)

--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -126,4 +126,15 @@ public class CompletionTests : IAsyncLifetime, IClassFixture<RoslynServicesFixtu
             Assert.Equal(expectedItems[i], completions.ElementAt(i).Item.DisplayText);
         }
     }
+
+    [Theory]
+    [InlineData("he", "help")]
+    [InlineData("ex", "exit")]
+    [InlineData("cl", "clear")]
+    public async Task Complete_ReplKeywords(string source, string item)
+    {
+        var completions = await promptCallbacks.GetCompletionItemsCoreAsync(source, source.Length);
+        var completion = completions.SingleOrDefault(c => c.DisplayText == item);
+        Assert.NotNull(completion);
+    }
 }

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -94,9 +94,15 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
 
     protected override async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
     {
+        return await GetCompletionItemsCoreAsync(text, caret, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Made internal for testing
+    internal async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsCoreAsync(string text, int caret, CancellationToken cancellationToken = default)
+    {
         var replKeywordCompletions = GetReplKeywordCompletions();
 
-        var completions = await roslyn.CompleteAsync(text, caret).ConfigureAwait(false);
+        var completions = await roslyn.CompleteAsync(text, caret, cancellationToken).ConfigureAwait(false);
         return replKeywordCompletions
             .Concat(completions
                 .OrderByDescending(i => i.Item.Rules.MatchPriority)

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -204,18 +204,36 @@ Run [green]--help[/] at the command line to view these options.
         }
     }
 
-    private static string Help =>
-        PromptConfiguration.HasUserOptedOutFromColor
-        ? @"""help"""
-        : AnsiColor.Green.GetEscapeSequence() + "help" + AnsiEscapeCodes.Reset;
+    public static string Help => Keywords.Help;
+    public static string Exit => Keywords.Exit;
+    public static string Clear => Keywords.Clear;
 
-    private static string Exit =>
-        PromptConfiguration.HasUserOptedOutFromColor
-        ? @"""exit"""
-        : AnsiColor.BrightRed.GetEscapeSequence() + "exit" + AnsiEscapeCodes.Reset;
+    public static class Keywords
+    {
+        public const string HelpText = "help";
+        public const string ExitText = "exit";
+        public const string ClearText = "clear";
 
-    private static string Clear =>
-        PromptConfiguration.HasUserOptedOutFromColor
-        ? @"""clear"""
-        : AnsiColor.BrightBlue.GetEscapeSequence() + "clear" + AnsiEscapeCodes.Reset;
+        public static readonly KeywordInfo HelpInfo = new(HelpText, AnsiColor.Green);
+        public static readonly KeywordInfo ExitInfo = new(ExitText, AnsiColor.BrightRed);
+        public static readonly KeywordInfo ClearInfo = new(ClearText, AnsiColor.BrightBlue);
+
+        public static string Help => GetColoredText(HelpInfo);
+        public static string Exit => GetColoredText(ExitInfo);
+        public static string Clear => GetColoredText(ClearInfo);
+
+        private static string GetColoredText(KeywordInfo keywordInfo)
+        {
+            return GetColoredText(keywordInfo.Text, keywordInfo.Color);
+        }
+
+        private static string GetColoredText(string text, AnsiColor color)
+        {
+            return PromptConfiguration.HasUserOptedOutFromColor
+                ? $@"""{text}"""
+                : color.GetEscapeSequence() + text + AnsiEscapeCodes.Reset;
+        }
+
+        public sealed record KeywordInfo(string Text, AnsiColor Color);
+    }
 }


### PR DESCRIPTION
- `RoslynServices.CompleteAsync` can be cancelled with `CancellationToken`, as provided by `GetCompletionItemsAsync`
- REPL command keywords (help, exit, clear)
  - Highlight them in the prompt to show that they will be executed, matching the behavior of the command handler
  - Show them as completion items
