### PR TITLE
Bump PrettyPrompt and Microsoft.Build.Framework dependencies

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -21,14 +21,16 @@
       runtime, so the MSBuild assemblies must NOT be copied to our output directory (otherwise they
       shadow the SDK's and cause version-skew failures). ExcludeAssets="runtime" keeps the
       compile-time reference but stops the runtime copy. This is the fix the MSBL001 check requires.
+      The same is required for Microsoft.NET.StringTools, a dependency of Microsoft.Build.Framework.
       See https://aka.ms/msbuild/locator/diagnostics/MSBL001
     -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.727501" />
     <PackageReference Include="OpenAI" Version="2.10.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.1.1" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="Spectre.Console.Ansi" Version="0.55.2" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -16,15 +16,16 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="4.1.1" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.108" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
-    <!-- Keep MSBuild assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
+    <!-- Keep MSBuild/StringTools assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
          arrives transitively through the CSharpRepl.Services project reference.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,13 +25,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="4.1.1" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
     <PackageReference Include="System.CommandLine" Version="3.0.0-preview.4.26230.115" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />
-    <!-- Keep MSBuild assemblies out of the output dir; they're loaded from the SDK via
+    <!-- Keep MSBuild/StringTools assemblies out of the output dir; they're loaded from the SDK via
          MSBuildLocator at runtime. Required transitively through CSharpRepl.Services.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
More nuget upgrades -- main benefit of PrettyPrompt 5.0 is better unicode support and performance.