### PR TITLE
Add benchmark project and fix a few performance issues

### DIFF
--- a/CSharpRepl.Benchmarks/AllocationBreakdownBenchmark.cs
+++ b/CSharpRepl.Benchmarks/AllocationBreakdownBenchmark.cs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Text;
+
+namespace CSharpRepl.Benchmarks;
+
+/// <summary>
+/// Attributes the per-keystroke highlight cost (and its allocation) to a stage of the Roslyn pipeline,
+/// to find where the ~36 MB/keystroke at depth 50 comes from. The session is a *dependent* chain — each
+/// prior submission references the previous one (var sN = s(N-1) + 1) — and the "typed" line references
+/// the most-recent variable, so binding must resolve through the whole submission chain.
+///
+/// Compare the Allocated column across stages at PriorSubmissions=50:
+///   Fork           - just CurrentDocument.WithText (no analysis)
+///   GetSyntaxRoot  - parse the current submission (expected depth-independent)
+///   GetCompilation - build the project's Compilation (walks the submission-project chain)
+///   GetSemanticModel - compilation + bind the current document
+///   Classify       - what production highlighting actually calls each keystroke
+///
+/// Run with: dotnet run -c Release --project CSharpRepl.Benchmarks -- --filter *AllocationBreakdown*
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class AllocationBreakdownBenchmark
+{
+    [Params(0, 50)]
+    public int PriorSubmissions;
+
+    private RoslynServices roslyn = null!;
+    private Document baseDocument = null!;
+    private string typedLine = "";
+    private int counter;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var config = new Configuration(useTerminalPaletteTheme: true);
+        roslyn = new RoslynServices(new BenchmarkConsole(), config, new NullTraceLogger());
+        roslyn.WarmUpAsync(Array.Empty<string>()).GetAwaiter().GetResult();
+
+        for (int i = 0; i < PriorSubmissions; i++)
+        {
+            var code = i == 0 ? "var s0 = 0;" : $"var s{i} = s{i - 1} + 1;";
+            var result = roslyn.EvaluateAsync(code).GetAwaiter().GetResult();
+            if (result is not EvaluationResult.Success)
+                throw new InvalidOperationException($"Setup submission {i} failed: {result}");
+        }
+
+        baseDocument = roslyn.CurrentDocumentForProfiling!;
+        // Reference the most-recent variable, forcing binding through the chain (depth-0 case uses a framework call).
+        typedLine = PriorSubmissions == 0 ? "System.Console.WriteLine(1)" : $"s{PriorSubmissions - 1}.ToString()";
+    }
+
+    // A fresh fork each invocation (unique trailing comment) so the per-keystroke "buffer changed" path is
+    // measured, not a cached re-render.
+    private Document Current() => baseDocument.WithText(SourceText.From(typedLine + "\n//" + counter++));
+
+    [Benchmark(Description = "1. WithText (fork only)")]
+    public Document Fork() => Current();
+
+    [Benchmark(Description = "2. GetSyntaxRoot (parse)")]
+    public async Task<SyntaxNode?> GetSyntaxRoot() => await Current().GetSyntaxRootAsync();
+
+    [Benchmark(Description = "3. GetCompilation (build chain)")]
+    public async Task<Compilation?> GetCompilation() => await Current().Project.GetCompilationAsync();
+
+    [Benchmark(Description = "4. GetSemanticModel (bind)")]
+    public async Task<SemanticModel?> GetSemanticModel() => await Current().GetSemanticModelAsync();
+
+    [Benchmark(Baseline = true, Description = "5. GetClassifiedSpans (full = production)")]
+    public async Task<int> Classify()
+    {
+        var doc = Current();
+        var length = (await doc.GetTextAsync()).Length;
+        var spans = await Classifier.GetClassifiedSpansAsync(doc, TextSpan.FromBounds(0, length));
+        return spans.Count();
+    }
+}

