### PR TITLE
Intermediate Language syntax highlighting and original c# in comments

### DIFF
--- a/CSharpRepl.Services/Disassembly/Disassembler.cs
+++ b/CSharpRepl.Services/Disassembly/Disassembler.cs
@@ -8,23 +8,32 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using CSharpRepl.Services.Extensions;
 using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.Disassembler;
 using ICSharpCode.Decompiler.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
 
 namespace CSharpRepl.Services.Disassembly;
 
 /// <summary>
 /// Shows the IL code for the user's C# code.
 /// </summary>
-internal class Disassembler
+internal partial class Disassembler
 {
+    // Roslyn marks "hidden" sequence points (compiler plumbing with no corresponding source) with this line number.
+    private const int HiddenSequencePointLine = 0xFEEFEE;
+    private static readonly Regex SequencePointPattern = SequencePointRegex();
+
     private readonly AssemblyReferenceService referenceService;
     private readonly (string name, CompileDelegate compile)[] compilers;
     private readonly CSharpParseOptions parseOptions;
@@ -51,7 +60,11 @@ internal class Disassembler
         ];
     }
 
-    public EvaluationResult Disassemble(string code, bool debugMode)
+    /// <returns>
+    /// The disassembled IL, plus (on success) the character ranges within that IL text of the embedded C# source
+    /// snippets, so a caller can highlight them with the C# classifier. The ranges are empty on failure.
+    /// </returns>
+    public (EvaluationResult Result, IReadOnlyList<TextSpan> CommentSpans) Disassemble(string code, bool debugMode)
     {
         var usings = referenceService.Usings.Select(u => u.NormalizeWhitespace().ToString());
         code = string.Join(Environment.NewLine, usings) + Environment.NewLine + code;
@@ -66,31 +79,54 @@ internal class Disassembler
         };
 
         using var stream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+
+        // emit a portable PDB alongside the assembly so we can annotate the IL with the
+        // C# source line each instruction came from (the "mixed IL + C#" view).
+        var emitOptions = new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb);
 
         foreach (var (name, compile) in compilers)
         {
             // step 1, try to compile the input using one of our compiler configurations.
             stream.SetLength(0);
+            pdbStream.SetLength(0);
             var compiled = compile(code, optimizationLevel);
-            var compilationResult = compiled.Emit(stream);
+            var compilationResult = compiled.Emit(stream, pdbStream: pdbStream, options: emitOptions);
 
             // step 2, disassemble the compiled result and return the IL
             if (compilationResult.Success)
             {
                 commentFooter.Add($"// Compiling code as {name}: succeeded.");
                 stream.Position = 0;
+                pdbStream.Position = 0;
                 var file = new PEFile(Guid.NewGuid().ToString(), stream, PEStreamOptions.LeaveOpen);
 
-                var ilCodeOutput = DisassembleFile(file);
+                using var debugInfo = new PortablePdbDebugInfoProvider(pdbStream);
+                var ilCodeOutput = DisassembleFile(file, debugInfo);
 
-                var ilCode =
-                    string.Join('\n', ilCodeOutput
-                        .ToString()
-                        .Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
-                        .Select(line => line.TrimEnd()) // output has trailing spaces on some lines, clean those up
-                    )
-                    + string.Join('\n', commentFooter);
-                return new EvaluationResult.Success(code, ilCode, []);
+                // ILSpy emits "// sequence point: (line, col)..." markers next to the IL each statement
+                // produced. Replace those with the actual C# source line so the IL reads as mixed IL + C#,
+                // recording where each snippet lands so the caller can syntax-highlight it.
+                var sourceLines = code.Replace("\r\n", "\n").Split('\n');
+                var rawLines = ilCodeOutput.ToString().Split(["\r\n", "\n"], StringSplitOptions.None);
+                var builder = new StringBuilder();
+                var commentSpans = new List<TextSpan>();
+                foreach (var rawLine in rawLines)
+                {
+                    if (builder.Length > 0)
+                    {
+                        builder.Append('\n');
+                    }
+                    var (text, snippetStart, snippetLength) = AnnotateSequencePoint(rawLine.TrimEnd(), sourceLines);
+                    if (snippetLength > 0)
+                    {
+                        commentSpans.Add(new TextSpan(builder.Length + snippetStart, snippetLength));
+                    }
+                    builder.Append(text);
+                }
+                builder.Append(string.Join('\n', commentFooter));
+
+                return (new EvaluationResult.Success(code, builder.ToString(), []), commentSpans);
             }
 
             // failure, we couldn't compile it, move on to the next compiler configuration.
@@ -102,12 +138,90 @@ internal class Disassembler
             );
         }
 
