### PR TITLE
Add support for .slnx solution references

### DIFF
--- a/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
+++ b/CSharpRepl.Services/Roslyn/MetadataResolvers/SolutionFileMetadataResolver.cs
@@ -28,6 +28,8 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
     public override bool CanResolve(string reference) =>
         reference.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
         reference.EndsWith(".sln\"", StringComparison.OrdinalIgnoreCase) ||
+        reference.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) ||
+        reference.EndsWith(".slnx\"", StringComparison.OrdinalIgnoreCase) ||
         reference.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
         reference.EndsWith(".csproj\"", StringComparison.OrdinalIgnoreCase);
 
@@ -57,7 +59,7 @@ internal sealed class SolutionFileMetadataResolver : AlternativeReferenceResolve
         var projects = Path.GetExtension(solutionOrProject) switch
         {
             ".csproj" => [await workspace.OpenProjectAsync(solutionOrProject, cancellationToken: cancellationToken)],
-            ".sln" => (await workspace.OpenSolutionAsync(solutionOrProject, cancellationToken: cancellationToken)).Projects,
+            ".sln" or ".slnx" => (await workspace.OpenSolutionAsync(solutionOrProject, cancellationToken: cancellationToken)).Projects,
             _ => throw new ArgumentException("Unexpected filetype for file " + solutionOrProject)
         };
 

--- a/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.slnx
+++ b/CSharpRepl.Tests/Data/DemoSolution/DemoSolution.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="DemoSolution.DemoProject1/DemoSolution.DemoProject1.csproj" />
+  <Project Path="DemoSolution.DemoProject2/DemoSolution.DemoProject2.csproj" />
+</Solution>

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -157,6 +157,18 @@ public class EvaluationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Evaluate_SolutionReference_ReferencesAllProjects_FromSlnx()
+    {
+        var referenceResult = await services.EvaluateAsync(@"#r ""./Data/DemoSolution/DemoSolution.slnx""");
+        var importProject1Result = await services.EvaluateAsync(@"using DemoSolution.DemoProject1;");
+        var importProject2Result = await services.EvaluateAsync(@"using DemoSolution.DemoProject2;");
+
+        Assert.IsType<EvaluationResult.Success>(referenceResult);
+        Assert.IsType<EvaluationResult.Success>(importProject1Result);
+        Assert.IsType<EvaluationResult.Success>(importProject2Result);
+    }
+
+    [Fact]
     public async Task Evaluate_SolutionReference_ReferencesMultipleTargetFrameworks()
     {
         var referenceResult = await services.EvaluateAsync(@"#r ""./Data/ComplexSolution/ComplexSolution.sln""");

--- a/CSharpRepl/ReadEvalPrintLoop.cs
+++ b/CSharpRepl/ReadEvalPrintLoop.cs
@@ -167,7 +167,7 @@ If the code isn't a complete statement, pressing [green]Enter[/] will insert a n
 Use the {Reference()} command to add reference to:
   - assembly ({Reference("AssemblyName")} or {Reference("path/to/assembly.dll")}),
   - NuGet package ({Reference("nuget: PackageName")} or {Reference("nuget: PackageName, version")}),
-  - project ({Reference("path/to/my.csproj")} or {Reference("path/to/my.sln")}).
+  - project ({Reference("path/to/my.csproj")}, {Reference("path/to/my.sln")}, or {Reference("path/to/my.slnx")}).
 
 Use {Preprocessor("#load", "path-to-file")} to evaluate C# stored in files (e.g. csx files). This can
 be useful, for example, to build a [{ToColor("string")}].profile.csx[/] that includes libraries you want

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When you're done with your session, you can type `exit` or press <kbd>Ctrl+D</kb
 Use the `#r` command to add assembly or nuget references.
 
 - For assembly references, run `#r "AssemblyName"` or `#r "path/to/assembly.dll"`
-- For project references, run `#r "path/to/project.csproj"`. Solution files (.sln) can also be referenced.
+- For project references, run `#r "path/to/project.csproj"`. Solution files (`.sln` and `.slnx`) can also be referenced.
 - For nuget references, run `#r "nuget: PackageName"` to install the latest version of a package, or `#r "nuget: PackageName, 13.0.5"` to install a specific version (13.0.5 in this case).
 
 <p align="center">


### PR DESCRIPTION
## Summary
- add `.slnx` support to the solution reference resolver used by `#r`
- add a regression test and version a demo `.slnx` file in test data
- update help text and README to mention `.slnx` solution references

## Validation
- built the project locally with `dotnet build CSharpRepl/CSharpRepl.csproj -c Debug`
- verified `#r ".../DemoSolution.slnx"` now builds the solution and adds references when running the local binary