--- a/CSharpRepl.Benchmarks/BenchmarkSupport.cs
+++ b/CSharpRepl.Benchmarks/BenchmarkSupport.cs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Logging;
+using PrettyPrompt.Consoles;
+using Spectre.Console;
+
+namespace CSharpRepl.Benchmarks;
+
+/// <summary>
+/// Minimal <see cref="IConsoleService"/> for benchmarks. The per-keystroke Roslyn paths
+/// (highlight / complete / format) only touch the console on initialization or warm-up errors,
+/// plus the rendering <see cref="Profile"/>, so every sink here is a no-op.
+/// </summary>
+internal sealed class BenchmarkConsole : IConsoleService
+{
+    private readonly IConsole prettyPromptConsole = new NullPromptConsole();
+    private readonly IAnsiConsole ansi = AnsiConsole.Create(new AnsiConsoleSettings
+    {
+        Ansi = AnsiSupport.No,
+        ColorSystem = ColorSystemSupport.NoColors,
+        Out = new AnsiConsoleOutput(TextWriter.Null),
+    });
+
+    IConsole IConsoleService.PrettyPromptConsole => prettyPromptConsole;
+    IAnsiConsole IConsoleService.Ansi => ansi;
+    public string? ReadLine() => null;
+
+    private sealed class NullPromptConsole : IConsole
+    {
+        public int CursorTop => 0;
+        public int BufferWidth => 240;
+        public int WindowHeight => 80;
+        public int WindowTop => 0;
+        public bool KeyAvailable => false;
+        public bool CaptureControlC { get => false; set { } }
+        public bool IsErrorRedirected => false;
+        public event ConsoleCancelEventHandler CancelKeyPress { add { } remove { } }
+        public void Clear() { }
+        public void HideCursor() { }
+        public void InitVirtualTerminalProcessing() { }
+        public ConsoleKeyInfo ReadKey(bool intercept) => default;
+        public void ShowCursor() { }
+        public void Write(string? value) { }
+        public void WriteError(string? value) { }
+        public void WriteErrorLine(string? value) { }
+        public void WriteLine(string? value) { }
+        public void Write(ReadOnlySpan<char> value) { }
+        public void WriteError(ReadOnlySpan<char> value) { }
+        public void WriteErrorLine(ReadOnlySpan<char> value) { }
+        public void WriteLine(ReadOnlySpan<char> value) { }
+    }
+}
+
+/// <summary>No-op trace logger; the real one only matters with the --trace flag.</summary>
+internal sealed class NullTraceLogger : ITraceLogger
+{
+    public void Log(string message) { }
+    public void Log(Func<string> message) { }
+    public void LogPaths(string message, Func<IEnumerable<string?>> paths) { }
+}

--- a/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
+++ b/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <!-- Keep MSBuild/StringTools assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
+         arrives transitively through the CSharpRepl.Services project reference.
+         See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpRepl.Services\CSharpRepl.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CSharpRepl.Benchmarks/ChainedEvaluationBenchmark.cs
+++ b/CSharpRepl.Benchmarks/ChainedEvaluationBenchmark.cs
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+
+namespace CSharpRepl.Benchmarks;
+
+/// <summary>
+/// Profiles the *evaluation* path of a dependent submission chain: each submission references the variable
+/// declared by the previous one (var sN = s(N-1) + 1), so every evaluation extends a chain the next must
+/// bind through. Measures the wall-clock and allocation to build a <see cref="ChainLength"/>-deep session.
+///
+/// RunStrategy.Monitoring + invocationCount=1 means each measured run is a single full chain build, preceded
+/// by a fresh RoslynServices in [IterationSetup] (evaluation mutates script state, so it can't be reused).
+///
+/// Run with: dotnet run -c Release --project CSharpRepl.Benchmarks -- --filter *ChainedEvaluation*
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Monitoring, launchCount: 1, warmupCount: 1, iterationCount: 5, invocationCount: 1)]
+public class ChainedEvaluationBenchmark
+{
+    [Params(10, 50)]
+    public int ChainLength;
+
+    private RoslynServices roslyn = null!;
+
+    // Fresh services per measured run; not timed (only the [Benchmark] body is measured).
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        var config = new Configuration(useTerminalPaletteTheme: true);
+        roslyn = new RoslynServices(new BenchmarkConsole(), config, new NullTraceLogger());
+        roslyn.WarmUpAsync(Array.Empty<string>()).GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task EvaluateChain()
+    {
+        for (int i = 0; i < ChainLength; i++)
+        {
+            var code = i == 0 ? "var s0 = 0;" : $"var s{i} = s{i - 1} + 1;";
+            var result = await roslyn.EvaluateAsync(code);
+            if (result is not EvaluationResult.Success)
+                throw new InvalidOperationException($"submission {i} failed: {result}");
+        }
+    }
+}

--- a/CSharpRepl.Benchmarks/ColdStartDiagnostic.cs
+++ b/CSharpRepl.Benchmarks/ColdStartDiagnostic.cs
@@ -103,13 +103,23 @@ internal static class ColdStartDiagnostic
         var shouldOpen = await roslyn.ShouldOpenCompletionWindowAsync(text, caret, key, default);
         Console.WriteLine($"  2. ShouldOpenCompletionWindow {t.Elapsed.TotalMilliseconds,8:F1} ms   (= {shouldOpen})");
 
