### PR TITLE
Add hint text to `inspect list` command

### DIFF
--- a/CSharpRepl/Commands/CommandLine.cs
+++ b/CSharpRepl/Commands/CommandLine.cs
@@ -432,16 +432,36 @@ internal static class CommandLine
                 "Launch your app with the environment variables from [green]csharprepl inspect init[/], then run [green]csharprepl inspect list[/] again.");
         }
 
+        (bool containsDotNetExecutable, string? appExecutable, int pid) hint = (false, null, 0);
+
         var table = new Table()
+            .MinimalBorder()
             .AddColumn("PID")
             .AddColumn("Process");
         // Use Text (not markup strings) for the cells so a process name containing '[' isn't parsed as markup.
         foreach (var (processId, processName) in processes)
         {
             table.AddRow(new Text(processId.ToString()), new Text(processName));
+
+            hint.containsDotNetExecutable |= processName == "dotnet";
+            if(processName != "dotnet" && hint.appExecutable is null)
+            {
+                hint.appExecutable = processName;
+                hint.pid = processId;
+            }
         }
 
-        return new Rows(table, new Markup("Connect with [green]csharprepl inspect [/][cyan]<pid>[/]."));
+        List<Renderable> rows = [
+            table,
+            new Markup("Connect with [green]csharprepl inspect [/][cyan]<PID>[/]."),
+        ];
+
+        if(processes.Count == 2 && hint.containsDotNetExecutable && hint.appExecutable is not null)
+        {
+            rows.Add(new Markup($"Hint: you most likely want to connect to the '{hint.appExecutable}' process (PID {hint.pid})."));
+        }
+
+        return new Rows(rows);
     }
 
     /// <summary>Resolves a pid to its process name, or null if the process is gone (e.g. a stale endpoint).</summary>

--- a/CSharpRepl/Repls/RemoteReadEvalPrintLoop.cs
+++ b/CSharpRepl/Repls/RemoteReadEvalPrintLoop.cs
@@ -156,7 +156,7 @@ internal sealed class RemoteReadEvalPrintLoop
 
         console.WriteLine(string.Empty);
         console.Write(new Markup(
-            "[yellow]⚠ Development/diagnostics tool: code you evaluate runs inside the target process with its full privileges. Never inspect a production process.[/]"));
+            "[yellow] Development/diagnostics tool: code you evaluate runs inside the target process with its full privileges. Never inspect a production process.[/]"));
         console.WriteLine();
         console.WriteLine("Type C# to evaluate it in the target. Type exit (or press Ctrl+D) to detach; the target keeps running and you can reconnect later.");
         console.WriteLine(string.Empty);

--- a/Tests/CSharpRepl.Tests/CommandLineTests.cs
+++ b/Tests/CSharpRepl.Tests/CommandLineTests.cs
@@ -269,7 +269,9 @@ public class CommandLineTests
         Assert.Contains("MyApp", output);
         Assert.Contains("5678", output);
         Assert.Contains("dotnet", output);
-        Assert.Contains("csharprepl inspect", output); // the "connect with" hint
+        // the "connect with" hint
+        Assert.Contains("csharprepl inspect", output);
+        Assert.Contains("Hint: you most likely want to connect to the 'MyApp' process (PID 1234).", output);
     }
 
     [Fact]


### PR DESCRIPTION
Make `csharprepl inspect list` a bit more friendly -- give guidance on which to connect to: dotnet.exe vs the App.exe (it is App.exe)