### PR TITLE
Publish releases with release notes to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,15 @@
-# On pushing a tag like v0.3.2, publish to nuget.org
-# Use publish-release.ps1 to push a release
+# On pushing a tag like v0.3.2, publish to nuget.org and create a GitHub release.
+# Use publish-release.ps1 to push a release.
 name: release
 
 on:
   push:
     tags:
     - "v[0-9]+.*" # not a regex! ".*" means a period followed by any character https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-    
+
+permissions:
+  contents: write # needed to create the GitHub release
+
 jobs:
   build:
 
@@ -39,3 +42,24 @@ jobs:
         cd CSharpRepl/nupkg
         ls
         dotnet nuget push CSharpRepl.*.nupkg --api-key=${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    # Pull the notes for this version straight out of CHANGELOG.md so the GitHub release
+    # mirrors what's already curated there (CHANGELOG.md is the single source of truth).
+    - name: Extract release notes from CHANGELOG
+      shell: pwsh
+      run: |
+        $version = '${{ github.ref_name }}'.TrimStart('v')
+        $changelog = Get-Content -Raw CHANGELOG.md
+        $escaped = [regex]::Escape($version)
+        $match = [regex]::Match($changelog, "(?ms)^## Release $escaped[ \t]*\r?\n(.*?)(?=\r?\n## Release |\z)")
+        if (-not $match.Success) {
+            Write-Error "Could not find a '## Release $version' section in CHANGELOG.md"
+            exit 1
+        }
+        Set-Content -Path release-notes.md -Value $match.Groups[1].Value.Trim()
+
+    - name: Create GitHub release
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes-file release-notes.md --verify-tag

--- a/PublishRelease.md
+++ b/PublishRelease.md
@@ -1,0 +1,20 @@
+# Release Steps
+
+If you want to make a new release of CSharpRepl:
+
+1. Pull the latest `main` branch.
+2. Increment the `<Version>` in `CSharpRepl/CSharpRepl.csproj`.
+3. Add a `## Release <version>` section to the top of `CHANGELOG.md` describing the changes.
+4. Make a pull request with the above, and merge it into `main`.
+5. From an up-to-date `main`, run `./publish-release.ps1`.
+
+The script verifies your checkout is clean and up to date, reads the version from the csproj,
+and (after a confirmation prompt) creates and pushes a `v<version>` git tag.
+
+Pushing the tag triggers `.github/workflows/release.yml`, which:
+
+- packs the platform-specific ReadyToRun tool and pushes the NuGet packages to nuget.org, and
+- creates a GitHub release for the tag, using the matching `## Release <version>` section of
+  `CHANGELOG.md` as the release notes.
+
+Nothing is published until you push the tag, so bumping the version in a PR is safe on its own.

--- a/publish-release.ps1
+++ b/publish-release.ps1
@@ -17,8 +17,8 @@ $csproj = [xml](Get-Content ./CSharpRepl/CSharpRepl.csproj)
 # blank entry — which interpolates into the tag name with a stray trailing space.
 $version = $csproj.SelectSingleNode('//Project/PropertyGroup/Version').InnerText.Trim()
 
-Write-Output "Reminder: Did you update the CHANGELOG.md?"
-Write-Output "Press Enter to create tag ""v$version"" and publish to nuget.org"
+Write-Output "Reminder: Did you add a '## Release $version' section to CHANGELOG.md? It becomes the GitHub release notes."
+Write-Output "Press Enter to create tag ""v$version"" and publish to nuget.org + GitHub releases"
 Read-Host
 
 git tag "v$version"


### PR DESCRIPTION
Adds a step to our existing github actions release step. This new step creates a "Github Release" with the changes read from the changelog.

Closes https://github.com/waf/CSharpRepl/issues/463