-        return new EvaluationResult.Error(
-            new InvalidOperationException("// Could not compile provided code:" + Environment.NewLine + string.Join(Environment.NewLine, commentFooter))
-        );
+        return (
+            new EvaluationResult.Error(
+                new InvalidOperationException("// Could not compile provided code:" + Environment.NewLine + string.Join(Environment.NewLine, commentFooter))),
+            []);
     }
 
-    private static PlainTextOutput DisassembleFile(PEFile file)
+    /// <summary>
+    /// Turns an ILSpy "// sequence point: (line, col) to (line, col)" comment into the actual C# source it
+    /// maps to. Non-matching lines (i.e. the IL itself) are returned unchanged. The returned span gives the
+    /// position/length of the C# snippet within the returned text (length 0 when there is no snippet).
+    /// </summary>
+    private static (string Text, int SnippetStart, int SnippetLength) AnnotateSequencePoint(string line, string[] sourceLines)
+    {
+        var match = SequencePointPattern.Match(line);
+        if (!match.Success)
+        {
+            return (line, 0, 0);
+        }
+
+        var indent = match.Groups["indent"].Value;
+        var startLine = int.Parse(match.Groups["sl"].Value);
+        if (startLine == HiddenSequencePointLine)
+        {
+            return ($"{indent}// (compiler-generated, no source)", 0, 0);
+        }
+
+        var source = ExtractSource(
+            sourceLines,
+            startLine,
+            int.Parse(match.Groups["sc"].Value),
+            int.Parse(match.Groups["el"].Value),
+            int.Parse(match.Groups["ec"].Value));
+
+        // if we couldn't resolve the span for any reason, leave the original marker rather than lose information.
+        if (source is null)
+        {
+            return (line, 0, 0);
+        }
+
+        // the snippet sits after the indentation and the "// " comment prefix.
+        return ($"{indent}// {source}", indent.Length + 3, source.Length);
+    }
+
+    /// <summary>
+    /// Extracts the substring of the source spanning the given 1-based line/column range, collapsed onto a single line.
+    /// </summary>
+    private static string? ExtractSource(string[] sourceLines, int startLine, int startColumn, int endLine, int endColumn)
+    {
+        if (startLine < 1 || endLine > sourceLines.Length || startLine > endLine)
+        {
+            return null;
+        }
+
+        if (startLine == endLine)
+        {
+            var text = sourceLines[startLine - 1];
+            var start = Math.Clamp(startColumn - 1, 0, text.Length);
+            var end = Math.Clamp(endColumn - 1, start, text.Length);
+            return text[start..end].Trim();
+        }
+
+        var builder = new StringBuilder();
+        for (var i = startLine; i <= endLine; i++)
+        {
+            var text = sourceLines[i - 1];
+            if (i == startLine)
+            {
+                text = text[Math.Clamp(startColumn - 1, 0, text.Length)..];
+            }
+            else if (i == endLine)
+            {
+                text = text[..Math.Clamp(endColumn - 1, 0, text.Length)];
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append(' ');
+            }
+            builder.Append(text.Trim());
+        }
+        return builder.ToString().Trim();
+    }
+
+    private static PlainTextOutput DisassembleFile(PEFile file, IDebugInfoProvider debugInfo)
     {
         // the disassemblers will write to the ilCodeOutput variable when invoked.
         var ilCodeOutput = new PlainTextOutput { IndentationString = new string(' ', 4) };
@@ -122,31 +236,32 @@ internal class Disassembler
         var definedTypeNames = definedTypes.Select(t => asmReader.GetString(asmReader.GetTypeDefinition(t).Name)).ToArray();
         if (definedTypeNames.Except(["<Module>", "Program", "RefSafetyRulesAttribute", "EmbeddedAttribute"]).Any())
         {
-            new ReflectionDisassembler(ilCodeOutput, CancellationToken.None).WriteModuleContents(file); // writes to the "ilCodeOutput" variable
-            return ilCodeOutput;
+            return DisassembleAll(file, ilCodeOutput, debugInfo);
         }
 
         // if we find any additional methods, fallback to disassembling and returning the entire file.
         var programTypeIndex = Array.IndexOf(definedTypeNames, "Program");
         if (programTypeIndex == -1)
         {
-            return DisassembleAll(file, ilCodeOutput);
+            return DisassembleAll(file, ilCodeOutput, debugInfo);
         }
         var programType = asmReader.GetTypeDefinition(definedTypes[programTypeIndex]);
         var methods = programType.GetMethods().ToArray();
         var methodNames = methods.Select(m => asmReader.GetString(asmReader.GetMethodDefinition(m).Name)).ToArray();
         if (methodNames.Except(["<Main>$", ".ctor"]).Any())
         {
-            return DisassembleAll(file, ilCodeOutput);
+            return DisassembleAll(file, ilCodeOutput, debugInfo);
         }
 
         // we successfully found that there's only a simple Program.Main, so disassemble just the Main method body.
-        new MethodBodyDisassembler(ilCodeOutput, CancellationToken.None).Disassemble(file, methods[Array.IndexOf(methodNames, "<Main>$")]);
+        new MethodBodyDisassembler(ilCodeOutput, CancellationToken.None) { ShowSequencePoints = true, DebugInfo = debugInfo }
+            .Disassemble(file, methods[Array.IndexOf(methodNames, "<Main>$")]);
         return ilCodeOutput;
 
-        static PlainTextOutput DisassembleAll(PEFile file, PlainTextOutput ilCodeOutput)
+        static PlainTextOutput DisassembleAll(PEFile file, PlainTextOutput ilCodeOutput, IDebugInfoProvider debugInfo)
         {
-            new ReflectionDisassembler(ilCodeOutput, CancellationToken.None).WriteModuleContents(file); // writes to the "ilCodeOutput" variable
+            new ReflectionDisassembler(ilCodeOutput, CancellationToken.None) { ShowSequencePoints = true, DebugInfo = debugInfo }
+                .WriteModuleContents(file); // writes to the "ilCodeOutput" variable
             return ilCodeOutput;
         }
     }
