### PR TITLE
Nuget upgrade 2026-05

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,13 @@ on:
 
 jobs:
   build:
+    # Disable the MSBuild build server and node reuse for every dotnet invocation in CI. The
+    # solution-reference tests spawn `dotnet build` and an out-of-process MSBuildWorkspace BuildHost;
+    # sharing persistent MSBuild nodes across these intermittently deadlocks and hangs the test run.
+    env:
+      DOTNET_CLI_USE_MSBUILD_SERVER: 0
+      MSBUILDDISABLENODEREUSE: 1
+
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -7,23 +6,32 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+    <PackageReference Include="ICSharpCode.Decompiler" Version="10.1.0.8386" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.2" />
-    <PackageReference Include="Microsoft.SymbolStore" Version="1.0.706201" />
-    <PackageReference Include="OpenAI" Version="2.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <!--
+      Microsoft.Build.Framework arrives transitively via Microsoft.CodeAnalysis.Workspaces.MSBuild.
+      We use MSBuildLocator (RegisterDefaults) to load MSBuild from the installed .NET SDK at
+      runtime, so the MSBuild assemblies must NOT be copied to our output directory (otherwise they
+      shadow the SDK's and cause version-skew failures). ExcludeAssets="runtime" keeps the
+      compile-time reference but stops the runtime copy. This is the fix the MSBL001 check requires.
+      See https://aka.ms/msbuild/locator/diagnostics/MSBL001
+    -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+    <PackageReference Include="Microsoft.SymbolStore" Version="1.0.727501" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
     <PackageReference Include="PrettyPrompt" Version="4.1.1" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.2" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
   </ItemGroup>
 
   <!--
@@ -33,35 +41,31 @@
 	https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188
 	-->
   <ItemGroup>
-		<PackageReference Include="NuGet.PackageManagement" Version="7.0.1" />
-		<PackageReference Include="NuGet.Common" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Commands" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Credentials" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Configuration" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.DependencyResolver.Core" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Frameworks" Version="7.0.1" PrivateAssets="all" ExcludeAssets="runtime" />
-		<PackageReference Include="NuGet.LibraryModel" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging.Core" Version="6.9.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Packaging" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.ProjectModel" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Protocol" Version="7.0.1" PrivateAssets="all" />
-		<PackageReference Include="NuGet.Versioning" Version="7.0.1" PrivateAssets="all" />
-	</ItemGroup>
+    <PackageReference Include="NuGet.PackageManagement" Version="7.6.0" />
+    <PackageReference Include="NuGet.Common" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Commands" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Credentials" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Configuration" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.DependencyResolver.Core" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.6.0" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.LibraryModel" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.ProjectModel" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" PrivateAssets="all" />
+  </ItemGroup>
 
-
-	<ItemGroup>
+  <ItemGroup>
     <InternalsVisibleTo Include="CSharpRepl.Tests" />
   </ItemGroup>
 
-
-	<ItemGroup>
-	  <EmbeddedResource Include="RuntimeHelper.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="RuntimeHelper.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="runtime.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
+++ b/CSharpRepl.Services/Nuget/NugetPackageInstaller.cs
@@ -70,7 +70,7 @@ internal sealed class NugetPackageInstaller
                 new GatherCache(),
                 sourceCacheContext);
 
-            var primarySourceRepositories = sourceRepositoryProvider.GetRepositories();
+            var primarySourceRepositories = GetSourceRepositoriesForPackage(sourceRepositoryProvider, settings, packageId);
             var packageIdentity = string.IsNullOrEmpty(version)
                 ? await QueryLatestPackageVersion(packageId, nuGetProject, resolutionContext, primarySourceRepositories, cancellationToken)
                 : new PackageIdentity(packageId, new NuGetVersion(version));
@@ -262,6 +262,31 @@ internal sealed class NugetPackageInstaller
             PackagesFolderNuGetProject = nuGetProject
         };
         return packageManager;