-        t.Restart();
-        _ = await roslyn.GetSpanToReplaceByCompletionAsync(text, caret, default);
-        Console.WriteLine($"  3. GetSpanToReplace           {t.Elapsed.TotalMilliseconds,8:F1} ms");
+        // Steps 3 & 4 only happen when the window actually opens — exactly as PrettyPrompt drives them.
+        // While completion is suppressed during warm-up, ShouldOpen returns false and the app makes neither call.
+        if (shouldOpen)
+        {
+            t.Restart();
+            _ = await roslyn.GetSpanToReplaceByCompletionAsync(text, caret, default);
+            Console.WriteLine($"  3. GetSpanToReplace           {t.Elapsed.TotalMilliseconds,8:F1} ms");
 
-        t.Restart();
-        var completions = await roslyn.CompleteAsync(text, caret, default);
-        Console.WriteLine($"  4. Complete                   {t.Elapsed.TotalMilliseconds,8:F1} ms   ({completions.Count} items)");
+            t.Restart();
+            var completions = await roslyn.CompleteAsync(text, caret, default);
+            Console.WriteLine($"  4. Complete                   {t.Elapsed.TotalMilliseconds,8:F1} ms   ({completions.Count} items)");
+        }
+        else
+        {
+            Console.WriteLine($"  3. GetSpanToReplace                  -      (window suppressed)");
+            Console.WriteLine($"  4. Complete                          -      (window suppressed)");
+        }
 
         Console.WriteLine($"  ============================================");
         Console.WriteLine($"  first-keystroke total         {total.Elapsed.TotalMilliseconds,8:F1} ms");

--- a/CSharpRepl.Benchmarks/ColdStartDiagnostic.cs
+++ b/CSharpRepl.Benchmarks/ColdStartDiagnostic.cs
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Logging;
+using CSharpRepl.Services.Roslyn;
+using PrettyPrompt.Consoles;
+
+namespace CSharpRepl.Benchmarks;
+
+/// <summary>Trace logger that prints each warm-up milestone with the elapsed time since construction.</summary>
+internal sealed class TimestampingTraceLogger : ITraceLogger
+{
+    private readonly Stopwatch sw = Stopwatch.StartNew();
+    public void Log(string message) => Console.WriteLine($"    [{sw.ElapsedMilliseconds,6}ms] {message}");
+    public void Log(Func<string> message) { }
+    public void LogPaths(string message, Func<IEnumerable<string?>> paths) { }
+}
+
+/// <summary>
+/// NOT a BenchmarkDotNet benchmark. BenchmarkDotNet measures warm steady-state by design (it JIT-warms before
+/// measuring), so it is blind to the thing we care about here: the cost the user pays on the *very first*
+/// keystroke of a session, which is dominated by first-run JIT + first-compilation of the editor pipeline.
+///
+/// Each invocation must be a fresh process to observe true cold cost — once a code path JITs, it stays JIT'd.
+/// Run one mode per process:
+///   dotnet run -c Release --project CSharpRepl.Benchmarks -- coldstart raw      # init done, pipeline cold (worst case)
+///   dotnet run -c Release --project CSharpRepl.Benchmarks -- coldstart warmed   # full WarmUpAsync awaited first (best case)
+///   dotnet run -c Release --project CSharpRepl.Benchmarks -- coldstart race     # warmup fired-and-forgotten, then type after a short delay (real app)
+/// </summary>
+internal static class ColdStartDiagnostic
+{
+    public static async Task RunAsync(string mode)
+    {
+        var sw = Stopwatch.StartNew();
+        var config = new Configuration(useTerminalPaletteTheme: true); // avoids theme-file I/O
+
+        // "warmtiming": just print when each warm-up milestone is reached (editor path vs. full warmup).
+        if (mode == "warmtiming")
+        {
+            var r = new RoslynServices(new BenchmarkConsole(), config, new TimestampingTraceLogger());
+            var ws = Stopwatch.StartNew();
+            await r.WarmUpAsync(Array.Empty<string>());
+            Console.WriteLine($"[{mode}] WarmUpAsync fully completed in {ws.ElapsedMilliseconds}ms");
+            return;
+        }
+
+        var roslyn = new RoslynServices(new BenchmarkConsole(), config, new NullTraceLogger());
+        Console.WriteLine($"[{mode}] RoslynServices ctor returned at {sw.ElapsedMilliseconds}ms");
+
+        switch (mode)
+        {
+            case "warmed":
+            {
+                var ws = Stopwatch.StartNew();
+                await roslyn.WarmUpAsync(Array.Empty<string>());
+                Console.WriteLine($"[{mode}] WarmUpAsync completed in {ws.ElapsedMilliseconds}ms");
+                break;
+            }
+            case "race":
+            {
+                // Mirror Preload: fire-and-forget, then the user reads the banner and reaches for the keyboard.
+                _ = roslyn.WarmUpAsync(Array.Empty<string>());
+                var delay = int.Parse(Environment.GetEnvironmentVariable("RACE_DELAY_MS") ?? "200");
+                await Task.Delay(delay);
+                Console.WriteLine($"[{mode}] typed after {delay}ms (warmup still running in background)");
+                break;
+            }
+            default: // "raw": let background init finish, but leave the keystroke pipeline un-JIT'd.
+            {
+                // CurrentDocumentForProfiling is null until Initialization completes; polling it does not
+                // touch the highlight/completion code paths, so the pipeline stays cold.
+                while (roslyn.CurrentDocumentForProfiling is null)
+                    await Task.Delay(5);
+                Console.WriteLine($"[{mode}] background init complete at {sw.ElapsedMilliseconds}ms");
+                break;
+            }
+        }
+
+        // The very first keystroke. Typing 's' as the first character drives exactly these PrettyPrompt
+        // callbacks, in this order, serially (see CSharpReplPromptCallbacks + Prompt.ReadLineAsync):
+        //   1. HighlightCallbackAsync          -> roslyn.SyntaxHighlightAsync
+        //   2. ShouldOpenCompletionWindowAsync -> roslyn.ShouldOpenCompletionWindowAsync
+        //   3. (window opens) GetSpanToReplaceByCompletionAsync
+        //   4. (window opens) GetCompletionItemsAsync -> roslyn.CompleteAsync
+        const string text = "s";
+        const int caret = 1;
+        var key = new KeyPress(new ConsoleKeyInfo('s', ConsoleKey.S, shift: false, alt: false, control: false));
+
+        Console.WriteLine($"[{mode}] --- first keystroke ('{text}') ---");
+        var total = Stopwatch.StartNew();
+
+        var t = Stopwatch.StartNew();
+        var spans = await roslyn.SyntaxHighlightAsync(text);
+        Console.WriteLine($"  1. Highlight                  {t.Elapsed.TotalMilliseconds,8:F1} ms   ({spans.Count} spans)");
+
+        t.Restart();
+        var shouldOpen = await roslyn.ShouldOpenCompletionWindowAsync(text, caret, key, default);
+        Console.WriteLine($"  2. ShouldOpenCompletionWindow {t.Elapsed.TotalMilliseconds,8:F1} ms   (= {shouldOpen})");
+
+        t.Restart();
+        _ = await roslyn.GetSpanToReplaceByCompletionAsync(text, caret, default);
+        Console.WriteLine($"  3. GetSpanToReplace           {t.Elapsed.TotalMilliseconds,8:F1} ms");
+
+        t.Restart();
+        var completions = await roslyn.CompleteAsync(text, caret, default);
+        Console.WriteLine($"  4. Complete                   {t.Elapsed.TotalMilliseconds,8:F1} ms   ({completions.Count} items)");
+
+        Console.WriteLine($"  ============================================");
+        Console.WriteLine($"  first-keystroke total         {total.Elapsed.TotalMilliseconds,8:F1} ms");
+    }
+}

