### PR TITLE
Set up a ReadyToRun build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,19 @@ jobs:
     - name: Dotnet Installation Info
       run: dotnet --info
       
+    # Pack the platform-specific ReadyToRun tool. PackRidSpecific opts into the RID/R2R settings in CSharpRepl.csproj.
+    # It creates:
+    #   - one R2R-crossgen'd nuget package per RID
+    #   - one fallback "any" package for unknown architectures
+    #   - the root package that selects the right one at install time.
     - name: Pack
-      run: dotnet pack -c Release /p:ContinuousIntegrationBuild=true
-      
-    # publish to nuget. This will publish both a nupkg and snupkg file.
+      run: dotnet pack CSharpRepl/CSharpRepl.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackRidSpecific=true
+
+    # Publish to nuget. The wildcard pushes the root package, the "any" fallback, and every per-RID package in one go.
+    # --skip-duplicate makes a re-run safe if an earlier push published only some of the packages.
     - name: Publish
       shell: pwsh
       run: |
-        pwd
         cd CSharpRepl/nupkg
         ls
-        dotnet nuget push CSharpRepl.*.nupkg --api-key=${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push CSharpRepl.*.nupkg --api-key=${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.7.0
+
+- Removed the noticeable lag on the first keystroke of a new session. Roslyn's editor services are now warmed up in a more effective order, and completion is briefly held back until that warm-up finishes so the first keystrokes stay responsive ([#459](https://github.com/waf/CSharpRepl/pull/459)).
+- Fixed a performance issue where code completion slowed down and memory grew as a session accumulated submissions ([#459](https://github.com/waf/CSharpRepl/pull/459)).
+- ReadyToRun platform-specific tool packages for faster warm-up ([#461](https://github.com/waf/CSharpRepl/pull/461)).
+
 ## Release 0.6.9
 
 - Much better unicode/emoji support ([#458](https://github.com/waf/CSharpRepl/pull/458) - via an upgrade to PrettyPrompt 5.0).

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -290,8 +290,7 @@ public sealed partial class RoslynServices
             return Task.FromResult(false);
         }
 
-        // Don't auto-open the completion window while warming up (and avoid this check's own cold cost) — see
-        // CompleteAsync. The warm-up drives ShouldOpenCompletionWindowCoreAsync directly so it still warms.
+        // Don't auto-open the completion window while warming up
         if (warmUpTask is not null && !editorPathWarmedUp)
             return Task.FromResult(false);
 
@@ -467,9 +466,8 @@ public sealed partial class RoslynServices
     {
         if (warmUpTask is not null) return warmUpTask;
 
-        // Publish the warm-up task atomically, no dedicated lock object needed. It's created cold (not
-        // started) so a caller that loses the race doesn't kick off a duplicate, orphaned warm-up .
-        // Use CompareExchange because we can't lock on warmUpTask as it's null here.
+        // Run the warm-up task atomically. It's created cold (not started) so a caller that loses the race doesn't
+        // kick off a duplicate, orphaned warm-up.  Use CompareExchange because we can't lock on warmUpTask (it's null here).
         var pending = new Task<Task>(() => WarmUpCoreAsync(args));
         var warmUp = pending.Unwrap();
         if (Interlocked.CompareExchange(ref warmUpTask, warmUp, null) is null)

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.6.9</Version>
+    <Version>0.7.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
@@ -37,6 +37,29 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CSharpRepl.Services\CSharpRepl.Services.csproj" />
+  </ItemGroup>
+
+
+  <!--
+    Platform-specific ReadyToRun (R2R) tool packagin. Opt-in via -p:PackRidSpecific=true . When enabled, `dotnet pack` emits one R2R-crossgen'd tool nuget package per
+    RID plus a root package that selects the right one at install time.  R2R precompiles the Roslyn assemblies, which shortens warm-up (the cold completion JIT).
+  -->
+  <PropertyGroup Condition="'$(PackRidSpecific)' == 'true'">
+    <!-- 'any' produces a portable (non-R2R) fallback package for RIDs we don't pre-build here -->
+    <RuntimeIdentifiers>any;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+  <!--
+    crossgen2 needs the full reference closure, but this project intentionally ships an incomplete one:
+    MSBuild assemblies are loaded from the SDK via MSBuildLocator (see MSBL001 above), and
+    NuGet.PackageManagement/Resolver chain to a NuGet.Packaging that isn't in the output. Exclude those from R2R.
+  -->
+  <ItemGroup Condition="'$(PackRidSpecific)' == 'true'">
+    <PublishReadyToRunExclude Include="NuGet.PackageManagement.dll" />
+    <PublishReadyToRunExclude Include="NuGet.Resolver.dll" />
+    <PublishReadyToRunExclude Include="Microsoft.CodeAnalysis.Workspaces.MSBuild.dll" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Sets up ReadyToRun to improve startup speed. The main benefit is the crossgen of the `Microsoft.CodeAnalysis.*` DLLs.