### PR TITLE
Improve help text on keybindings

### DIFF
--- a/CSharpRepl.Services/Configuration.cs
+++ b/CSharpRepl.Services/Configuration.cs
@@ -31,6 +31,9 @@ public sealed class Configuration
 
     public const string PromptDefault = "> ";
 
+    public const string KeyBindingPatternDescription =
+        "Key pattern is a key with optional modifiers (Alt/Shift/Control) e.g. 'Enter', 'Control+A'";
+
     public static readonly string ApplicationDirectory =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".csharprepl");
 
@@ -212,8 +215,6 @@ public sealed class Configuration
     {
         if (string.IsNullOrEmpty(keyPattern)) return default;
 
-        const string GeneralInfo = "Key pattern must contain one key with optional modifiers (Alt/Shift/Control). E.g. 'Enter', 'Control+A', '(', 'Alt+.', ...";
-
         ConsoleKey? key = null;
         char? keyChar = null;
         ConsoleModifiers modifiers = default;
@@ -235,7 +236,7 @@ public sealed class Configuration
             }
             else
             {
-                throw new ArgumentException($"Unable to parse '{part}'. {GeneralInfo}", nameof(keyPattern));
+                throw new ArgumentException($"Unable to parse '{part}'. {KeyBindingPatternDescription}", nameof(keyPattern));
             }
         }
 
@@ -252,7 +253,7 @@ public sealed class Configuration
             return new KeyPressPattern(keyChar.Value);
         }
 
-        static void Throw() => throw new ArgumentException(GeneralInfo, nameof(keyPattern));
+        static void Throw() => throw new ArgumentException(KeyBindingPatternDescription, nameof(keyPattern));
 
         static bool TryParseConsoleModifiers(string text, out ConsoleModifiers result)
         {

--- a/CSharpRepl/Commands/CommandLine.cs
+++ b/CSharpRepl/Commands/CommandLine.cs
@@ -630,7 +630,8 @@ internal static class CommandLine
             $"  [green]--tabSize[/] [cyan]<width>[/]:                          {TabSize.Description}" + NewLine +
             $"  [green]--culture[/] [cyan]<culture name>[/]:                   {Culture.Description}" + NewLine +
             NewLine +
-            $"  Key Bindings" + NewLine +
+            $"  Key Bindings:                               {Configuration.KeyBindingPatternDescription}" + NewLine +
+            $"                                              Specifying an option multiple times makes any of its key bindings trigger the action." + NewLine +
             $"  [green]--triggerCompletionListKeys[/] [cyan]<key-binding>[/]:  {TriggerCompletionListKeyBindings.Description}" + NewLine +
             $"  [green]--newLineKeys[/] [cyan]<key-binding>[/]:                {NewLineKeyBindings.Description}" + NewLine +
             $"  [green]--submitPromptKeys[/] [cyan]<key-binding>[/]:           {SubmitPromptKeyBindings.Description}" + NewLine +


### PR DESCRIPTION
Improve help text to clarify the format for custom keybindings.

Fixes #363, #364