@@ -166,4 +281,7 @@ internal class Disassembler
     }
 
     internal delegate Compilation CompileDelegate(string code, OptimizationLevel optimizationLevel);
+
+    [GeneratedRegex(@"^(?<indent>\s*)// sequence point: \(line (?<sl>\d+), col (?<sc>\d+)\) to \(line (?<el>\d+), col (?<ec>\d+)\).*$")]
+    private static partial Regex SequencePointRegex();
 }

--- a/CSharpRepl.Services/Disassembly/IntermediateLanguageSyntaxHighlighter.cs
+++ b/CSharpRepl.Services/Disassembly/IntermediateLanguageSyntaxHighlighter.cs
@@ -1,0 +1,233 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using CSharpRepl.Services.SyntaxHighlighting;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Text;
+using PrettyPrompt.Highlighting;
+
+namespace CSharpRepl.Services.Disassembly;
+
+/// <summary>
+/// A syntax highlighter for ILSpy's IL text output. It produces <see cref="FormatSpan"/>s colored from the active theme.
+/// It reuses the same classification names as the C# highlighter, so IL and C# share the same color theme.
+///
+/// It deliberately leaves the embedded C# source comments alone — their character ranges are passed in as
+/// <paramref name="protectedRegions"/> and highlighted separately by the real Roslyn classifier.
+/// </summary>
+internal static partial class IntermediateLanguageSyntaxHighlighter
+{
+    private static readonly Regex Token = TokenRegex();
+    private static readonly Regex StringLiteral = StringLiteralRegex();
+    private static readonly Regex Label = LabelRegex();
+    private static readonly Regex Number = NumberRegex();
+
+    // Common IL keywords: primitive types, calling conventions, and type/member modifiers. Opcodes are not
+    // listed here — the first bare word on an instruction line (the one after the IL_xxxx label) is treated
+    // as the opcode mnemonic.
+    private static readonly HashSet<string> Keywords = new(StringComparer.Ordinal)
+    {
+        "void", "bool", "char", "object", "string", "class", "valuetype", "typedref",
+        "int", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64",
+        "float32", "float64", "native", "nativeint", "unsigned",
+        "instance", "explicit", "static", "vararg", "cil", "managed", "unmanaged", "pinned",
+        "public", "private", "family", "assembly", "famandassem", "famorassem", "privatescope",
+        "extends", "implements", "auto", "sequential", "ansi", "unicode", "autochar",
+        "sealed", "abstract", "beforefieldinit", "specialname", "rtspecialname", "initonly",
+        "literal", "modreq", "modopt", "nested", "hidebysig", "newslot", "virtual", "final",
+        "serializable", "import", "default", "init", "out", "in", "opt", "to", "at",
+    };
+
+    public static IReadOnlyList<FormatSpan> Highlight(string il, SyntaxHighlighter theme, IReadOnlyList<TextSpan> protectedRegions)
+    {
+        var spans = new List<FormatSpan>();
+
+        void Add(int start, int length, string classification)
+        {
+            if (length > 0 && theme.TryGetAnsiColor(classification, out var color))
+            {
+                spans.Add(new FormatSpan(start, length, new ConsoleFormat(Foreground: color)));
+            }
+        }
+
+        var lineStart = 0;
+        foreach (var line in il.Split('\n'))
+        {
+            HighlightLine(line, lineStart, protectedRegions, Add);
+            lineStart += line.Length + 1; // +1 for the '\n' separator that join restored
+        }
+
+        // returned unsorted: the caller merges these with the embedded-C# spans and sorts the combined set.
+        return spans;
+    }
+
+    private static void HighlightLine(string line, int lineStart, IReadOnlyList<TextSpan> protectedRegions, Action<int, int, string> add)
+    {
+        // 1. a "// ..." comment runs to the end of the line. Color it, but clip so we never paint over an
+        //    embedded C# snippet (those are highlighted by Roslyn instead).
+        var commentIndex = FindCommentStart(line);
+        if (commentIndex >= 0)
+        {
+            var commentStart = lineStart + commentIndex;
+            var commentLength = ClipToProtected(commentStart, line.Length - commentIndex, protectedRegions);
+            add(commentStart, commentLength, ClassificationTypeNames.Comment);
+        }
+
+        var codeEnd = commentIndex < 0 ? line.Length : commentIndex;
+        if (codeEnd == 0)
+        {
+            return;
+        }
+
+        var code = line[..codeEnd];
+
+        // 2. string literals get their own color; mask them so the tokenizer doesn't split them on spaces.
+        var masked = code.ToCharArray();
+        foreach (Match s in StringLiteral.Matches(code))
+        {
+            add(lineStart + s.Index, s.Length, ClassificationTypeNames.StringLiteral);
+            for (var i = s.Index; i < s.Index + s.Length; i++)
+            {
+                masked[i] = ' ';
+            }
+        }
+        var tokenized = new string(masked);
+
+        // 3. tokenize the remainder and classify each token.
+        var tokens = Token.Matches(tokenized);
+        var isInstruction = tokens.Count > 0 && Label.IsMatch(tokens[0].Value);
+        for (var k = 0; k < tokens.Count; k++)
+        {
+            var token = tokens[k].Value;
+            var start = lineStart + tokens[k].Index;
+
+            if (k == 0 && isInstruction)
+            {
+                add(start, token.Length, ClassificationTypeNames.LabelName);
+            }
+            else if (k == 1 && isInstruction)
+            {
+                // the opcode mnemonic, e.g. "ldc.i4.5" or "callvirt".
+                add(start, token.Length, ClassificationTypeNames.Keyword);
+            }
+            else if (token[0] == '.')
+            {
+                add(start, token.Length, ClassificationTypeNames.ControlKeyword);
+            }
+            else if (token.Contains("::", StringComparison.Ordinal))
+            {
+                HighlightMemberReference(token, start, add);
+            }
+            else
+            {
+                var (coreStart, core) = StripWrappers(token, start);
+                if (Keywords.Contains(core))
+                {
+                    add(coreStart, core.Length, ClassificationTypeNames.Keyword);
+                }
+                else if (Number.IsMatch(core))
+                {
+                    add(coreStart, core.Length, ClassificationTypeNames.NumericLiteral);
+                }
+            }
+        }
+    }
+
+    /// <summary>Colors the type and method name within a reference like <c>[Asm]Some.Type::Method(int32)</c>.</summary>
+    private static void HighlightMemberReference(string token, int tokenStart, Action<int, int, string> add)
+    {
+        var separator = token.IndexOf("::", StringComparison.Ordinal);
+        if (separator < 0)
+        {
+            return;
+        }
+
+        // type name: the segment between the assembly reference's closing ']' (if any) and "::".
+        var typeStart = token.LastIndexOf(']', separator) + 1;
+        if (typeStart < separator)
+        {
+            add(tokenStart + typeStart, separator - typeStart, ClassificationTypeNames.ClassName);
+        }
+
+        // method name: after "::" up to the opening parenthesis (or end of token).
+        var methodStart = separator + 2;
+        var parenthesis = token.IndexOf('(', methodStart);
+        var methodEnd = parenthesis < 0 ? token.Length : parenthesis;
+        add(tokenStart + methodStart, methodEnd - methodStart, ClassificationTypeNames.MethodName);
+    }
+
+    /// <summary>Strips surrounding brackets/punctuation (e.g. <c>[0]</c> → <c>0</c>, <c>int32,</c> → <c>int32</c>).</summary>
+    private static (int Start, string Core) StripWrappers(string token, int tokenStart)
+    {
+        var start = 0;
+        var end = token.Length;
+        while (start < end && (token[start] is '(' or '['))
+        {
+            start++;
+        }
+        while (end > start && (token[end - 1] is ')' or ']' or ',' or ';'))
+        {
+            end--;
+        }
+        return (tokenStart + start, token[start..end]);
+    }
+
+    private static int FindCommentStart(string line)
+    {
+        var inString = false;
+        for (var i = 0; i < line.Length; i++)
+        {
+            var c = line[i];
+            if (inString)
+            {
+                if (c == '\\')
+                {
+                    i++; // skip the escaped character
+                }
+                else if (c == '"')
+                {
+                    inString = false;
+                }
+            }
+            else if (c == '"')
+            {
+                inString = true;
+            }
+            else if (c == '/' && i + 1 < line.Length && line[i + 1] == '/')
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>Shortens a span so it stops before the first protected (C#) region it would otherwise enter.</summary>
+    private static int ClipToProtected(int start, int length, IReadOnlyList<TextSpan> protectedRegions)
+    {
+        var end = start + length;
+        foreach (var region in protectedRegions)
+        {
+            if (region.Start >= start && region.Start < end)
+            {
+                end = region.Start;
+            }
+        }
+        return end - start;
+    }
+
+    [GeneratedRegex(@"\S+")]
+    private static partial Regex TokenRegex();
+
+    [GeneratedRegex("\"(?:\\\\.|[^\"\\\\])*\"")]
+    private static partial Regex StringLiteralRegex();
+
+    [GeneratedRegex("^IL_[0-9A-Fa-f]+:?$")]
+    private static partial Regex LabelRegex();
+
+    [GeneratedRegex(@"^(?:0x[0-9A-Fa-f]+|-?\d+)$")]
+    private static partial Regex NumberRegex();
+}

--- a/CSharpRepl.Services/Disassembly/PortablePdbDebugInfoProvider.cs
+++ b/CSharpRepl.Services/Disassembly/PortablePdbDebugInfoProvider.cs
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using ICSharpCode.Decompiler.DebugInfo;
+using DecompilerSequencePoint = ICSharpCode.Decompiler.DebugInfo.SequencePoint;
+
+namespace CSharpRepl.Services.Disassembly;
+
+/// <summary>
+/// Exposes the sequence points from an in-memory portable PDB to the ILSpy disassemblers,
+/// so the IL output can be annotated with the C# source line each instruction came from.
+/// </summary>
+internal sealed class PortablePdbDebugInfoProvider : IDebugInfoProvider, IDisposable
+{
+    private readonly MetadataReaderProvider provider;
+    private readonly MetadataReader reader;
+
+    public PortablePdbDebugInfoProvider(Stream portablePdbStream)
+    {
+        // PrefetchMetadata reads the whole PDB into memory, so we don't depend on the
+        // stream staying open after construction.
+        provider = MetadataReaderProvider.FromPortablePdbStream(portablePdbStream, MetadataStreamOptions.PrefetchMetadata);
+        reader = provider.GetMetadataReader();
+    }
+
+    public string Description => "In-memory portable PDB";
+
+    // Not backed by a file on disk; the source lives in the REPL input.
+    public string SourceFileName => string.Empty;
+
+    public IList<DecompilerSequencePoint> GetSequencePoints(MethodDefinitionHandle method)
+    {
+        var debugHandle = method.ToDebugInformationHandle();
+        if (debugHandle.IsNil)
+        {
+            return [];
+        }
+
+        var debugInfo = reader.GetMethodDebugInformation(debugHandle);
+        var points = new List<DecompilerSequencePoint>();
+        foreach (var sp in debugInfo.GetSequencePoints())
+        {
+            var documentUrl = sp.Document.IsNil
+                ? string.Empty
+                : reader.GetString(reader.GetDocument(sp.Document).Name);
+
+            points.Add(new DecompilerSequencePoint
+            {
+                Offset = sp.Offset,
+                StartLine = sp.StartLine,
+                StartColumn = sp.StartColumn,
+                EndLine = sp.EndLine,
+                EndColumn = sp.EndColumn,
+                DocumentUrl = documentUrl,
+            });
+        }
+
+        // ILSpy expects each sequence point's EndOffset to mark where the next one begins.
+        points.Sort((a, b) => a.Offset.CompareTo(b.Offset));
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            points[i].EndOffset = points[i + 1].Offset;
+        }
+        if (points.Count > 0)
+        {
+            points[^1].EndOffset = points[^1].Offset;
+        }
+        return points;
+    }
+
+    public IList<Variable> GetVariables(MethodDefinitionHandle method) => [];
+
+    public bool TryGetName(MethodDefinitionHandle method, int index, out string name)
+    {
+        name = string.Empty;
+        return false;
+    }
+
+    public bool TryGetExtraTypeInfo(MethodDefinitionHandle method, int index, out PdbExtraTypeInfo extraTypeInfo)
+    {
+        extraTypeInfo = default;
+        return false;
+    }
+
+    public void Dispose() => provider.Dispose();
+}

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -455,7 +455,39 @@ public sealed partial class RoslynServices
     public async Task<EvaluationResult> ConvertToIntermediateLanguage(string csharpCode, bool debugMode)
     {
         await Initialization.ConfigureAwait(false);
-        return disassembler.Disassemble(csharpCode, debugMode);
+        var (result, csharpCommentSpans) = disassembler.Disassemble(csharpCode, debugMode);
+
+        // attach syntax highlighting: the IL itself (lexically) plus the embedded C# comments (via the
+        // real classifier). The text is carried as a FormattedString so the UI can render it with color
+        // while FormattedString.ToString() still yields the plain IL.
+        if (result is EvaluationResult.Success success && success.ReturnValue.Value is string il)
+        {
+            var highlights = await BuildDisassemblyHighlightsAsync(il, csharpCommentSpans).ConfigureAwait(false);
+            return success with { ReturnValue = new Optional<object?>(new FormattedString(il, highlights)) };
+        }
+
+        return result;
+    }
+
+    private async Task<IReadOnlyList<FormatSpan>> BuildDisassemblyHighlightsAsync(string il, IReadOnlyList<TextSpan> csharpCommentSpans)
+    {
+        var spans = new List<FormatSpan>(IntermediateLanguageSyntaxHighlighter.Highlight(il, highlighter, csharpCommentSpans));
+
+        // highlight each embedded C# snippet with the same classifier the prompt uses, then offset its spans
+        // into the IL text. These regions are disjoint from the IL spans above (which clip around them).
+        foreach (var commentSpan in csharpCommentSpans)
+        {
+            var snippet = il[commentSpan.Start..commentSpan.End];
+            foreach (var classified in await SyntaxHighlightAsync(snippet).ConfigureAwait(false))
+            {
+                // classified spans are relative to the snippet, which is exactly the comment span, so offsetting them keeps them in-bounds.
+                var start = commentSpan.Start + classified.TextSpan.Start;
+                spans.Add(new FormatSpan(start, classified.TextSpan.Length, new ConsoleFormat(Foreground: classified.Color)));
+            }
+        }
+
+        spans.Sort((a, b) => a.Start.CompareTo(b.Start));
+        return spans;
     }
 
     /// <summary>

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Debug.il
@@ -1,4 +1,4 @@
-﻿// Method begins at RVA 0x2050
+// Method begins at RVA 0x2050
 // Header size: 12
 // Code size: 14 (0xe)
 .maxstack 2
@@ -8,10 +8,13 @@
     [1] int32
 )
 
+// var x = 5;
 IL_0000: ldc.i4.5
 IL_0001: stloc.0
+// var y = 3;
 IL_0002: ldc.i4.3
 IL_0003: stloc.1
+// Console.WriteLine(x + y);
 IL_0004: ldloc.0
 IL_0005: ldloc.1
 IL_0006: add

--- a/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TopLevelProgram.Output.Release.il
@@ -1,4 +1,4 @@
-﻿// Method begins at RVA 0x2050
+// Method begins at RVA 0x2050
 // Header size: 12
 // Code size: 11 (0xb)
 .maxstack 2
@@ -7,9 +7,12 @@
     [0] int32
 )
 