--- a/CSharpRepl.Benchmarks/PerKeystrokeBenchmark.cs
+++ b/CSharpRepl.Benchmarks/PerKeystrokeBenchmark.cs
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using CSharpRepl.Services;
+using CSharpRepl.Services.Roslyn;
+using CSharpRepl.Services.Roslyn.Scripting;
+using PrettyPrompt.Consoles;
+
+namespace CSharpRepl.Benchmarks;
+
+/// <summary>
+/// Measures the Roslyn-backed callbacks that PrettyPrompt invokes on the input loop. The loop is serial:
+/// each keystroke is processed to completion (see PrettyPrompt's Prompt.ReadLineAsync) before the next key
+/// is read, so the wall-clock here is exactly the input latency a keystroke pays — there is no per-keystroke
+/// cancellation, the token threaded into these callbacks is always CancellationToken.None.
+///
+/// <para><see cref="PriorSubmissions"/> grows the linked list of Roslyn projects (each evaluation appends a
+/// project with a ProjectReference to the previous one — see WorkspaceManager), letting us see whether
+/// per-keystroke cost scales with how long the session has been running.</para>
+///
+/// Run with: dotnet run -c Release --project CSharpRepl.Benchmarks -- --filter *PerKeystroke*
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class PerKeystrokeBenchmark
+{
+    [Params(0, 10, 50)]
+    public int PriorSubmissions;
+
+    // A representative line mid-typing: a member-access that forces real semantic binding.
+    // The caret sits right after the partial member name, as it would while typing.
+    private const string TypedLine = "System.Console.Wri";
+    private const int Caret = 18; // == TypedLine.Length
+
+    private RoslynServices roslyn = null!;
+    private int counter;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var config = new Configuration(useTerminalPaletteTheme: true); // avoids theme-file I/O
+        roslyn = new RoslynServices(new BenchmarkConsole(), config, new NullTraceLogger());
+
+        // WarmUpAsync awaits initialization and exercises the compile/highlight pipeline so we measure
+        // warm steady-state, not first-use JIT/metadata-table construction.
+        roslyn.WarmUpAsync(Array.Empty<string>()).GetAwaiter().GetResult();
+
+        for (int i = 0; i < PriorSubmissions; i++)
+        {
+            var result = roslyn.EvaluateAsync($"var s{i} = {i};").GetAwaiter().GetResult();
+            if (result is not EvaluationResult.Success)
+                throw new InvalidOperationException($"Setup submission {i} failed: {result}");
+        }
+    }
+
+    // Every keystroke changes the buffer, so CSharpRepl's highlight cache (keyed on the full text) misses
+    // during real typing. A unique trailing comment forces that miss, measuring the true per-keystroke cost.
+    [Benchmark(Baseline = true, Description = "Highlight (cache miss = real typing)")]
+    public async Task<int> Highlight_CacheMiss()
+        => (await roslyn.SyntaxHighlightAsync(Unique(TypedLine))).Count;
+
+    // Identical text every call: a cache hit. This is the re-render path (cursor move, resize, completion-list
+    // navigation) — what the cache actually buys. Contrast its time with the cache-miss baseline above.
+    [Benchmark(Description = "Highlight (cache hit = re-render)")]
+    public async Task<int> Highlight_CacheHit()
+        => (await roslyn.SyntaxHighlightAsync(TypedLine)).Count;
+
+    [Benchmark(Description = "Completion list compute")]
+    public async Task<int> Complete()
+        => (await roslyn.CompleteAsync(UniqueTrailing(TypedLine), Caret)).Count;
+
+    [Benchmark(Description = "ShouldOpenCompletionWindow (every key)")]
+    public async Task<bool> ShouldOpenCompletionWindow()
+    {
+        var key = new KeyPress(new ConsoleKeyInfo('i', ConsoleKey.I, shift: false, alt: false, control: false));
+        return await roslyn.ShouldOpenCompletionWindowAsync(TypedLine, Caret, key, CancellationToken.None);
+    }
+
+    [Benchmark(Description = "IsCompleteStatement (Enter)")]
+    public Task<bool> IsCompleteStatement()
+        => roslyn.IsTextCompleteStatementAsync(Unique(TypedLine));
+
+    [Benchmark(Description = "FormatInput (on ; } {)")]
+    public async Task<int> FormatInput()
+        => (await roslyn.FormatInput(UniqueTrailing(TypedLine), Caret, formatParentNodeOnly: false, CancellationToken.None)).Text.Length;
+
+    // Appends a unique trailing line comment to defeat the text-keyed cache while keeping classification cost
+    // and the caret position (which stays within the original line) stable across invocations.
+    private string UniqueTrailing(string text) => text + "\n//" + counter++;
+
+    // Same idea for calls where caret doesn't matter.
+    private string Unique(string text) => text + "\n//" + counter++;
+}

