### PR TITLE
Nitpick: ensure files have license headers

### DIFF
--- a/CSharpRepl.Services/Extensions/KeyExtensions.cs
+++ b/CSharpRepl.Services/Extensions/KeyExtensions.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 using System;
 using System.Linq;
 using PrettyPrompt.Consoles;

--- a/CSharpRepl.Services/Extensions/MiscExtensions.cs
+++ b/CSharpRepl.Services/Extensions/MiscExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSharpRepl.Services.Extensions;
 

--- a/CSharpRepl.Services/Extensions/SpectreExtensions.cs
+++ b/CSharpRepl.Services/Extensions/SpectreExtensions.cs
@@ -1,4 +1,8 @@
-﻿using CSharpRepl.Services.Theming;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Theming;
 using Spectre.Console;
 
 namespace CSharpRepl.Services.Extensions;

--- a/CSharpRepl.Services/Roslyn/Formatting/FormattedObject.cs
+++ b/CSharpRepl.Services/Roslyn/Formatting/FormattedObject.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
 using Spectre.Console.Rendering;
 
 namespace CSharpRepl.Services.Roslyn.Formatting;

--- a/CSharpRepl/Repls/PipedInputEvaluator.cs
+++ b/CSharpRepl/Repls/PipedInputEvaluator.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 using System;
 using System.Linq;
 using System.Text;

--- a/Tests/CSharpRepl.Tests/DecompilerTests.cs
+++ b/Tests/CSharpRepl.Tests/DecompilerTests.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.Services;

--- a/Tests/CSharpRepl.Tests/DisassemblerTests.cs
+++ b/Tests/CSharpRepl.Tests/DisassemblerTests.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.Services;

--- a/Tests/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
+++ b/Tests/CSharpRepl.Tests/DotNetInstallationLocatorTest.cs
@@ -1,4 +1,8 @@
-﻿using CSharpRepl.Services.Roslyn.References;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.Services.Roslyn.References;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Tests/CSharpRepl.Tests/Extensions.cs
+++ b/Tests/CSharpRepl.Tests/Extensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Text.RegularExpressions;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Text.RegularExpressions;
 
 namespace CSharpRepl.Tests;
 

--- a/Tests/CSharpRepl.Tests/ObjectFormatting/CustomObjectFormattersTests.cs
+++ b/Tests/CSharpRepl.Tests/ObjectFormatting/CustomObjectFormattersTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Tests/CSharpRepl.Tests/ObjectFormatting/DebuggerDisplayTests.cs
+++ b/Tests/CSharpRepl.Tests/ObjectFormatting/DebuggerDisplayTests.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #nullable enable
 
 using System;

--- a/Tests/CSharpRepl.Tests/ObjectFormatting/PrettyPrinterTests.cs
+++ b/Tests/CSharpRepl.Tests/ObjectFormatting/PrettyPrinterTests.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #nullable enable
 
 using System;

--- a/Tests/CSharpRepl.Tests/ObjectFormatting/TestFormatter.cs
+++ b/Tests/CSharpRepl.Tests/ObjectFormatting/TestFormatter.cs
@@ -1,4 +1,8 @@
-﻿#nullable enable
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#nullable enable
 
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn.Formatting;

--- a/Tests/CSharpRepl.Tests/PipedInputEvaluatorTests.cs
+++ b/Tests/CSharpRepl.Tests/PipedInputEvaluatorTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Threading.Tasks;
 using CSharpRepl.Repls;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;

--- a/Tests/CSharpRepl.Tests/ProgramTests.cs
+++ b/Tests/CSharpRepl.Tests/ProgramTests.cs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 using System;
 using System.IO;
 using System.Threading;

--- a/Tests/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/Tests/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;

--- a/Tests/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
+++ b/Tests/CSharpRepl.Tests/ReadEvalPrintLoopTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Linq;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/Tests/CSharpRepl.Tests/RoslynServicesFixture.cs
+++ b/Tests/CSharpRepl.Tests/RoslynServicesFixture.cs
@@ -1,4 +1,8 @@
-﻿using System.Text;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Text;
 using System.Threading.Tasks;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;

--- a/Tests/CSharpRepl.Tests/RoslynServicesTests.cs
+++ b/Tests/CSharpRepl.Tests/RoslynServicesTests.cs
@@ -1,4 +1,8 @@
-﻿#nullable enable
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/CSharpRepl.Tests/ScriptArgumentTests.cs
+++ b/Tests/CSharpRepl.Tests/ScriptArgumentTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Threading.Tasks;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;

--- a/Tests/CSharpRepl.Tests/TraceLoggerTests.cs
+++ b/Tests/CSharpRepl.Tests/TraceLoggerTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using CSharpRepl.Logging;


### PR DESCRIPTION
Add a license headers to a few files that are missing them. Mostly tests, but a few non-test files as well.