+// var x = 5;
 IL_0000: ldc.i4.5
+// var y = 3;
 IL_0001: ldc.i4.3
 IL_0002: stloc.0
+// Console.WriteLine(x + y);
 IL_0003: ldloc.0
 IL_0004: add
 IL_0005: call void [System.Console]System.Console::WriteLine(int32)

--- a/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Debug.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Debug.il
@@ -1,4 +1,4 @@
-﻿.class private auto ansi '<Module>'
+.class private auto ansi '<Module>'
 {
 } // end of class <Module>
 
@@ -26,6 +26,7 @@
         // Code size: 7 (0x7)
         .maxstack 8
 
+        // get;
         IL_0000: ldarg.0
         IL_0001: ldfld string Panda::'<Name>k__BackingField'
         IL_0006: ret
@@ -44,6 +45,7 @@
         // Code size: 8 (0x8)
         .maxstack 8
 
+        // init;
         IL_0000: ldarg.0
         IL_0001: ldarg.1
         IL_0002: stfld string Panda::'<Name>k__BackingField'

--- a/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Release.il
+++ b/CSharpRepl.Tests/Data/Disassembly/TypeDeclaration.Output.Release.il
@@ -1,4 +1,4 @@
-﻿.class private auto ansi '<Module>'
+.class private auto ansi '<Module>'
 {
 } // end of class <Module>
 