+    }
+
+    /// <summary>
+    /// Returns the source repositories that should be queried for <paramref name="packageId"/>,
+    /// honoring any packageSourceMapping configured in NuGet.config.
+    /// </summary>
+    private static IReadOnlyList<SourceRepository> GetSourceRepositoriesForPackage(
+        SourceRepositoryProvider sourceRepositoryProvider,
+        ISettings settings,
+        string packageId)
+    {
+        var allRepositories = sourceRepositoryProvider.GetRepositories().ToList();
+
+        var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+        if (!sourceMapping.IsEnabled)
+        {
+            return allRepositories;
+        }
+
+        var mappedSourceNames = sourceMapping.GetConfiguredPackageSources(packageId);
+        var mappedRepositories = allRepositories
+            .Where(repo => mappedSourceNames.Contains(repo.PackageSource.Name, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        return mappedRepositories.Count > 0 ? mappedRepositories : allRepositories;
     }
 
     private static FolderNuGetProject CreateFolderProject(NuGetFramework targetFramework, string directory)

--- a/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
+++ b/CSharpRepl.Services/Roslyn/Scripting/ScriptRunner.cs
@@ -64,7 +64,7 @@ internal sealed class ScriptRunner
         );
         this.scriptOptions = ScriptOptions.Default
             .WithMetadataResolver(metadataResolver)
-            .WithSourceResolver(compilationOptions.SourceReferenceResolver)
+            .WithSourceResolver(compilationOptions.SourceReferenceResolver ?? SourceFileResolver.Default)
             .WithReferences(referenceAssemblyService.LoadedImplementationAssemblies)
             .WithAllowUnsafe(compilationOptions.AllowUnsafe)
             .WithLanguageVersion(LanguageVersion.Preview)

--- a/CSharpRepl.Services/SystemConsoleEx.cs
+++ b/CSharpRepl.Services/SystemConsoleEx.cs
@@ -24,5 +24,7 @@ public sealed class SystemConsoleEx : IConsoleEx
 
     public void Write(IRenderable renderable) => ansiConsole.Write(renderable);
 
+    public void WriteAnsi(Action<AnsiWriter> action) => ansiConsole.WriteAnsi(action);
+
     public string? ReadLine() => Console.ReadLine();
 }

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -14,24 +14,28 @@
   </ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="PrettyPrompt" Version="4.1.1" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.54.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Keep MSBuild assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
+         arrives transitively through the CSharpRepl.Services project reference.
+         See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Applies test.runsettings automatically to `dotnet test` (disables MSBuild build server /
+         node reuse to avoid intermittent hangs in the solution-reference tests). -->
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Tests/FakeConsole.cs
+++ b/CSharpRepl.Tests/FakeConsole.cs
@@ -272,6 +272,8 @@ public abstract class FakeConsoleAbstract : IConsoleEx
     public void Clear(bool home) => AnsiConsole.Clear(home);
     public void Write(IRenderable renderable) => AnsiConsole.Write(renderable);
 
+    public void WriteAnsi(Action<AnsiWriter> action) => AnsiConsole.WriteAnsi(action);
+
     public virtual string? ReadLine() => string.Empty;
 }
 

