### PR TITLE
Show documentation on suggested REPL keywords

### DIFF
--- a/CSharpRepl.Tests/CompletionTests.cs
+++ b/CSharpRepl.Tests/CompletionTests.cs
@@ -137,4 +137,17 @@ public class CompletionTests : IAsyncLifetime, IClassFixture<RoslynServicesFixtu
         var completion = completions.SingleOrDefault(c => c.DisplayText == item);
         Assert.NotNull(completion);
     }
+
+    [Theory]
+    [InlineData("he", "help", "Show help")]
+    [InlineData("ex", "exit", "Exit the REPL")]
+    [InlineData("cl", "clear", "Clear the terminal")]
+    public async Task Complete_ReplKeywords_HaveDescription(string source, string item, string expectedDescriptionFragment)
+    {
+        var completions = await promptCallbacks.GetCompletionItemsCoreAsync(source, source.Length);
+        var completion = completions.SingleOrDefault(c => c.DisplayText == item);
+        Assert.NotNull(completion);
+        var description = await completion.GetExtendedDescriptionAsync(default);
+        Assert.Contains(expectedDescriptionFragment, description.Text);
+    }
 }

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -373,15 +373,18 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
 
         public static CompletionItem Help { get; } = new(
             ReadEvalPrintLoop.Keywords.HelpText,
-            displayText: helpFormattedString);
+            displayText: helpFormattedString,
+            getExtendedDescription: _ => Task.FromResult(new FormattedString("Show help and usage information for the C# REPL.")));
 
         public static CompletionItem Exit { get; } = new(
             ReadEvalPrintLoop.Keywords.ExitText,
-            displayText: exitFormattedString);
+            displayText: exitFormattedString,
+            getExtendedDescription: _ => Task.FromResult(new FormattedString("Exit the REPL. You can also press Ctrl + d.")));
 
         public static CompletionItem Clear { get; } = new(
             ReadEvalPrintLoop.Keywords.ClearText,
-            displayText: clearFormattedString);
+            displayText: clearFormattedString,
+            getExtendedDescription: _ => Task.FromResult(new FormattedString("Clear the terminal screen.")));
 
         public static IReadOnlyList<CompletionItem> AllItems = [Help, Exit, Clear];
     }


### PR DESCRIPTION
Closes #448 

## What changed
Added extended descriptions to the `help`, `exit`, and `clear` REPL keyword completion items, so users see documentation when they appear in autocomplete suggestions.

## Details
- `help` : "Show help and usage information for the C# REPL."
- `exit` : "Exit the REPL. You can also press CTRL + d."
- `clear` : "Clear the terminal screen."

## Test
Added `Complete_ReplKeywords_HaveDescription` to verify each keyword surfaces its description through `GetExtendedDescriptionAsync`. 