@@ -23,6 +23,7 @@
         // Code size: 7 (0x7)
         .maxstack 8
 
+        // get;
         IL_0000: ldarg.0
         IL_0001: ldfld string Panda::'<Name>k__BackingField'
         IL_0006: ret
@@ -41,6 +42,7 @@
         // Code size: 8 (0x8)
         .maxstack 8
 
+        // init;
         IL_0000: ldarg.0
         IL_0001: ldarg.1
         IL_0002: stfld string Panda::'<Name>k__BackingField'

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
 using Microsoft.CodeAnalysis;
 using NSubstitute;
+using PrettyPrompt.Highlighting;
 using Xunit;
 
 namespace CSharpRepl.Tests;
@@ -67,6 +69,51 @@ public class DisassemblerTests : IAsyncLifetime
 
         var success = Assert.IsType<EvaluationResult.Success>(result);
         Assert.Contains("Compiling code as Scripting session (will be overly verbose): succeeded", success.ReturnValue.ToString());
+    }
+
+    [Fact]
+    public async Task Disassemble_AnnotatesILWithSourceLines()
+    {
+        // the IL view interleaves each C# statement (as a comment) above the IL it compiled to.
+        var result = await services.ConvertToIntermediateLanguage("Console.WriteLine(42);", debugMode: true);
+
+        var success = Assert.IsType<EvaluationResult.Success>(result);
+        var output = success.ReturnValue.ToString();
+
+        // the source line appears as a comment...
+        Assert.Contains("// Console.WriteLine(42);", output);
+        // ...immediately above the IL it produced, and the raw sequence-point markers are gone.
+        Assert.DoesNotContain("// sequence point:", output);
+    }
+
+    [Fact]
+    public async Task Disassemble_ProducesValidHighlightSpans()
+    {
+        var result = await services.ConvertToIntermediateLanguage("var x = 5;", debugMode: true);
+
+        var success = Assert.IsType<EvaluationResult.Success>(result);
+        var formatted = Assert.IsType<FormattedString>(success.ReturnValue.Value);
+        var text = formatted.Text!;
+        var spans = formatted.FormatSpans.ToArray();
+
+        Assert.NotEmpty(spans);
+
+        // every span must be in-bounds...
+        Assert.All(spans, s => Assert.True(s.Start >= 0 && s.Start + s.Length <= text.Length));
+
+        // ...and non-overlapping when sorted, which the ANSI renderer requires.
+        var sorted = spans.OrderBy(s => s.Start).ToArray();
+        for (var i = 1; i < sorted.Length; i++)
+        {
+            Assert.True(sorted[i - 1].Start + sorted[i - 1].Length <= sorted[i].Start, "highlight spans must not overlap");
+        }
+
+        // the IL opcode is highlighted...
+        Assert.Contains(spans, s => s.Start == text.IndexOf("ldc.i4.5"));
+        // ...and the C# `var` keyword inside the "// var x = 5;" comment is highlighted at the right offset,
+        // proving the embedded C# is classified and offset correctly.
+        var varInComment = text.IndexOf("// var x = 5;") + "// ".Length;
+        Assert.Contains(spans, s => s.Start == varInComment && s.Length == "var".Length);
     }
 
     /// <summary>

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -302,8 +302,10 @@ internal class CSharpReplPromptCallbacks : PromptCallbacks
         switch (result)
         {
             case EvaluationResult.Success success:
-                var ilCode = success.ReturnValue.ToString();
-                var output = Prompt.RenderAnsiOutput(ilCode, [], console.BufferWidth);
+                var (ilCode, highlights) = success.ReturnValue.Value is FormattedString formatted
+                    ? (formatted.Text ?? string.Empty, (IReadOnlyCollection<FormatSpan>)formatted.FormatSpans.ToArray())
+                    : (success.ReturnValue.ToString() ?? string.Empty, []);
+                var output = Prompt.RenderAnsiOutput(ilCode, highlights, console.BufferWidth);
                 return new KeyPressCallbackResult(text, output);
             case EvaluationResult.Error err:
                 return new KeyPressCallbackResult(text, AnsiColor.Red.GetEscapeSequence() + err.Exception.Message + AnsiEscapeCodes.Reset);


### PR DESCRIPTION
Use ILSpy's sequence points feature to put original C# source code in the IL as comments. Syntax highlight that C# code, and also provide some very light syntax highlighting to the IL itself:

<img width="1155" height="627" alt="image" src="https://github.com/user-attachments/assets/e8269cb8-ba53-4034-9fd0-3471bb958e01" />
