### PR TITLE
Fix assembly resolve issue when loading asp.net core

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -28,6 +28,12 @@
     <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+    <!--
+      Microsoft.CodeAnalysis.Workspaces.MSBuild depends on Microsoft.Extensions.{Logging, DependencyInjection} at 9.0. When a user references a shared framework
+      (e.g. `-f Microsoft.AspNetCore.App`) their code requests 10.0, our copies are found it throws a FileLoadException. Set these at 10.0 to fix that. See issue #414.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.727501" />
     <PackageReference Include="OpenAI" Version="2.10.0" />
     <PackageReference Include="PrettyPrompt" Version="5.0.1" />

--- a/CSharpRepl.Tests/EvaluationTests.cs
+++ b/CSharpRepl.Tests/EvaluationTests.cs
@@ -135,6 +135,22 @@ public class EvaluationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Evaluate_RunSharedFrameworkCode_DoesNotThrowAssemblyLoadException()
+    {
+        // Regression test for https://github.com/waf/CSharpRepl/issues/414. Referencing the ASP.NET Core shared framework and 
+        // then running code that transitively loaded Microsoft.Extensions.Logging / Microsoft.Extensions.DependencyInjection threw
+        // the exception "Manifest definition does not match the assembly reference", because we bundled those assemblies
+        // at a lower version than the shared framework (they are dependencies of Microsoft.CodeAnalysis.Workspaces.MSBuild)
+        await services.EvaluateAsync(@"#r ""./Data/WebApplication1.dll""", cancellationToken: TestContext.Current.CancellationToken);
+        var result = await services.EvaluateAsync(
+            @"Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder().Build().GetType().Name",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var success = Assert.IsType<EvaluationResult.Success>(result);
+        Assert.Equal("WebApplication", success.ReturnValue.Value);
+    }
+
+    [Fact]
     public async Task Evaluate_ProjectReference_ReferencesProject()
     {
         var referenceResult = await services.EvaluateAsync(@"#r ""./../../../../CSharpRepl.Services/CSharpRepl.Services.csproj""", cancellationToken: TestContext.Current.CancellationToken);

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -39,7 +39,6 @@
     <ProjectReference Include="..\CSharpRepl.Services\CSharpRepl.Services.csproj" />
   </ItemGroup>
 
-
   <!--
     Platform-specific ReadyToRun (R2R) tool packagin. Opt-in via -p:PackRidSpecific=true . When enabled, `dotnet pack` emits one R2R-crossgen'd tool nuget package per
     RID plus a root package that selects the right one at install time.  R2R precompiles the Roslyn assemblies, which shortens warm-up (the cold completion JIT).
@@ -72,16 +71,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="themes\dracula.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="themes\VisualStudio_BlueExtraContrast.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="themes\VisualStudio_Dark.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="themes\VisualStudio_Light.json">
+    <None Update="themes\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
See code comments -- Microsoft.CodeAnalysis.Workspaces.MSBuild pulls in old 9.0 dependencies that then cause assembly resolve issues when referencing asp.net core 10

Fixes https://github.com/waf/CSharpRepl/issues/414