### PR TITLE
Better handling for newlines and nested syntax highlight spans

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.727501" />
     <PackageReference Include="OpenAI" Version="2.11.0" />
-    <PackageReference Include="PrettyPrompt" Version="5.0.2" />
+    <PackageReference Include="PrettyPrompt" Version="6.0.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageReference Include="Spectre.Console.Ansi" Version="0.56.0" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />

--- a/CSharpRepl.Services/CodeTransformation/Lowering/CodeLowerer.cs
+++ b/CSharpRepl.Services/CodeTransformation/Lowering/CodeLowerer.cs
@@ -34,10 +34,10 @@ internal sealed class CodeLowerer(AssemblyReferenceService referenceService)
         try
         {
             var csharp = DecompileToLoweredCSharp(compilation.AssemblyStream);
+            // ILSpy emits Windows '\r\n' line endings; PrettyPrompt's renderer treats them as single line breaks.
             var output = csharp.TrimEnd() + "\n\n" + string.Join('\n', compilation.Footer);
 
-            // normalize to '\n'-only line endings: ILSpy emits Windows '\r\n', but PrettyPrompt's ANSI renderer advances lines with its own cursor-movement codes.
-            return new EvaluationResult.Success(compilation.Code, output.Replace("\r\n", "\n"), []);
+            return new EvaluationResult.Success(compilation.Code, output, []);
         }
         catch (Exception ex)
         {

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -487,8 +487,9 @@ public sealed partial class RoslynServices
             }
         }
 
-        spans.Sort((a, b) => a.Start.CompareTo(b.Start));
-        return spans;
+        // the C# classifier nests spans (e.g. string-escape-character inside string-literal), but
+        // FormattedString requires disjoint spans.
+        return spans.FlattenOverlappingSpans();
     }
 
     /// <summary>
@@ -501,7 +502,9 @@ public sealed partial class RoslynServices
 
         if (result is EvaluationResult.Success success && success.ReturnValue.Value is string csharp && !PromptConfiguration.HasUserOptedOutFromColor)
         {
-            var highlights = (await SyntaxHighlightAsync(csharp).ConfigureAwait(false)).ToFormatSpans();
+            // FlattenOverlappingSpans: the classifier nests spans (e.g. string-escape-character inside
+            // string-literal), but FormattedString requires disjoint spans.
+            var highlights = (await SyntaxHighlightAsync(csharp).ConfigureAwait(false)).ToFormatSpans().FlattenOverlappingSpans();
             return success with { ReturnValue = new Optional<object?>(new FormattedString(csharp, highlights)) };
         }
 

--- a/CSharpRepl.Services/SyntaxHighlighting/HighlightedSpan.cs
+++ b/CSharpRepl.Services/SyntaxHighlighting/HighlightedSpan.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Text;
@@ -20,4 +21,51 @@ public static class HighlightedSpanExtensions
             new ConsoleFormat(Foreground: span.Color)
         ))
         .ToArray();
+
+    /// <summary>
+    /// Converts possibly-overlapping format spans into the disjoint spans <see cref="FormattedString"/> requires.
+    /// Roslyn's classifier nests spans (e.g. a string-escape-character span inside a string-literal span). The
+    /// later-starting span is the more specific classification, so it wins; the span it interrupts resumes after
+    /// it ends. The prompt's own renderer tolerates overlap, so this is only needed when building a FormattedString.
+    /// </summary>
+    public static IReadOnlyList<FormatSpan> FlattenOverlappingSpans(this IEnumerable<FormatSpan> spans)
+    {
+        // at equal starts, the longer (enclosing) span sorts first so the shorter, more specific span is
+        // pushed later and takes precedence over it.
+        var sorted = spans.OrderBy(s => s.Start).ThenByDescending(s => s.Length).ToArray();
+        var result = new List<FormatSpan>(sorted.Length);
+        var enclosing = new Stack<FormatSpan>();
+        int position = 0;
+
+        foreach (var span in sorted)
+        {
+            // emit the tails of spans that end before this one starts
+            while (enclosing.TryPeek(out var top) && top.End <= span.Start)
+            {
+                Emit(top, top.End);
+                enclosing.Pop();
+            }
+            // emit the segment of the still-open span leading up to this more specific span
+            if (enclosing.TryPeek(out var current))
+            {
+                Emit(current, span.Start);
+            }
+            enclosing.Push(span);
+        }
+        while (enclosing.TryPop(out var top))
+        {
+            Emit(top, top.End);
+        }
+        return result;
+
+        void Emit(FormatSpan span, int end)
+        {
+            int start = Math.Max(position, span.Start);
+            if (end > start)
+            {
+                result.Add(new FormatSpan(start, end - start, span.Formatting));
+                position = end;
+            }
+        }
+    }
 }

--- a/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="5.0.2" />
+    <PackageReference Include="PrettyPrompt" Version="6.0.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.108" />