--- a/CSharpRepl.Benchmarks/Program.cs
+++ b/CSharpRepl.Benchmarks/Program.cs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using BenchmarkDotNet.Running;
+
+// With no args, run every benchmark non-interactively. Pass BenchmarkDotNet filters to scope a run, e.g.
+//   dotnet run -c Release --project CSharpRepl.Benchmarks -- --filter *Highlight*
+var switcher = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
+if (args.Length == 0)
+{
+    switcher.RunAll();
+}
+else
+{
+    switcher.Run(args);
+}
+
+// Top-level statements generate a Program class; declaring it partial lets BenchmarkSwitcher reference typeof(Program).
+public partial class Program { }

--- a/CSharpRepl.Benchmarks/Program.cs
+++ b/CSharpRepl.Benchmarks/Program.cs
@@ -3,6 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using BenchmarkDotNet.Running;
+using CSharpRepl.Benchmarks;
+
+// Cold-start diagnostic (not a BenchmarkDotNet benchmark): `coldstart <raw|warmed|race>`.
+// Run one mode per fresh process to observe true first-keystroke cost. See ColdStartDiagnostic.
+if (args.Length >= 1 && args[0] == "coldstart")
+{
+    await ColdStartDiagnostic.RunAsync(args.Length >= 2 ? args[1] : "raw");
+    return;
+}
 
 // With no args, run every benchmark non-interactively. Pass BenchmarkDotNet filters to scope a run, e.g.
 //   dotnet run -c Release --project CSharpRepl.Benchmarks -- --filter *Highlight*

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -60,6 +60,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="CSharpRepl.Tests" />
+    <InternalsVisibleTo Include="CSharpRepl.Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -47,8 +47,11 @@ public sealed partial class RoslynServices
     private readonly IConsoleService console;
     private readonly ITraceLogger logger;
     private readonly SemaphoreSlim semaphore = new(1);
