### PR TITLE
Ensure Debug.Assert failures do not crash the REPL

### DIFF
--- a/CSharpRepl.Services/Roslyn/DebugAssertHandler.cs
+++ b/CSharpRepl.Services/Roslyn/DebugAssertHandler.cs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace CSharpRepl.Services.Roslyn;
+
+/// <summary>
+/// Makes a failed <see cref="Debug.Assert"/> in evaluated code throw instead of crashing the REPL.
+/// </summary>
+internal static class DebugAssertHandler
+{
+    private static int installed;
+
+    /// <summary>
+    /// Installs the throwing listener process-wide. Only the first call takes effect.
+    /// </summary>
+    public static void Install()
+    {
+        if (Interlocked.Exchange(ref installed, 1) != 0)
+        {
+            return;
+        }
+
+        var listeners = Trace.Listeners;
+
+        // Remove the default listener(s) - their Fail() is what FailFasts the process.
+        for (var i = listeners.Count - 1; i >= 0; i--)
+        {
+            if (listeners[i] is DefaultTraceListener)
+            {
+                listeners.RemoveAt(i);
+            }
+        }
+
+        listeners.Add(new ThrowingTraceListener());
+    }
+
+    private sealed class ThrowingTraceListener : TraceListener
+    {
+        // Debug.Write / Debug.WriteLine route here; the default listener forwarded them to the debugger (unused in the REPL), so swallowing them does not cause any harm.
+        public override void Write(string? message) { }
+
+        public override void WriteLine(string? message) { }
+
+        public override void Fail(string? message) => throw Build(message, null);
+
+        public override void Fail(string? message, string? detailMessage) =>
+            throw Build(message, detailMessage);
+
+        private static DebugAssertException Build(string? message, string? detailMessage)
+        {
+            var text = string.IsNullOrEmpty(message) ? "Assertion failed." : message;
+            if (!string.IsNullOrEmpty(detailMessage))
+            {
+                text += Environment.NewLine + detailMessage;
+            }
+            return new DebugAssertException(text);
+        }
+    }
+}
+
+/// <summary>
+/// Thrown when an assertion fails in evaluated code. We return/throw this which causes the REPL to show the error, instead of crashing.
+/// </summary>
+internal sealed class DebugAssertException : Exception
+{
+    public DebugAssertException(string message)
+        : base(message) { }
+}

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -87,6 +87,8 @@ public sealed partial class RoslynServices
 
     public RoslynServices(IConsoleService console, Configuration config, ITraceLogger logger, RemoteEditorContext? remoteEditor = null)
     {
+        DebugAssertHandler.Install(); // Prevent a failed Debug.Assert in evaluated code from killing the whole REPL.
+
         var cache = new MemoryCache(new MemoryCacheOptions());
         this.console = console;
         this.logger = logger;

--- a/Tests/CSharpRepl.Tests/EvaluationTests.cs
+++ b/Tests/CSharpRepl.Tests/EvaluationTests.cs
@@ -44,6 +44,20 @@ public class EvaluationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Evaluate_FailingDebugAssert_DoesNotCrashAndReturnsError()
+    {
+        // Without DebugAssertHandler, a failed Debug.Assert FailFasts and crashes the whole process.
+        // Debug.Assert is [Conditional("DEBUG")], so the submission must define DEBUG for it to emit.
+        // See https://github.com/waf/CSharpRepl/issues/374.
+        var result = await services.EvaluateAsync(
+            "#define DEBUG\nSystem.Diagnostics.Debug.Assert(false, \"boom\");",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var error = Assert.IsType<EvaluationResult.Error>(result);
+        Assert.Contains("boom", error.Exception.Message);
+    }
+
+    [Fact]
     public async Task Evaluate_Variable_ReturnsValue()
     {
         var variableAssignment = await services.EvaluateAsync(@"var x = ""Hello World"";", cancellationToken: TestContext.Current.CancellationToken);


### PR DESCRIPTION
Fixes https://github.com/waf/CSharpRepl/issues/374

See also https://github.com/dotnet/runtime/issues/82758