--- a/CSharpRepl.Tests/DecompilerTests.cs
+++ b/CSharpRepl.Tests/DecompilerTests.cs
@@ -136,16 +136,29 @@ public class DecompilerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Decompile_UsesUnixLineEndings()
+    public async Task Decompile_EscapeSequenceInStringLiteral_ProducesNonOverlappingSpans()
+    {
+        // regression: same as the disassembler case - roslyn emits a string-escape-character span nested
+        // inside the string-literal span, and FormattedString requires disjoint spans.
+        var result = await services.ConvertToLoweredCSharp("""Console.WriteLine("as\ndf");""", debugMode: true);
+
+        var success = Assert.IsType<EvaluationResult.Success>(result);
+        Assert.IsType<FormattedString>(success.ReturnValue.Value); // the ctor validates non-overlap
+    }
+
+    [Fact]
+    public async Task Decompile_WindowsLineEndings_DoNotReachTheTerminal()
     {
         var result = await services.ConvertToLoweredCSharp("System.Console.WriteLine(1);", debugMode: true);
 
         var output = Assert.IsType<EvaluationResult.Success>(result).ReturnValue.ToString();
 
-        // regression: ILSpy emits '\r\n', but the ANSI renderer advances lines itself, so a stray '\r\n'
-        // double-spaces the output. The text must use '\n'-only line endings (like the IL disassembler).
-        Assert.DoesNotContain('\r', output!);
-        Assert.Contains('\n', output);
+        // regression: ILSpy emits '\r\n' line endings, and the ANSI renderer advances lines itself. A literal
+        // '\r' written to the terminal would desync the renderer's cursor tracking (it originally double-spaced
+        // the output). PrettyPrompt treats '\r\n' as a single line break, so no '\r' may survive rendering.
+        var rendered = PrettyPrompt.Prompt.RenderAnsiOutput(output!, [], 120);
+        Assert.DoesNotContain('\r', rendered);
+        Assert.Contains('\n', rendered);
     }
 
     [Fact]

--- a/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/CSharpRepl.Tests/DisassemblerTests.cs
@@ -87,6 +87,19 @@ public class DisassemblerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Disassemble_EscapeSequenceInStringLiteral_ProducesNonOverlappingSpans()
+    {
+        // regression: roslyn classifies the whole string literal AND each escape sequence inside it, producing
+        // nested spans. FormattedString requires disjoint spans, so F9 on this input crashed with
+        // "Spans cannot overlap". The escape spans must win over the enclosing string-literal span.
+        var result = await services.ConvertToIntermediateLanguage("""Console.WriteLine("as\ndf");""", debugMode: true);
+
+        var success = Assert.IsType<EvaluationResult.Success>(result);
+        var formatted = Assert.IsType<FormattedString>(success.ReturnValue.Value); // the ctor validates non-overlap
+        Assert.Contains("""ldstr "as\ndf""", formatted.Text);
+    }
+
+    [Fact]
     public async Task Disassemble_ProducesValidHighlightSpans()
     {
         var result = await services.ConvertToIntermediateLanguage("var x = 5;", debugMode: true);

--- a/CSharpRepl.Tests/SyntaxHighlighting/FlattenOverlappingSpansTests.cs
+++ b/CSharpRepl.Tests/SyntaxHighlighting/FlattenOverlappingSpansTests.cs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.SyntaxHighlighting;
+using PrettyPrompt.Highlighting;
+using Xunit;
+using static PrettyPrompt.Highlighting.AnsiColor;
+
+namespace CSharpRepl.Tests.SyntaxHighlighting;
+
+public class FlattenOverlappingSpansTests
+{
+    private static FormatSpan Span(int start, int length, AnsiColor color) => new(start, length, new ConsoleFormat(Foreground: color));
+
+    [Fact]
+    public void NestedSpan_SplitsTheEnclosingSpanAroundIt()
+    {
+        // models a string literal (0..10) containing an escape sequence (3..5): the escape color wins
+        // in the middle, and the literal's color resumes after it.
+        var flattened = new[] { Span(0, 10, Red), Span(3, 2, Magenta) }.FlattenOverlappingSpans();
+
+        Assert.Equal(new[] { Span(0, 3, Red), Span(3, 2, Magenta), Span(5, 5, Red) }, flattened);
+    }
+
+    [Fact]
+    public void PartiallyOverlappingSpan_LaterStartingSpanWins()
+    {
+        var flattened = new[] { Span(0, 5, Red), Span(3, 5, Magenta) }.FlattenOverlappingSpans();
+
+        Assert.Equal(new[] { Span(0, 3, Red), Span(3, 5, Magenta) }, flattened);
+    }
+
+    [Fact]
+    public void DisjointSpans_AreReturnedSorted()
+    {
+        var flattened = new[] { Span(6, 2, Magenta), Span(0, 4, Red) }.FlattenOverlappingSpans();
+
+        Assert.Equal(new[] { Span(0, 4, Red), Span(6, 2, Magenta) }, flattened);
+    }
+
+    [Fact]
+    public void SameStart_ShorterMoreSpecificSpanWins()
+    {
+        var flattened = new[] { Span(0, 8, Red), Span(0, 3, Magenta) }.FlattenOverlappingSpans();
+
+        Assert.Equal(new[] { Span(0, 3, Magenta), Span(3, 5, Red) }, flattened);
+    }
+
+    [Fact]
+    public void MultipleNestedSpans_EachInterruptAndResumeTheEnclosingSpan()
+    {
+        // a literal with two escape sequences, e.g. "a\nb\tc"
+        var flattened = new[] { Span(0, 12, Red), Span(2, 2, Magenta), Span(7, 2, Magenta) }.FlattenOverlappingSpans();
+
+        Assert.Equal(
+            new[] { Span(0, 2, Red), Span(2, 2, Magenta), Span(4, 3, Red), Span(7, 2, Magenta), Span(9, 3, Red) },
+            flattened);
+    }
+}

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="5.0.2" />
+    <PackageReference Include="PrettyPrompt" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="3.0.0-preview.4.26230.115" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir; they're loaded from the SDK via


### PR DESCRIPTION
- Upgrade PrettyPrompt to get https://github.com/waf/PrettyPrompt/pull/296 -- we can simplify/correct newline handling with it.
- Handle when roslyn emits nested syntax highlight spans -- this fixes a crash in our IL code syntax highlight output (where we include the C# code as comments).