-    private readonly object warmUpLock = new();
     private Task? warmUpTask;
+
+    // false until the per-keystroke editor path has been warmed up (see WarmUpCoreAsync). While warm-up is running, the completion callbacks early exit so the user's first keystrokes don't lag.
+    private volatile bool editorPathWarmedUp;
+
     private readonly IPromptCallbacks defaultPromptCallbacks = new PromptCallbacks();
     private readonly ThreadLocal<OverloadItemGenerator> overloadItemGenerator;
     private readonly CSharpParseOptions parseOptions = CSharpParseOptions.Default.WithKind(SourceCodeKind.Script).WithLanguageVersion(LanguageVersion.Latest);
@@ -210,7 +213,17 @@ public sealed partial class RoslynServices
             .ToList();
     }
 
-    public async Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteAsync(string text, int caret, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteAsync(string text, int caret, CancellationToken cancellationToken = default)
+    {
+        // Suppress completion while warm-up is still warming the editor path. the first time the completion engine runs it pays a large one-time JIT cost
+        // of Microsoft.CodeAnalysis.* (~600ms), which is the main source of first-keystroke lag. Returning nothing here keeps early keystrokes instant.
+        if (warmUpTask is not null && !editorPathWarmedUp)
+            return Task.FromResult<IReadOnlyCollection<CompletionItemWithDescription>>([]);
+
+        return CompleteCoreAsync(text, caret, cancellationToken);
+    }
+
+    private async Task<IReadOnlyCollection<CompletionItemWithDescription>> CompleteCoreAsync(string text, int caret, CancellationToken cancellationToken)
     {
         if (!Initialization.IsCompleted)
             return [];
@@ -266,7 +279,7 @@ public sealed partial class RoslynServices
         return new PrettyPromptTextSpan(span.Start, span.Length);
     }
 
-    public async Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+    public Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
         var keyChar = keyPress.ConsoleKeyInfo.KeyChar;
         var keyModifiers = keyPress.ConsoleKeyInfo.Modifiers;
@@ -274,9 +287,19 @@ public sealed partial class RoslynServices
             (keyModifiers & ConsoleModifiers.Control) != 0 ||
             (keyModifiers & ConsoleModifiers.Alt) != 0)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
+        // Don't auto-open the completion window while warming up (and avoid this check's own cold cost) — see
+        // CompleteAsync. The warm-up drives ShouldOpenCompletionWindowCoreAsync directly so it still warms.
+        if (warmUpTask is not null && !editorPathWarmedUp)
+            return Task.FromResult(false);
+
+        return ShouldOpenCompletionWindowCoreAsync(text, caret, keyPress, cancellationToken);
+    }
+
+    private async Task<bool> ShouldOpenCompletionWindowCoreAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+    {
         await Initialization.ConfigureAwait(false);
 
         var sourceText = SourceText.From(text);
@@ -288,7 +311,7 @@ public sealed partial class RoslynServices
             return await defaultPromptCallbacks.ShouldOpenCompletionWindowAsync(text, caret, keyPress, cancellationToken);
         }
 
-        var trigger = CompletionTrigger.CreateInsertionTrigger(keyChar);
+        var trigger = CompletionTrigger.CreateInsertionTrigger(keyPress.ConsoleKeyInfo.KeyChar);
         return completionService.ShouldTriggerCompletion(sourceText, caret, trigger);
     }
 
@@ -440,17 +463,21 @@ public sealed partial class RoslynServices
     /// Roslyn services can be a bit slow to initialize the first time they're executed.
     /// Warm them up in the background so it doesn't affect the user.
     /// </summary>
-    /// <remarks>
-    /// Idempotent: the warm-up runs once per instance and later calls return the same task. Production
-    /// warms exactly once, but tests share a single instance and warm it repeatedly.
-    /// </remarks>
     public Task WarmUpAsync(string[] args)
     {
         if (warmUpTask is not null) return warmUpTask;
-        lock (warmUpLock)
+
+        // Publish the warm-up task atomically, no dedicated lock object needed. It's created cold (not
+        // started) so a caller that loses the race doesn't kick off a duplicate, orphaned warm-up .
+        // Use CompareExchange because we can't lock on warmUpTask as it's null here.
+        var pending = new Task<Task>(() => WarmUpCoreAsync(args));
+        var warmUp = pending.Unwrap();
+        if (Interlocked.CompareExchange(ref warmUpTask, warmUp, null) is null)
         {
-            return warmUpTask ??= WarmUpCoreAsync(args);
+            pending.Start();
+            return warmUp;
         }
+        return warmUpTask;
     }
 
     private Task WarmUpCoreAsync(string[] args) =>
