### PR TITLE
Fix Shell Detection when csharprepl is wrapped in .cmd file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `inspect init` printing `cmd` syntax (`set "..."`) instead of PowerShell syntax when the RID-specific tool is run from PowerShell. The `.cmd` tool shim makes Windows insert a transient `cmd.exe /c` between PowerShell and the tool; shell detection now walks past such a cmd when its own parent is itself a recognized shell.
+
 ## Release 0.8.0
 
 - New `inspect` feature: attach to a separate, already-running .NET process and evaluate C# inside it with full local-REPL parity (IntelliSense, highlighting, pretty-printing), reading and writing its live state. Run `csharprepl inspect init` to get the launch environment variables, then `csharprepl inspect <pid>`. It is cooperative and opt-in only ([#477](https://github.com/waf/CSharpRepl/pull/477)).

--- a/CSharpRepl/Commands/ShellDetector.cs
+++ b/CSharpRepl/Commands/ShellDetector.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -10,67 +11,101 @@ using System.Runtime.InteropServices;
 namespace CSharpRepl.Commands;
 
 /// <summary>
-/// Best-effort detection of the interactive shell that launched this process, used by
-/// <c>csharprepl inspect init</c> to emit env-var exports in the right syntax without the user
-/// having to pass <c>--shell</c>. The reliable signal is the parent process: shell variables like
-/// <c>BASH_VERSION</c>/<c>ZSH_VERSION</c> aren't exported (a child can't see them) and <c>SHELL</c>
-/// is the login shell, not necessarily the one currently driving the terminal. So we walk up the
-/// process tree and match the first recognized shell name.
+/// Best-effort detection of the interactive shell that launched us, so `csharprepl inspect init`
+/// can emit env-var exports in the right syntax without the user passing `--shell`. We match the
+/// parent process, not env vars, because:
+/// - shell vars like `BASH_VERSION`/`ZSH_VERSION` aren't exported to children
+/// - `SHELL` is the login shell, not necessarily the one driving the terminal
 /// </summary>
 internal static class ShellDetector
 {
     /// <summary>
-    /// Returns the normalized shell name (<c>"pwsh"</c>, <c>"cmd"</c>, <c>"bash"</c>, or <c>"fish"</c>)
-    /// of the nearest ancestor process that is a recognized shell, or <c>null</c> when none is found
-    /// (the caller should fall back to an OS default). Never throws.
+    /// Returns the normalized shell name (`pwsh`, `cmd`, `bash`, or `fish`) of the nearest ancestor
+    /// process that is a recognized shell, or `null` when none is found (the caller should fall back
+    /// to an OS default). Never throws.
     /// </summary>
     public static string? DetectShell()
     {
         try
         {
-            // Walk up a few levels so intermediate hosts (the apphost, `dotnet`, `dotnet tool run`)
-            // between us and the real shell don't hide it. The cap also guards against pid cycles.
-            var pid = Environment.ProcessId;
-            for (var depth = 0; depth < 5; depth++)
-            {
-                var ppid = GetParentPid(pid);
-                if (ppid <= 0)
-                {
-                    break;
-                }
-
-                string name;
-                try
-                {
-                    using var parent = Process.GetProcessById(ppid);
-                    name = parent.ProcessName;
-                }
-                catch
-                {
-                    // Parent already exited, or the pid was reused for something we can't open.
-                    break;
-                }
-
-                var shell = MapShellName(name);
-                if (shell is not null)
-                {
-                    return shell;
-                }
-
-                pid = ppid;
-            }
+            return ResolveShellFromAncestry(GetAncestorProcessNames());
         }
         catch
         {
             // Best-effort only: any failure falls back to the caller's OS default.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Collects up to a few ancestor process names, nearest first. Best-effort:
+    /// - walks several levels so hosts between us and the shell (apphost, `dotnet`, a transient `cmd /c` shim) don't hide it
+    /// - the depth cap also guards against pid cycles
+    /// - stops at the first ancestor it can't resolve (exited / pid reused / unsupported platform)
+    /// </summary>
+    private static List<string> GetAncestorProcessNames()
+    {
+        var names = new List<string>();
+        var pid = Environment.ProcessId;
+        for (var depth = 0; depth < 5; depth++)
+        {
+            var ppid = GetParentPid(pid);
+            if (ppid <= 0)
+            {
+                break;
+            }
+
+            try
+            {
+                using var parent = Process.GetProcessById(ppid);
+                names.Add(parent.ProcessName);
+            }
+            catch
+            {
+                // Parent already exited, or the pid was reused for something we can't open.
+                break;
+            }
+
+            pid = ppid;
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Picks the shell from an ancestry chain (nearest first): the first recognized shell wins, except a
+    /// `cmd` whose own parent is also a recognized shell. That's the transient `cmd.exe /c` wrapper around
+    /// our `.cmd` tool shim that Windows inserts when a non-cmd shell runs it (RID-specific tools ship a
+    /// `.cmd`, not an apphost `.exe`):
+    /// - shim wrapper — its parent is the real shell, so skip it and keep walking
+    /// - genuine interactive cmd — its parent is the terminal/conhost (not a shell), so keep it
+    /// Returns `null` when no ancestor is a recognized shell.
+    /// </summary>
+    internal static string? ResolveShellFromAncestry(IReadOnlyList<string> ancestorNames)
+    {
+        for (var i = 0; i < ancestorNames.Count; i++)
+        {
+            var shell = MapShellName(ancestorNames[i]);
+            if (shell is null)
+            {
+                continue;
+            }
+
+            // Transient `cmd /c <shim>.cmd` wrapper: its parent is the real shell, so keep walking.
+            if (shell == "cmd" && i + 1 < ancestorNames.Count && MapShellName(ancestorNames[i + 1]) is not null)
+            {
+                continue;
+            }
+
+            return shell;
         }
 
         return null;
     }
 
     /// <summary>
-    /// Maps a raw process name (no path, no <c>.exe</c>, any casing) to the normalized shell name
-    /// understood by the export builder, or <c>null</c> if it isn't a recognized shell.
+    /// Maps a raw process name (no path, no `.exe`, any casing) to the normalized shell name
+    /// understood by the export builder, or `null` if it isn't a recognized shell.
     /// </summary>
     internal static string? MapShellName(string processName) => processName.ToLowerInvariant() switch
     {
@@ -82,10 +117,10 @@ internal static class ShellDetector
     };
 
     /// <summary>
-    /// Returns the parent process id of <paramref name="pid"/>, or a non-positive value when it can't
-    /// be determined. Windows and Linux resolve any pid; macOS resolves only the current process's
-    /// parent (the common single-hop case), since deeper walks there would require fragile struct
-    /// offsets into <c>kinfo_proc</c>.
+    /// Returns the parent pid of <paramref name="pid"/>, or a non-positive value when it can't be
+    /// determined. Per platform:
+    /// - Windows / Linux — resolve any pid
+    /// - macOS — only the current process's parent (the common single-hop case); deeper walks would need fragile `kinfo_proc` struct offsets
     /// </summary>
     private static int GetParentPid(int pid)
     {

--- a/Tests/CSharpRepl.Tests/ShellDetectorTests.cs
+++ b/Tests/CSharpRepl.Tests/ShellDetectorTests.cs
@@ -40,4 +40,37 @@ public class ShellDetectorTests
         var shell = ShellDetector.DetectShell();
         Assert.True(shell is null or "pwsh" or "cmd" or "bash" or "fish");
     }
+
+    [Fact]
+    public void ResolveShellFromAncestry_ReturnsNearestRecognizedShell()
+        => Assert.Equal("pwsh", ShellDetector.ResolveShellFromAncestry(["pwsh", "WindowsTerminal"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_SkipsNonShellHostsToReachShell()
+        // `dotnet run`: pwsh → dotnet → dotnet → CSharpRepl. The dotnet hosts are skipped to reach pwsh.
+        => Assert.Equal("pwsh", ShellDetector.ResolveShellFromAncestry(["dotnet", "dotnet", "pwsh"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_SkipsTransientCmdShimWrapper()
+        // RID-specific tool from pwsh: pwsh → cmd (/c …csharprepl.cmd) → CSharpRepl. The cmd is a
+        // transient batch-shim wrapper whose parent is the real shell, so we resolve pwsh, not cmd.
+        => Assert.Equal("pwsh", ShellDetector.ResolveShellFromAncestry(["cmd", "pwsh"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_KeepsInteractiveCmd()
+        // WindowsTerminal → cmd → CSharpRepl: cmd's parent isn't a shell, so it's a genuine cmd prompt.
+        => Assert.Equal("cmd", ShellDetector.ResolveShellFromAncestry(["cmd", "WindowsTerminal"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_KeepsCmdWhenItIsTheTopKnownAncestor()
+        // Nothing above the cmd to prove it's a shim wrapper → keep cmd (the conservative default).
+        => Assert.Equal("cmd", ShellDetector.ResolveShellFromAncestry(["cmd"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_NoRecognizedShell_ReturnsNull()
+        => Assert.Null(ShellDetector.ResolveShellFromAncestry(["explorer", "services"]));
+
+    [Fact]
+    public void ResolveShellFromAncestry_EmptyAncestry_ReturnsNull()
+        => Assert.Null(ShellDetector.ResolveShellFromAncestry([]));
 }


### PR DESCRIPTION
Since CSharpRepl is shipped as a global tool and ReadyToRun, the tooling infrastructure wraps CSharpRepl in a csharprepl.cmd file. This interferes with the "shell autodetection" code of the `inspect init` command.

To fix this, walk up the process hierarchy a bit farther to see if we're actually in powershell. This isn't perfect, but should handle the majority of cases.