--- a/CSharpRepl.Tests/StyledStringTests.cs
+++ b/CSharpRepl.Tests/StyledStringTests.cs
@@ -14,7 +14,7 @@ public class StyledStringTests
     public void SubstringSimple()
     {
         var redStyle = new Style(foreground: Color.Red);
-        foreach (var style in new[] { null, redStyle })
+        foreach (var style in new Style?[] { null, redStyle })
         {
             var text = new StyledString("abcd", style);
 

--- a/CSharpRepl.Tests/test.runsettings
+++ b/CSharpRepl.Tests/test.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!--
+      Disable the MSBuild build server and node reuse for the test host. These env vars are
+      inherited by the child processes the solution-reference tests spawn (the `dotnet build`
+      subprocess and the out-of-process MSBuildWorkspace BuildHost). Sharing persistent MSBuild
+      nodes across those processes intermittently deadlocks and hangs the test run.
+      Keep in sync with the job-level env in .github/workflows/main.yml.
+    -->
+    <EnvironmentVariables>
+      <DOTNET_CLI_USE_MSBUILD_SERVER>0</DOTNET_CLI_USE_MSBUILD_SERVER>
+      <MSBUILDDISABLENODEREUSE>1</MSBUILDDISABLENODEREUSE>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -26,8 +26,12 @@
 
   <ItemGroup>
     <PackageReference Include="PrettyPrompt" Version="4.1.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.2" />
+    <PackageReference Include="System.CommandLine" Version="3.0.0-preview.4.26230.115" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />
+    <!-- Keep MSBuild assemblies out of the output dir; they're loaded from the SDK via
+         MSBuildLocator at runtime. Required transitively through CSharpRepl.Services.
+         See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl/CommandLine.cs
+++ b/CSharpRepl/CommandLine.cs
@@ -1,13 +1,11 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.CommandLine.Completions;
-using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
@@ -31,180 +29,189 @@ internal static class CommandLine
 {
     private const string DisableFurtherOptionParsing = "--";
 
-    private static readonly Option<string[]?> References = new(
-        aliases: ["--reference", "-r", "/r"],
-        description: "Reference assemblies, nuget packages, and csproj files. Can be specified multiple times."
-    )
+    private static readonly Option<string[]?> References = new("--reference", "-r", "/r")
     {
+        Description = "Reference assemblies, nuget packages, and csproj files. Can be specified multiple times.",
         AllowMultipleArgumentsPerToken = true
     };
 
-    private static readonly Option<string[]?> Usings = new Option<string[]?>(
-        aliases: ["--using", "-u", "/u"],
-        description: "Add using statement. Can be specified multiple times."
-    )
+    private static readonly Option<string[]?> Usings = BuildUsingsOption();
+
+    private static readonly Option<string> Framework = BuildFrameworkOption();
+
+    private static readonly Option<string> Theme = new("--theme", "-t", "/t")
     {
-        AllowMultipleArgumentsPerToken = true
+        Description = "Read a theme file for syntax highlighting. Respects the NO_COLOR standard.",
+        DefaultValueFactory = _ => Configuration.DefaultThemeRelativePath
+    };
+
+    private static readonly Option<bool> UseTerminalPaletteTheme = new("--useTerminalPaletteTheme")
+    {
+        Description = "Uses terminal palette colors for syntax highlighting. Respects the NO_COLOR standard."
+    };
+
+    private static readonly Option<string> Prompt = new("--prompt")
+    {
+        Description = "Formatted prompt string.",
+        DefaultValueFactory = _ => Configuration.PromptDefault
+    };
+
+    private static readonly Option<bool> UseUnicode = new("--useUnicode")
+    {
+        Description = "Use UTF8 output encoding and unicode character decorations (requires terminal support)."
+    };
+
+    private static readonly Option<bool> UsePrereleaseNugets = new("--usePrereleaseNugets")
+    {
+        Description = "Allows prerelease NuGet versions when searching for the latest package version."
+    };
+
+    private static readonly Option<bool> StreamPipedInput = new("--streamPipedInput")
+    {
+        Description = "If input is piped via stdin, evaluate it line by line instead of in one batch."
+    };
+
+    private static readonly Option<bool> Trace = new("--trace")
+    {
+        Description = "Produce a trace file in the current directory, for CSharpRepl bug reports."
+    };
+
+    private static readonly Option<bool> Version = new("--version", "-v", "/v")
+    {
+        Description = "Show version number and exit."
+    };
+
+    private static readonly Option<bool> Help = new("--help", "-h", "-?", "/h", "/?")
+    {
+        Description = "Show this help and exit."
+    };
+
+    private static readonly Option<int> TabSize = new("--tabSize")
+    {
+        Description = "Width of tab character.",
+        DefaultValueFactory = _ => 4
+    };
+
+    private static readonly Option<string> OpenAIApiKey = new("--openAIApiKey")
+    {
+        Description = $"OpenAI API key. Alternatively, set the {OpenAICompleteService.ApiKeyEnvironmentVariableName} environment variable."
+    };
+
+    private static readonly Option<string> OpenAIPrompt = new("--openAIPrompt")
+    {
+        Description = "OpenAI prompt to prefix to all code submissions"
+    };
+
+    private static readonly Option<string> OpenAIModel = new("--openAIModel")
+    {
+        Description = "OpenAI model configuration"
+    };
+
+    private static readonly Option<int?> OpenAIHistoryCount = new("--openAIHistoryCount")
+    {
+        Description = "Maximum number of previous REPL entries to send to OpenAI as context."
+    };
+
+    private static readonly Option<string[]?> TriggerCompletionListKeyBindings = new("--triggerCompletionListKeys")
+    {
+        Description = "Key binding to trigger the completion list. Can be specified multiple times.",
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    private static readonly Option<string[]?> NewLineKeyBindings = new("--newLineKeys")
+    {
+        Description = "Key binding to insert a newline character. Can be specified multiple times.",
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    private static readonly Option<string[]?> SubmitPromptKeyBindings = new("--submitPromptKeys")
+    {
+        Description = "Key binding to submit the prompt. Can be specified multiple times.",
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    private static readonly Option<string[]?> SubmitPromptDetailedKeyBindings = new("--submitPromptDetailedKeys")
+    {
+        Description = "Key binding to submit the prompt with detailed output. Can be specified multiple times.",
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    private static readonly Option<bool> Configure = new("--configure")
+    {
+        Description = "Launches an editor to edit the CSharpRepl configuration file. Reads the EDITOR environment variable."
+    };
+
+    private static readonly Option<string> Culture = new("--culture")
+    {
+        Description = "Culture to use for access to the MSDN documentation. Defaults to the current culture."
+    };
+
+    private static Option<string[]?> BuildUsingsOption()
+    {
+        var option = new Option<string[]?>("--using", "-u", "/u")
+        {
+            Description = "Add using statement. Can be specified multiple times.",
+            AllowMultipleArgumentsPerToken = true
+        };
+        option.CompletionSources.Add(GetAvailableUsings);
+        return option;
     }
-    .AddCompletions(GetAvailableUsings);
 
-    private static readonly Option<string> Framework = new Option<string>(
-        aliases: ["--framework", "-f", "/f"],
-        description: "Reference a shared framework.",
-        getDefaultValue: () => Configuration.FrameworkDefault
-    )
-    .AddCompletions(SharedFramework.SupportedFrameworks);
-
-    private static readonly Option<string> Theme = new(
-        aliases: ["--theme", "-t", "/t"],
-        description: "Read a theme file for syntax highlighting. Respects the NO_COLOR standard.",
-        getDefaultValue: () => Configuration.DefaultThemeRelativePath
-    );
-
-    private static readonly Option<bool> UseTerminalPaletteTheme = new(
-        aliases: ["--useTerminalPaletteTheme"],
-        description: "Uses terminal palette colors for syntax highlighting. Respects the NO_COLOR standard."
-    );
-
-    private static readonly Option<string> Prompt = new(
-        aliases: ["--prompt"],
-        description: "Formatted prompt string.",
-        getDefaultValue: () => Configuration.PromptDefault
-    );
-
-    private static readonly Option<bool> UseUnicode = new(
-        aliases: ["--useUnicode"],
-        description: "Use UTF8 output encoding and unicode character decorations (requires terminal support)."
-    );
-
-    private static readonly Option<bool> UsePrereleaseNugets = new(
-        aliases: ["--usePrereleaseNugets"],
-        description: "Allows prerelease NuGet versions when searching for the latest package version."
-    );
-
-    private static readonly Option<bool> StreamPipedInput = new(
-        aliases: ["--streamPipedInput"],
-        description: "If input is piped via stdin, evaluate it line by line instead of in one batch."
-    );
-
-    private static readonly Option<bool> Trace = new(
-        aliases: ["--trace"],
-        description: "Produce a trace file in the current directory, for CSharpRepl bug reports."
-    );
-
-    private static readonly Option<bool> Version = new(
-        aliases: ["--version", "-v", "/v"],
-        description: "Show version number and exit."
-    );
-
-    private static readonly Option<bool> Help = new(
-        aliases: ["--help", "-h", "-?", "/h", "/?"],
-        description: "Show this help and exit."
-    );
-
-    private static readonly Option<int> TabSize = new(
-        aliases: ["--tabSize"],
-        getDefaultValue: () => 4,
-        description: "Width of tab character."
-    );
-
-    private static readonly Option<string> OpenAIApiKey = new(
-        aliases: ["--openAIApiKey"],
-        description: $"OpenAI API key. Alternatively, set the {OpenAICompleteService.ApiKeyEnvironmentVariableName} environment variable."
-    );
-
-    private static readonly Option<string> OpenAIPrompt = new(
-        aliases: ["--openAIPrompt"],
-        description: "OpenAI prompt to prefix to all code submissions"
-    );
-
-    private static readonly Option<string> OpenAIModel = new(
-        aliases: ["--openAIModel"],
-        description: "OpenAI model configuration"
-    );
-
-    private static readonly Option<int?> OpenAIHistoryCount = new(
-        aliases: ["--openAIHistoryCount"],
-        description: "Maximum number of previous REPL entries to send to OpenAI as context."
-    );
-
-    private static readonly Option<string[]?> TriggerCompletionListKeyBindings = new(
-        aliases: ["--triggerCompletionListKeys"],
-        description: "Key binding to trigger the completion list. Can be specified multiple times."
-    )
+    private static Option<string> BuildFrameworkOption()
     {
-        AllowMultipleArgumentsPerToken = true,
-    };
+        var option = new Option<string>("--framework", "-f", "/f")
+        {
+            Description = "Reference a shared framework.",
+            DefaultValueFactory = _ => Configuration.FrameworkDefault
+        };
+        option.CompletionSources.Add(SharedFramework.SupportedFrameworks);
+        option.Validators.Add(result =>
+        {
+            // when the option isn't specified on the command line its value comes from the
+            // default value factory, which is always a supported framework, so skip validation.
+            if (result.Implicit) return;
 
-    private static readonly Option<string[]?> NewLineKeyBindings = new(
-        aliases: ["--newLineKeys"],
-        description: "Key binding to insert a newline character. Can be specified multiple times."
-    )
-    {
-        AllowMultipleArgumentsPerToken = true,
-    };
-
-    private static readonly Option<string[]?> SubmitPromptKeyBindings = new(
-        aliases: ["--submitPromptKeys"],
-        description: "Key binding to submit the prompt. Can be specified multiple times."
-    )
-    {
-        AllowMultipleArgumentsPerToken = true,
-    };
-
-    private static readonly Option<string[]?> SubmitPromptDetailedKeyBindings = new(
-        aliases: ["--submitPromptDetailedKeys"],
-        description: "Key binding to submit the prompt with detailed output. Can be specified multiple times."
-    )
-    {
-        AllowMultipleArgumentsPerToken = true,
-    };
-
-    private static readonly Option<bool> Configure = new(
-        aliases: ["--configure"],
-        description: "Launches an editor to edit the CSharpRepl configuration file. Reads the EDITOR environment variable."
-    );
-
-    private static readonly Option<string> Culture = new(
-        aliases: ["--culture"],
-        description: "Culture to use for access to the MSDN documentation. Defaults to the current culture."
-    );
+            string frameworkValue = result.GetValueOrDefault<string>() ?? string.Empty;
+            if (!SharedFramework.SupportedFrameworks.Any(f => frameworkValue.StartsWith(f, StringComparison.OrdinalIgnoreCase)))
+            {
+                result.AddError("Unrecognized --framework value");
+            }
+        });
+        return option;
+    }
 
     public static Configuration Parse(string[] args, string configFilePath)
     {
         var parseArgs = PreProcessArguments(args, configFilePath).ToArray();
 
-        Framework.AddValidator(r =>
-        {
-            if (!r.Children.Any()) return;
+        var availableCommands = new RootCommand("C# REPL");
 
-            string frameworkValue = r.GetValueOrDefault<string>() ?? string.Empty;
-            if (!SharedFramework.SupportedFrameworks.Any(f => frameworkValue.StartsWith(f, StringComparison.OrdinalIgnoreCase)))
-            {
-                r.ErrorMessage = "Unrecognized --framework value";
-            }
-        });
+        // RootCommand adds built-in --help and --version options by default. We render our own
+        // formatted help/version output, so remove the defaults to avoid duplicate-alias conflicts
+        // with our Help and Version options below. The default dotnet-suggest directive added by
+        // RootCommand is left in place (response files are also supported by default).
+        availableCommands.Options.Clear();
 
-        var availableCommands = new RootCommand("C# REPL")
+        foreach (var option in new Option[]
         {
             References, Usings, Framework, Theme, UseTerminalPaletteTheme, Prompt, UseUnicode, UsePrereleaseNugets,
             StreamPipedInput, Trace, Version, Help, TabSize,
             OpenAIApiKey, OpenAIPrompt, OpenAIModel, OpenAIHistoryCount,
             TriggerCompletionListKeyBindings, NewLineKeyBindings, SubmitPromptKeyBindings, SubmitPromptDetailedKeyBindings,
             Configure, Culture,
-        };
-        var commandLine = new CommandLineBuilder(availableCommands)
-            .EnableLegacyDoubleDashBehavior() // for passing tokens after "--" as load script arguments
-            .UseSuggestDirective() // support autocompletion via dotnet-suggest
-            .Build()
-            .Parse(parseArgs);
+        })
+        {
+            availableCommands.Options.Add(option);
+        }
+
+        var commandLine = availableCommands.Parse(parseArgs);
 
         if (!File.Exists(configFilePath))
         {
             ConfigurationFile.CreateDefaultConfigurationFile(configFilePath, availableCommands, ignoreCommands: new[] { Help, Version, Configure });
         }
 
-        if (commandLine.GetValueForOption(Configure))
+        if (commandLine.GetValue(Configure))
         {
             ConfigurationFile.LaunchEditor(configFilePath);
             return new Configuration(outputForEarlyExit: "Launching editor for " + configFilePath);
@@ -215,34 +222,34 @@ internal static class CommandLine
         }
         if (commandLine.Errors.Count > 0)
         {
-            throw new InvalidOperationException(string.Join(NewLine, commandLine.Errors));
+            throw new InvalidOperationException(string.Join(NewLine, commandLine.Errors.Select(e => e.Message)));
         }
 
         var config = new Configuration(
-            references: commandLine.GetValueForOption(References),
-            usings: commandLine.GetValueForOption(Usings),
-            framework: commandLine.GetValueForOption(Framework),
+            references: commandLine.GetValue(References),
+            usings: commandLine.GetValue(Usings),
+            framework: commandLine.GetValue(Framework),
             loadScript: ProcessScriptArguments(args),
-            loadScriptArgs: commandLine.UnparsedTokens.ToArray(),
-            theme: commandLine.GetValueForOption(Theme),
-            useTerminalPaletteTheme: commandLine.GetValueForOption(UseTerminalPaletteTheme),
-            promptMarkup: commandLine.GetValueForOption(Prompt) ?? Configuration.PromptDefault,
-            useUnicode: commandLine.GetValueForOption(UseUnicode),
-            usePrereleaseNugets: commandLine.GetValueForOption(UsePrereleaseNugets),
-            streamPipedInput: commandLine.GetValueForOption(StreamPipedInput),
-            tabSize: commandLine.GetValueForOption(TabSize),
-            trace: commandLine.GetValueForOption(Trace),
-            triggerCompletionListKeyPatterns: commandLine.GetValueForOption(TriggerCompletionListKeyBindings),
-            newLineKeyPatterns: commandLine.GetValueForOption(NewLineKeyBindings),
-            submitPromptKeyPatterns: commandLine.GetValueForOption(SubmitPromptKeyBindings),
-            submitPromptDetailedKeyPatterns: commandLine.GetValueForOption(SubmitPromptDetailedKeyBindings),
+            loadScriptArgs: GetLoadScriptArgs(args),
+            theme: commandLine.GetValue(Theme),
+            useTerminalPaletteTheme: commandLine.GetValue(UseTerminalPaletteTheme),
+            promptMarkup: commandLine.GetValue(Prompt) ?? Configuration.PromptDefault,
+            useUnicode: commandLine.GetValue(UseUnicode),
+            usePrereleaseNugets: commandLine.GetValue(UsePrereleaseNugets),
+            streamPipedInput: commandLine.GetValue(StreamPipedInput),
+            tabSize: commandLine.GetValue(TabSize),
+            trace: commandLine.GetValue(Trace),
+            triggerCompletionListKeyPatterns: commandLine.GetValue(TriggerCompletionListKeyBindings),
+            newLineKeyPatterns: commandLine.GetValue(NewLineKeyBindings),
+            submitPromptKeyPatterns: commandLine.GetValue(SubmitPromptKeyBindings),
+            submitPromptDetailedKeyPatterns: commandLine.GetValue(SubmitPromptDetailedKeyBindings),
             openAIConfiguration: new OpenAIConfiguration(
-                apiKey: commandLine.GetValueForOption(OpenAIApiKey) ?? OpenAICompleteService.ApiKey,
-                prompt: commandLine.GetValueForOption(OpenAIPrompt) ?? OpenAICompleteService.DefaultPrompt,
-                model: commandLine.GetValueForOption(OpenAIModel) ?? OpenAICompleteService.DefaultModel,
-                historyCount: commandLine.GetValueForOption(OpenAIHistoryCount) ?? OpenAICompleteService.DefaultHistoryEntryCount
+                apiKey: commandLine.GetValue(OpenAIApiKey) ?? OpenAICompleteService.ApiKey,
+                prompt: commandLine.GetValue(OpenAIPrompt) ?? OpenAICompleteService.DefaultPrompt,
+                model: commandLine.GetValue(OpenAIModel) ?? OpenAICompleteService.DefaultModel,
+                historyCount: commandLine.GetValue(OpenAIHistoryCount) ?? OpenAICompleteService.DefaultHistoryEntryCount
             ),
-            cultureName: commandLine.GetValueForOption(Culture)
+            cultureName: commandLine.GetValue(Culture)
         );
 
         return config;
@@ -250,21 +257,21 @@ internal static class CommandLine
 
     private static bool ShouldExitEarly(ParseResult commandLine, string configFilePath, out FormattedString text)
     {
-        if (commandLine.Directives.Any())
+        if (commandLine.Tokens.Any(token => token.Type == TokenType.Directive))
         {
             // this is just for dotnet-suggest directive processing. Invoking should write to stdout
             // and should not start the REPL. It's a feature of System.CommandLine.
-            var console = new TestConsole();
-            commandLine.Invoke(console);
-            text = console.Out.ToString() ?? string.Empty;
+            var output = new StringWriter();
+            commandLine.Invoke(new InvocationConfiguration { Output = output });
+            text = output.ToString();
             return true;
         }
-        if (commandLine.GetValueForOption(Help))
+        if (commandLine.GetValue(Help))
         {
             text = GetHelp(configFilePath);
             return true;
         }
-        if (commandLine.GetValueForOption(Version))
+        if (commandLine.GetValue(Version))
         {
             text = GetVersion();
             return true;
@@ -297,18 +304,32 @@ internal static class CommandLine
             yield return "@" + configFilePath;
         }
 
-        // We allow csx files to be specified, sometimes in ambiguous scenarios that
-        // System.CommandLine can't figure out. So we remove it from processing here,
-        // and process it manually in ProcessScriptArguments
-        bool foundIgnore = false;
         foreach (var arg in args)
         {
-            foundIgnore |= arg == DisableFurtherOptionParsing;
-            if (foundIgnore || !arg.EndsWith(".csx"))
+            // Everything after "--" is forwarded to the load script as arguments (see
+            // GetLoadScriptArgs), so stop handing tokens to the parser here. System.CommandLine v3
+            // no longer has a dedicated "unparsed tokens" bucket for these and would otherwise
+            // report them as unrecognized arguments.
+            if (arg == DisableFurtherOptionParsing) yield break;
+
+            // We allow csx files to be specified, sometimes in ambiguous scenarios that
+            // System.CommandLine can't figure out. So we remove it from processing here,
+            // and process it manually in ProcessScriptArguments
+            if (!arg.EndsWith(".csx"))
             {
                 yield return arg;
             }
         }
+    }
+
+    /// <summary>
+    /// Arguments after the "--" token are not parsed as options; they're forwarded to the
+    /// load script and made available via a global `args` variable.
+    /// </summary>
+    private static string[] GetLoadScriptArgs(string[] args)
+    {
+        var doubleDashIndex = Array.IndexOf(args, DisableFurtherOptionParsing);
+        return doubleDashIndex >= 0 ? args[(doubleDashIndex + 1)..] : [];
     }
 
     /// <summary>

--- a/CSharpRepl/ConfigurationFile.cs
+++ b/CSharpRepl/ConfigurationFile.cs
@@ -24,7 +24,8 @@ internal static class ConfigurationFile
         {
             var availableOptions = commandLine.Options
                 .Where(option => !ignoreCommands.Contains(option))
-                .Select(option => $"{NewLine}# {option.Description}{NewLine}# --{option.Name} <{option.ValueType.Name.ToLower()}>");
+                // In System.CommandLine v3 Option.Name includes the leading "--" prefix.
+                .Select(option => $"{NewLine}# {option.Description}{NewLine}# {option.Name} <{option.ValueType.Name.ToLower()}>");
             File.WriteAllText(
                 configFilePath,
                 "# Add csharprepl command line options to this file to configure csharprepl." + NewLine +


### PR DESCRIPTION
Nuget Upgrade:

Breaking changes to handle internally:

- System.CommandLine had a major API change that required extensive changes to our CommandLine.cs file
- Spectre.Console added `WriteAnsi` that we need to add to our interfaces
- Spectre.Console changed Style from class to struct (only affected our unit tests)
- `Microsoft.Build.Framework` changes to resolve to fix new warning `MSBL001`