@@ -465,15 +492,18 @@ public sealed partial class RoslynServices
             var completionKey = new KeyPress(new ConsoleKeyInfo('C', ConsoleKey.C, shift: false, alt: false, control: false));
             var highlightTask = SyntaxHighlightAsync(@"_ = ""REPL Warmup""");
             var formattingTask = FormatInput(@"_=""REPL Warmup"";", caret: 16, formatParentNodeOnly: false, default);
-            var shouldOpenTask = ShouldOpenCompletionWindowAsync(completionSample, caret: 1, completionKey, default);
+            var shouldOpenTask = ShouldOpenCompletionWindowCoreAsync(completionSample, caret: 1, completionKey, default);
             var spanToReplaceTask = GetSpanToReplaceByCompletionAsync(completionSample, caret: 1, default);
             var completionTask = Task.WhenAny(
-                (await CompleteAsync(completionSample, 1))
+                (await CompleteCoreAsync(completionSample, 1, default))
                     .Where(completion => completion.Item.DisplayText.StartsWith("C"))
                     .Take(15)
                     .Select(completion => completion.GetDescriptionAsync(cancellationToken: default))
             );
             await Task.WhenAll(highlightTask, formattingTask, shouldOpenTask, spanToReplaceTask, completionTask).ConfigureAwait(false);
+
+            // Editor path is warm: let the public completion callbacks serve real results from here on.
+            editorPathWarmedUp = true;
             logger.Log("Warm-up: editor path warm");
 
             // Now warm the evaluation path (compile + emit + load + run). This also loads the runtime helper

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -47,6 +47,8 @@ public sealed partial class RoslynServices
     private readonly IConsoleService console;
     private readonly ITraceLogger logger;
     private readonly SemaphoreSlim semaphore = new(1);
+    private readonly object warmUpLock = new();
+    private Task? warmUpTask;
     private readonly IPromptCallbacks defaultPromptCallbacks = new PromptCallbacks();
     private readonly ThreadLocal<OverloadItemGenerator> overloadItemGenerator;
     private readonly CSharpParseOptions parseOptions = CSharpParseOptions.Default.WithKind(SourceCodeKind.Script).WithLanguageVersion(LanguageVersion.Latest);
@@ -438,39 +440,58 @@ public sealed partial class RoslynServices
     /// Roslyn services can be a bit slow to initialize the first time they're executed.
     /// Warm them up in the background so it doesn't affect the user.
     /// </summary>
-    public Task WarmUpAsync(string[] args) =>
+    /// <remarks>
+    /// Idempotent: the warm-up runs once per instance and later calls return the same task. Production
+    /// warms exactly once, but tests share a single instance and warm it repeatedly.
+    /// </remarks>
+    public Task WarmUpAsync(string[] args)
+    {
+        if (warmUpTask is not null) return warmUpTask;
+        lock (warmUpLock)
+        {
+            return warmUpTask ??= WarmUpCoreAsync(args);
+        }
+    }
+
+    private Task WarmUpCoreAsync(string[] args) =>
         Task.Run(async () =>
         {
             await Initialization.ConfigureAwait(false);
 
             logger.Log("Warm-up Starting");
 
+            // Warm the per-keystroke editor path first, and finish it before the heavier evaluation path below.
+            const string completionSample = @"C";
+            var completionKey = new KeyPress(new ConsoleKeyInfo('C', ConsoleKey.C, shift: false, alt: false, control: false));
+            var highlightTask = SyntaxHighlightAsync(@"_ = ""REPL Warmup""");
+            var formattingTask = FormatInput(@"_=""REPL Warmup"";", caret: 16, formatParentNodeOnly: false, default);
+            var shouldOpenTask = ShouldOpenCompletionWindowAsync(completionSample, caret: 1, completionKey, default);
+            var spanToReplaceTask = GetSpanToReplaceByCompletionAsync(completionSample, caret: 1, default);
+            var completionTask = Task.WhenAny(
+                (await CompleteAsync(completionSample, 1))
+                    .Where(completion => completion.Item.DisplayText.StartsWith("C"))
+                    .Take(15)
+                    .Select(completion => completion.GetDescriptionAsync(cancellationToken: default))
+            );
+            await Task.WhenAll(highlightTask, formattingTask, shouldOpenTask, spanToReplaceTask, completionTask).ConfigureAwait(false);
+            logger.Log("Warm-up: editor path warm");
+
+            // Now warm the evaluation path (compile + emit + load + run). This also loads the runtime helper
+            // used for ref-struct output handling, which the first user submission may need.
             const string RuntimeHelperName = "CSharpRepl.Services.RuntimeHelper.cs";
-            Task evaluationTask;
             using (var runtimeHelperStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(RuntimeHelperName))
             {
                 if (runtimeHelperStream != null)
                 {
                     var runtimeHelperText = new StreamReader(runtimeHelperStream).ReadToEnd();
-                    evaluationTask = EvaluateAsync(runtimeHelperText, args);
+                    await EvaluateAsync(runtimeHelperText, args).ConfigureAwait(false);
                 }
                 else
                 {
-                    evaluationTask = Task.CompletedTask;
                     console.WriteErrorLine($"Unable to load '{RuntimeHelperName}'");
                 }
             }
 
-            var highlightTask = SyntaxHighlightAsync(@"_ = ""REPL Warmup""");
-            var formattingTask = FormatInput(@"_=""REPL Warmup"";", caret: 16, formatParentNodeOnly: false, default);
-            var completionTask = Task.WhenAny(
-                (await CompleteAsync(@"C", 1))
-                    .Where(completion => completion.Item.DisplayText.StartsWith("C"))
-                    .Take(15)
-                    .Select(completion => completion.GetDescriptionAsync(cancellationToken: default))
-            );
-
-            await Task.WhenAll(evaluationTask, highlightTask, formattingTask, completionTask).ConfigureAwait(false);
             logger.Log("Warm-up Complete");
         });
 

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -68,6 +68,11 @@ public sealed partial class RoslynServices
 
     internal event Action<string>? EvaluatingInput;
 
