### PR TITLE
Add inspect list command to show attachable processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add `csharprepl inspect list`, which lists the running, inspector-enabled processes you can attach to, so you no longer have to find the process id by hand.
 - Fix `inspect init` printing `cmd` syntax (`set "..."`) instead of PowerShell syntax when the RID-specific tool is run from PowerShell. The `.cmd` tool shim makes Windows insert a transient `cmd.exe /c` between PowerShell and the tool; shell detection now walks past such a cmd when its own parent is itself a recognized shell.
 
 ## Release 0.8.0

--- a/CSharpRepl/Commands/CommandLine.cs
+++ b/CSharpRepl/Commands/CommandLine.cs
@@ -7,11 +7,13 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Completions;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using CSharpRepl.InjectedHook.Contracts;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Completion;
 using CSharpRepl.Services.Roslyn.References;
@@ -215,6 +217,7 @@ internal static class CommandLine
 
     private static readonly string InspectUsage =
         "Usage: csharprepl inspect <pid>                          connect to a running, inspector-enabled process" + NewLine +
+        "       csharprepl inspect list                           list the inspector-enabled processes you can connect to" + NewLine +
         "       csharprepl inspect init [--shell pwsh|bash|cmd]   print the env vars to launch your app with";
 
     public static Configuration Parse(string[] args, string configFilePath)
@@ -252,10 +255,11 @@ internal static class CommandLine
         {
             Options = { InspectShell }
         };
+        var inspectList = new Command("list", "List the running, inspector-enabled processes you can connect to.");
         var inspect = new Command("inspect", "Connect to and evaluate code in a running, inspector-enabled .NET process.")
         {
             Arguments = { InspectPid },
-            Subcommands = { inspectInit },
+            Subcommands = { inspectInit, inspectList },
         };
         availableCommands.Subcommands.Add(inspect);
 
@@ -279,6 +283,17 @@ internal static class CommandLine
             // Wrapped in PlainText (not Text) so the exports are written verbatim — word-wrapping a long path
             // would corrupt a copy-paste or a pipe into the shell.
             return new Configuration(outputForEarlyExit: new PlainText(BuildInspectInitExports(ResolveInitShell(commandLine.GetValue(InspectShell)))));
+        }
+
+        // `inspect list` is a human-facing report of the currently attachable processes — print it and exit,
+        // before any REPL or config-file setup (like `inspect init`).
+        if (invokedCommand == inspectList)
+        {
+            if (commandLine.Errors.Count > 0)
+            {
+                throw new InvalidOperationException(string.Join(NewLine, commandLine.Errors.Select(e => e.Message)));
+            }
+            return new Configuration(outputForEarlyExit: BuildInspectListOutput());
         }
 
         if (!File.Exists(configFilePath))
@@ -386,6 +401,61 @@ internal static class CommandLine
                 $@"$env:DOTNET_STARTUP_HOOKS = ""{bootstrap}""",
                 $@"$env:ASPNETCORE_HOSTINGSTARTUPASSEMBLIES = ""{HostingStartupAssembly}"""),
         };
+    }
+
+    /// <summary>
+    /// Builds the `inspect list` report: the inspector-enabled processes the current user can connect to.
+    /// The process name is read from the pid, which also drops a stale endpoint left behind by a crashed process.
+    /// </summary>
+    private static IRenderable BuildInspectListOutput()
+    {
+        var processes = InspectorTransport.EnumerateListeningProcessIds()
+            .Select(pid => (Pid: pid, Name: TryGetProcessName(pid)))
+            .Where(p => p.Name is not null)
+            .Select(p => (p.Pid, p.Name!))
+            .ToList();
+
+        return RenderInspectList(processes);
+    }
+
+    /// <summary>
+    /// Renders the `inspect list` report from an already-resolved (pid, name) set: a hint when nothing is
+    /// attachable, otherwise a table plus the connect hint. Split from <see cref="BuildInspectListOutput"/>
+    /// (which does the live discovery) so the rendering can be tested without depending on running processes.
+    /// </summary>
+    internal static IRenderable RenderInspectList(IReadOnlyList<(int ProcessId, string ProcessName)> processes)
+    {
+        if (processes.Count == 0)
+        {
+            return new Markup(
+                "No inspector-enabled processes found." + NewLine +
+                "Launch your app with the environment variables from [green]csharprepl inspect init[/], then run [green]csharprepl inspect list[/] again.");
+        }
+
+        var table = new Table()
+            .AddColumn("PID")
+            .AddColumn("Process");
+        // Use Text (not markup strings) for the cells so a process name containing '[' isn't parsed as markup.
+        foreach (var (processId, processName) in processes)
+        {
+            table.AddRow(new Text(processId.ToString()), new Text(processName));
+        }
+
+        return new Rows(table, new Markup("Connect with [green]csharprepl inspect [/][cyan]<pid>[/]."));
+    }
+
+    /// <summary>Resolves a pid to its process name, or null if the process is gone (e.g. a stale endpoint).</summary>
+    private static string? TryGetProcessName(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.ProcessName;
+        }
+        catch
+        {
+            return null; // not running anymore — skip it
+        }
     }
 
     private static bool ShouldExitEarly(ParseResult commandLine, string configFilePath, out IRenderable? text)
