### PR TITLE
Upgrade dependencies to get PrettyPrompt 5.0.1

### DIFF
--- a/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
+++ b/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
          arrives transitively through the CSharpRepl.Services project reference.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.727501" />
     <PackageReference Include="OpenAI" Version="2.10.0" />
-    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="Spectre.Console.Ansi" Version="0.55.2" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.1" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.108" />

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="5.0.0" />
+    <PackageReference Include="PrettyPrompt" Version="5.0.1" />
     <PackageReference Include="System.CommandLine" Version="3.0.0-preview.4.26230.115" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir; they're loaded from the SDK via


### PR DESCRIPTION
PrettyPrompt 5.0.1 has some syntax highlighting fixes (better unicode and newline handling).