+    // The base document that every per-keystroke editor operation (highlight/completion) forks via WithText.
+    // Exposed internally so benchmarks can profile the sub-steps (parse / compilation / semantic model /
+    // classification) of the per-keystroke pipeline. Null until Initialization completes.
+    internal Document? CurrentDocumentForProfiling => workspaceManager?.CurrentDocument;
+
     public RoslynServices(IConsoleService console, Configuration config, ITraceLogger logger)
     {
         var cache = new MemoryCache(new MemoryCacheOptions());
@@ -126,7 +131,7 @@ public sealed partial class RoslynServices
             {
                 // update our final document text, and add a new, empty project that can be
                 // used for future evaluations (whether evaluation, syntax highlighting, or completion)
-                workspaceManager.UpdateCurrentDocument(success);
+                await workspaceManager.UpdateCurrentDocumentAsync(success, cancellationToken).ConfigureAwait(false);
             }
 
             return result;

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Logging;
 using CSharpRepl.Services.Roslyn.References;
@@ -67,7 +69,7 @@ internal sealed class WorkspaceManager
         this.CurrentDocument = document;
     }
 
-    public void UpdateCurrentDocument(EvaluationResult.Success result)
+    public async Task UpdateCurrentDocumentAsync(EvaluationResult.Success result, CancellationToken cancellationToken = default)
     {
         var assemblyReferences = referenceAssemblyService.EnsureReferenceAssemblyWithDocumentation(result.References);
         var document = EmptyProjectAndDocumentChangeset(
@@ -90,6 +92,14 @@ internal sealed class WorkspaceManager
         }
 
         this.CurrentDocument = document;
+
+        // Performance:
+        // Generate this snapshot's compilation now by calling GetCompilationAsync. Roslyn holds a project's Compilation once its CompilationTracker reaches the final state (FinalCompilationWithGeneratedDocuments):
+        // https://github.com/dotnet/roslyn/blob/9fa44037cfccdd8ec2e56429627522e15712af23/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.CompilationTracker.CompilationTrackerState.cs#L162
+        // Each per-keystroke CurrentDocument.WithText(...) makes a *new* snapshot, but it reuses the previous submission's compilation if it's been generated as above.
+        // The result is discarded on purpose. CurrentDocument already references this snapshot for the rest of the session; we only need to generate the compilation, not hold the Compilation ourselves.
+        // Confirmed by benchmarks; if we comment out the following line, memory usage grows with each submission, and code completion becomes slower.
+        _ = await CurrentDocument.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public IReadOnlyList<Document> GetPreviousDocuments()

--- a/CSharpRepl.slnx
+++ b/CSharpRepl.slnx
@@ -8,6 +8,7 @@
     <File Path=".github/workflows/main.yml" />
     <File Path=".github/workflows/release.yml" />
   </Folder>
+  <Project Path="CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj" />
   <Project Path="CSharpRepl.Services/CSharpRepl.Services.csproj" />
   <Project Path="CSharpRepl.Tests/CSharpRepl.Tests.csproj" />
   <Project Path="CSharpRepl/CSharpRepl.csproj" />


### PR DESCRIPTION
- Add benchmark project.
- Reduce memory usage for longer sessions (see comments near `GetCompilationAsync`)
- Re-order warmup to warm up per-keystroke operations first; evaluation warmup can run after that
- If code completion is not yet warmed up, don't open the completion menu -- that's responsible for about ~1s of lag when first typing in a newly started REPL.