@@ -537,7 +607,7 @@ internal static class CommandLine
     {
         var text =
             "[underline]Usage[/]: [aqua]csharprepl[/] [green][[OPTIONS]][/] [cyan][[@response-file.rsp]][/] [cyan][[script-file.csx]][/] [green][[-- <additional-arguments>]][/]" + NewLine +
-            "       [aqua]csharprepl[/] [green]inspect[/] [cyan]<pid>[/]   or   [aqua]csharprepl[/] [green]inspect init[/] [green][[--shell <shell>]][/]" + NewLine + NewLine +
+            "       [aqua]csharprepl[/] [green]inspect[/] [cyan]<pid>[/]   or   [aqua]csharprepl[/] [green]inspect list[/]   or   [aqua]csharprepl[/] [green]inspect init[/] [green][[--shell <shell>]][/]" + NewLine + NewLine +
             "Starts a REPL (read eval print loop) according to the provided [green][[OPTIONS]][/]." + NewLine +
             "These [green][[OPTIONS]][/] can be provided at the command line, or via a [cyan][[@response-file.rsp]][/]." + NewLine +
             "A [cyan][[script-file.csx]][/], if provided, will be executed before the prompt starts." + NewLine + NewLine +
@@ -580,6 +650,8 @@ internal static class CommandLine
             "  [green]inspect[/] [cyan]<pid>[/]:" + NewLine +
             "      Connect to and evaluate code in a running, inspector-enabled .NET process." + NewLine +
             "      The REPL [green][[OPTIONS]][/] above (e.g. [green]--theme[/]) also apply to the remote session." + NewLine +
+            "  [green]inspect list[/]:" + NewLine +
+            "      List the running, inspector-enabled processes you can connect to (with their process ids)." + NewLine +
             "  [green]inspect init[/] [green][[--shell pwsh|powershell|cmd|bash|fish]][/]:" + NewLine +
             "      Print the environment variables to launch your app with so it can be inspected." + NewLine +
             "      The shell is auto-detected from the parent process when [green]--shell[/] is omitted." + NewLine + NewLine +

--- a/InjectedHook/CSharpRepl.InjectedHook.Contracts/InspectorTransport.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.Contracts/InspectorTransport.cs
@@ -3,6 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Sockets;
@@ -26,12 +28,94 @@ public static class InspectorTransport
 {
     public const int ProtocolVersion = 1;
 
+    // The endpoint name embeds the target's process id. These are the single source of truth for that
+    // convention: PipeName/SocketPath build it, and TryParseProcessId/EnumerateListeningProcessIds reverse it
+    // for discovery (`inspect list`). Keep them in sync.
+    private const string PipeNamePrefix = "CSharpRepl.InjectedHook.";
+    private const string SocketNamePrefix = "inspector-";
+    private const string SocketNameSuffix = ".sock";
+
     /// <summary>The Windows named-pipe name for a given target process id.</summary>
-    public static string PipeName(int processId) => $"CSharpRepl.InjectedHook.{processId}";
+    public static string PipeName(int processId) => PipeNamePrefix + processId;
 
     /// <summary>The Unix domain socket path for a given target process id (inside a 0700 user dir).</summary>
     public static string SocketPath(int processId) =>
-        Path.Combine(SocketDirectory(), $"inspector-{processId}.sock");
+        Path.Combine(SocketDirectory(), SocketNamePrefix + processId + SocketNameSuffix);
+
+    /// <summary>
+    /// Discovers the process ids of inspector-enabled processes for the current user by scanning the
+    /// transport namespace for our PID-embedded endpoints.
+    ///
+    /// - Windows: named pipes under <c>\\.\pipe\</c> matching <see cref="PipeName(int)"/>.
+    /// - Unix: socket files in the user-private socket directory matching <see cref="SocketPath(int)"/>.
+    ///
+    /// Best-effort and never throws. A returned id may still be stale (a crashed Unix process can leave 
+    /// its socket behind), so the caller should confirm liveness.
+    /// </summary>
+    public static IReadOnlyList<int> EnumerateListeningProcessIds()
+    {
+        var processIds = new HashSet<int>();
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                const string PipeRoot = @"\\.\pipe\";
+                foreach (var pipe in Directory.GetFiles(PipeRoot))
+                {
+                    // Directory.GetFiles returns full paths like \\.\pipe\CSharpRepl.InjectedHook.1234.
+                    var name = pipe.StartsWith(PipeRoot, StringComparison.Ordinal) ? pipe[PipeRoot.Length..] : pipe;
+                    if (TryParseProcessId(name, out var processId)) processIds.Add(processId);
+                }
+            }
+            else
+            {
+                var directory = SocketDirectory();
+                if (Directory.Exists(directory))
+                {
+                    foreach (var socket in Directory.GetFiles(directory, SocketNamePrefix + "*" + SocketNameSuffix))
+                    {
+                        if (TryParseProcessId(Path.GetFileName(socket), out var processId)) processIds.Add(processId);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Discovery is advisory; a failure to enumerate the namespace just yields what we found so far.
+        }
+
+        var sorted = new List<int>(processIds);
+        sorted.Sort();
+        return sorted;
+    }
+
+    /// <summary>
+    /// Extracts the process id from a transport endpoint name (a Windows pipe name or a Unix socket file
+    /// name), reversing <see cref="PipeName(int)"/> / <see cref="SocketPath(int)"/>.
+    /// </summary>
+    public static bool TryParseProcessId(string endpointName, out int processId)
+    {
+        processId = 0;
+        if (string.IsNullOrEmpty(endpointName)) return false;
+
+        string number;
+        if (endpointName.StartsWith(PipeNamePrefix, StringComparison.Ordinal))
+        {
+            number = endpointName[PipeNamePrefix.Length..];
+        }
+        else if (endpointName.StartsWith(SocketNamePrefix, StringComparison.Ordinal) &&
+                 endpointName.EndsWith(SocketNameSuffix, StringComparison.Ordinal))
+        {
+            number = endpointName[SocketNamePrefix.Length..^SocketNameSuffix.Length];
+        }
+        else
+        {
+            return false;
+        }
+
+        // NumberStyles.None: digits only — reject a leading sign, whitespace, or thousands separators.
+        return int.TryParse(number, NumberStyles.None, CultureInfo.InvariantCulture, out processId) && processId > 0;
+    }
 
     /// <summary>
     /// Connects to the inspector listening for processId, retrying until the listener exists or the timeout

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ csharprepl inspect init        # this autodetects your shell, or pass e.g. --she
 3. Attach to the application by its process ID:
 
 ```console
-csharprepl inspect 1234
+csharprepl inspect list   # lists available processes to attach to, with their process ID.
+csharprepl inspect 1234   # attaches to a process with process ID e.g. 1234
 ```
 
 This will start the REPL in the target application. Some things you can try:

--- a/Tests/CSharpRepl.Tests/CommandLineTests.cs
+++ b/Tests/CSharpRepl.Tests/CommandLineTests.cs
@@ -184,7 +184,9 @@ public class CommandLineTests
     public void ParseArguments_DotNetSuggestInspectSubcommand_IsAutocompleted()
     {
         var result = Parse(new[] { "[suggest:8]", "inspect " });
-        Assert.Contains("init", Render(result.OutputForEarlyExit));
+        var output = Render(result.OutputForEarlyExit);
+        Assert.Contains("init", output);
+        Assert.Contains("list", output);
     }
 
     [Fact]
@@ -236,6 +238,47 @@ public class CommandLineTests
         Assert.Contains("DOTNET_STARTUP_HOOKS", output);
         Assert.Contains("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", output);
         Assert.Null(result.InspectProcessId);
+    }
+
+    [Fact]
+    public void ParseArguments_InspectList_ProducesEarlyExitWithoutInspecting()
+    {
+        // `inspect list` reports the attachable processes and exits, like `inspect init` — it never enters
+        // inspect mode (no pid). The rendered content depends on what's running, so only assert the shape.
+        var result = Parse("inspect list");
+        Assert.NotNull(result.OutputForEarlyExit);
+        Assert.Null(result.InspectProcessId);
+    }
+
+    [Fact]
+    public void RenderInspectList_WithNoProcesses_ShowsTheInitHint()
+    {
+        var output = Render(CommandLine.RenderInspectList([]));
+        Assert.Contains("No inspector-enabled processes found", output);
+        Assert.Contains("csharprepl inspect init", output);
+    }
+
+    [Fact]
+    public void RenderInspectList_WithProcesses_ListsEachPidAndNameAndAConnectHint()
+    {
+        var output = Render(CommandLine.RenderInspectList([(1234, "MyApp"), (5678, "dotnet")]));
+
+        Assert.Contains("PID", output);
+        Assert.Contains("Process", output);
+        Assert.Contains("1234", output);
+        Assert.Contains("MyApp", output);
+        Assert.Contains("5678", output);
+        Assert.Contains("dotnet", output);
+        Assert.Contains("csharprepl inspect", output); // the "connect with" hint
+    }
+
+    [Fact]
+    public void RenderInspectList_WithMarkupCharsInName_RendersThemLiterally()
+    {
+        // A process name with '[' must not be interpreted as Spectre markup (it would otherwise throw or be
+        // swallowed). The cells use Text, not markup, so the brackets survive verbatim.
+        var output = Render(CommandLine.RenderInspectList([(42, "weird[name]")]));
+        Assert.Contains("weird[name]", output);
     }
 
     [Theory]

--- a/Tests/CSharpRepl.Tests/InspectorDiscoveryTests.cs
+++ b/Tests/CSharpRepl.Tests/InspectorDiscoveryTests.cs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CSharpRepl.InjectedHook.Contracts;
+using Xunit;
+
+namespace CSharpRepl.Tests;
+
+/// <summary>
+/// Tests for the `inspect list` discovery layer (<see cref="InspectorTransport.TryParseProcessId"/> and
+/// <see cref="InspectorTransport.EnumerateListeningProcessIds"/>).
+/// A mix of unit tests (parsing) and integration tests (launch a real hooked target and proves the 
+/// target's pid is discovered while a non-hooked process (this test runner) is not.
+/// </summary>
+public class InspectorDiscoveryTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(1234)]
+    [InlineData(int.MaxValue)]
+    public void TryParseProcessId_RoundTripsTheEndpointNamesItBuilds(int processId)
+    {
+        // Round-trip through the real builders so the parser and PipeName/SocketPath can't drift apart.
+        Assert.True(InspectorTransport.TryParseProcessId(InspectorTransport.PipeName(processId), out var fromPipe));
+        Assert.Equal(processId, fromPipe);
+
+        var socketName = Path.GetFileName(InspectorTransport.SocketPath(processId));
+        Assert.True(InspectorTransport.TryParseProcessId(socketName, out var fromSocket));
+        Assert.Equal(processId, fromSocket);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("CSharpRepl.InjectedHook.")]      // our prefix but no number
+    [InlineData("CSharpRepl.InjectedHook.abc")]   // not numeric
+    [InlineData("CSharpRepl.InjectedHook.-5")]    // a sign is not a bare digit run
+    [InlineData("CSharpRepl.InjectedHook.0")]     // pids are positive
+    [InlineData("CSharpRepl.InjectedHook.12.3")]  // not an integer
+    [InlineData("dotnet-diagnostic-1234")]        // a real .NET diagnostic-port pipe must NOT be claimed as ours
+    [InlineData("inspector-1234.txt")]            // wrong suffix
+    [InlineData("inspector-.sock")]               // socket form but no number
+    [InlineData("inspector-abc.sock")]            // socket form, not numeric
+    [InlineData("some-unrelated-pipe")]
+    public void TryParseProcessId_RejectsAnythingThatIsNotOurEndpoint(string? endpointName)
+    {
+        Assert.False(InspectorTransport.TryParseProcessId(endpointName!, out _));
+    }
+
+    [Fact]
+    public void EnumerateListeningProcessIds_DoesNotListThisNonHookedProcess()
+    {
+        // The test runner wasn't launched with the inspector hook, so it must never appear as attachable.
+        Assert.DoesNotContain(Environment.ProcessId, InspectorTransport.EnumerateListeningProcessIds());
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task EnumerateListeningProcessIds_FindsAHookedTarget()
+    {
+        using var process = InspectorTestSupport.StartHookedTarget();
+
+        // Drain the child's output so a full pipe buffer can't block it; the content isn't needed.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            // The listener comes up on a background thread shortly after the process starts (before Main),
+            // so poll rather than assuming it's immediately present.
+            var found = await WaitUntilListedAsync(process.Id, TimeSpan.FromSeconds(30));
+            Assert.True(found,
+                $"The hooked target (pid {process.Id}) should be discoverable via its inspector endpoint.");
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            try { await Task.WhenAll(stdoutTask, stderrTask); } catch { /* output drained on process exit */ }
+        }
+    }
+
+    private static async Task<bool> WaitUntilListedAsync(int processId, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (InspectorTransport.EnumerateListeningProcessIds().Contains(processId))
+                return true;
+            await Task.Delay(200, TestContext.Current.CancellationToken);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Add `csharprepl inspect list` command that shows available processes to inspect. It scans for available named pipes / domain sockets from the CSharpRepl hook.

This makes it so users don't need to manually run `ps` or use the task manager to get the process id.