### PR TITLE
Use MonoMod.RuntimeDetour to support replacement of inspected processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,21 @@ When attached, csharprepl is a thin **controller**: it compiles nothing for eval
 
 A single duplex connection (named pipe on Windows, Unix domain socket elsewhere, **current-user only**). Every frame is a 4-byte little-endian length prefix + UTF-8 JSON body; messages are a `System.Text.Json` **polymorphic** `WireMessage` hierarchy keyed on a `$kind` discriminator (`MessageChannel`). Security model mirrors the .NET diagnostic port — OS access control, no secret. An inspector-enabled process is RCE-equivalent for same-user code and must never run in production.
 
+### Live method replacement
+
+`#replace`/`#wrap`/`#patches`/`#revert` (controller commands in `RemoteReadEvalPrintLoop`) detour a live method in the target to a REPL-defined delegate.
+
+- Engine side: `InspectorPatcher` (in `CSharpRepl.InjectedHook.ScriptEngine`) over `MonoMod.RuntimeDetour`. Resolves the target by name, matches the overload from the delegate's signature, coerces a bare method group via a generated cast, applies a `Hook`, tracks it by id for revert.
+- Wire (protocol v2): `ReplaceRequest`/`ReplaceResponse`, `PatchListRequest`/`PatchListResponse`, `RevertRequest`/`RevertResponse`, plus three `IInspectorEngine` methods served in `InspectorServer`.
+- Replacement shape: instance methods take the instance as the first parameter; `#wrap` prepends an `orig` delegate the body can call.
+- Detours repoint native code, so they cross the engine-ALC/target-ALC boundary: the replacement compiles in the engine ALC, the target method lives in the default ALC.
+- `ref`/`out`/`in` work in Replace mode: `BuildCastDelegate` emits a delegate type carrying the modifiers (Func can't), which the engine prepends to the probe submission before the method-group cast. Not supported: generic methods, pointer parameters, Wrap + by-ref (the `orig` delegate can't be a shared type).
+- Limits: JIT-inlined call sites keep old behavior. Patches persist after detach until reverted.
+- Tests: `InspectorEngineTests.ReplaceMethod_*` (in-process engine) and `RemoteReadEvalPrintLoopTests` (cross-process, real hooked child).
+
 ### Packaging
 
-`CSharpRepl.csproj`'s `IncludeInspectorPayload` target stages the full inspector payload (bootstrap + contracts + engine + Roslyn closure + `.deps.json`) into an **`inspector/` subdirectory** next to the tool (both on `dotnet run` and in the packed global tool), isolated so the engine's Roslyn never shadows the tool's. `inspect init` points `DOTNET_STARTUP_HOOKS` at `inspector/CSharpRepl.InjectedHook.dll`. The bootstrap is a `ProjectReference` with `ReferenceOutputAssembly="false"` (the tool must not link it).
+`CSharpRepl.csproj`'s `IncludeInspectorPayload` target stages the full inspector payload (bootstrap + contracts + engine + Roslyn closure + `MonoMod.RuntimeDetour` closure + `.deps.json`) into an **`inspector/` subdirectory** next to the tool (both on `dotnet run` and in the packed global tool), isolated so the engine's Roslyn never shadows the tool's. `inspect init` points `DOTNET_STARTUP_HOOKS` at `inspector/CSharpRepl.InjectedHook.dll`. The bootstrap is a `ProjectReference` with `ReferenceOutputAssembly="false"` (the tool must not link it).
 
 ## Gotchas
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -201,3 +201,12 @@ classDiagram
 Statics and any singletons stored in statics are reachable for free — a submission just names them like ordinary code. For dependency-injected services, the bootstrap cooperatively captures the application's root service provider and exposes it to submissions (as `services` and `Get<T>()`), so a script can resolve the app's real services.
 
 The capture mechanism: before the target's `Main` runs, the bootstrap subscribes to the `"Microsoft.Extensions.Hosting"` `DiagnosticListener` — the same effectively-public contract `HostFactoryResolver` and the EF Core design-time tools rely on. Both `HostBuilder.Build()` and `HostApplicationBuilder.Build()` write a `HostBuilt` event whose payload is the `IHost`; the bootstrap reflects the host's `Services` property off the payload (reflection rather than a typed reference, so the bootstrap carries no hosting dependency and no version coupling) and stores it in the shared `InspectorRoots`. This covers the non-web Generic Host and modern ASP.NET Core (`WebApplication.CreateBuilder` builds through `HostApplicationBuilder`); the first host built wins, and apps that don't use the hosting abstractions simply report "no provider captured" — statics remain reachable.
+
+### Live method replacement
+
+When attached, the controller can detour a live method in the target to a method the user defines in the REPL, so the running application's behavior changes immediately.
+
+- The user defines a delegate, then runs `#replace` (supplant the original) or `#wrap` (call the original via a leading `orig` delegate). `#patches` lists active patches; `#revert` undoes them.
+- The engine's `InspectorPatcher` detours the method via MonoMod.RuntimeDetour: it resolves the target, matches the overload from the delegate's signature, applies a reversible `Hook`, and tracks it by id.
+- The detour repoints native code, so it works across the engine-ALC/target-ALC split: the replacement compiles in the engine ALC and patches a method in the target's default ALC.
+- Patches persist until reverted or the process exits, so they outlive a controller detach. `ref`/`out`/`in` parameters work in Replace mode (the patcher emits a delegate type carrying the modifiers, since `Func` can't). Generic methods, pointer parameters, `#wrap` with by-ref, and already-inlined call sites are out of scope.

--- a/CSharpRepl.Services/Completion/ReplaceMethodCompletionProvider.cs
+++ b/CSharpRepl.Services/Completion/ReplaceMethodCompletionProvider.cs
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CSharpRepl.Services.Remote.Commands;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace CSharpRepl.Services.Completion;
+
+/// <summary>
+/// Completion for the inspect-mode REPL commands <c>#replace</c> / <c>#wrap</c>. Roslyn doesn't understand them
+/// (they're bad preprocessor directives in Script mode), so the built-in providers produce nothing useful on
+/// such a line. This provider detects the command, rewrites the argument under the caret into a snippet Roslyn
+/// CAN complete, delegates to the normal <see cref="CompletionService"/> on a throwaway document, and re-emits
+/// the results as its own items.
+///
+/// - Target position (<c>#replace MyApp.Type.Meth</c>): wrapped in <c>nameof(...)</c> so namespaces, types, and
+///   BOTH static and instance members complete (plain member access on a type name omits instance members).
+/// - Replacement position (<c>#replace X.M with expr</c>): the expression is completed as ordinary script code,
+///   against the submission chain (so the user's just-defined delegate/method is offered).
+///
+/// Registered only in the inspect-mode workspace (see <c>WorkspaceManager</c>), so the local REPL is unaffected.
+/// </summary>
+[ExportCompletionProvider(nameof(ReplaceMethodCompletionProvider), LanguageNames.CSharp), Shared]
+internal sealed class ReplaceMethodCompletionProvider : CompletionProvider
+{
+    // The argument-taking commands, each with the trailing space that precedes its argument.
+    private static readonly string[] Commands =
+        [InspectorCommands.Replace.Token + " ", InspectorCommands.Wrap.Token + " "];
+    private const string WithSeparator = InspectorCommands.WithSeparator;
+
+    // Carried on each re-emitted item so GetDescriptionAsync can rebuild the synthetic document on demand.
+    private const string SyntheticTextProperty = "CSharpRepl.SyntheticText";
+    private const string SyntheticPositionProperty = "CSharpRepl.SyntheticPosition";
+
+    [ImportingConstructor]
+    public ReplaceMethodCompletionProvider() { }
+
+    public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+    {
+        if (!TryRewrite(text, caretPosition, out _, out _))
+        {
+            return false;
+        }
+
+        return trigger.Kind switch
+        {
+            CompletionTriggerKind.Invoke or CompletionTriggerKind.InvokeAndCommitIfUnique => true,
+            CompletionTriggerKind.Insertion => trigger.Character == '.' || IsIdentifierChar(trigger.Character),
+            _ => false,
+        };
+    }
+
+    public override async Task ProvideCompletionsAsync(CompletionContext context)
+    {
+        var text = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+        if (!TryRewrite(text, context.Position, out var synthetic, out var syntheticPosition))
+        {
+            return;
+        }
+
+        var delegated = await GetDelegatedCompletionsAsync(context.Document, synthetic, syntheticPosition, context.CancellationToken).ConfigureAwait(false);
+        if (delegated is null || delegated.ItemsList.Count == 0)
+        {
+            return;
+        }
+
+        // Only type/member/expression completions make sense on a #replace/#wrap line, so suppress the unrelated
+        // built-in items (keywords, snippets) that would otherwise mix in from the bad-directive document.
+        context.IsExclusive = true;
+
+        foreach (var item in delegated.ItemsList)
+        {
+            context.AddItem(Reemit(item, synthetic, syntheticPosition));
+        }
+    }
+
+    public override async Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+    {
+        // Re-emitted items aren't owned by the built-in provider that produced them, so rebuild the synthetic
+        // document, re-run completion, and forward to the real provider's description for the matching item.
+        if (!item.Properties.TryGetValue(SyntheticTextProperty, out var synthetic) ||
+            !item.Properties.TryGetValue(SyntheticPositionProperty, out var positionText) ||
+            !int.TryParse(positionText, NumberStyles.None, CultureInfo.InvariantCulture, out var syntheticPosition))
+        {
+            return await base.GetDescriptionAsync(document, item, cancellationToken).ConfigureAwait(false);
+        }
+
+        var syntheticDoc = document.WithText(SourceText.From(synthetic));
+        var service = CompletionService.GetService(syntheticDoc);
+        if (service is null)
+        {
+            return await base.GetDescriptionAsync(document, item, cancellationToken).ConfigureAwait(false);
+        }
+
+        var delegated = await service.GetCompletionsAsync(syntheticDoc, syntheticPosition, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var match = delegated?.ItemsList.FirstOrDefault(i => i.DisplayText == item.DisplayText && i.SortText == item.SortText);
+        return match is null
+            ? await base.GetDescriptionAsync(document, item, cancellationToken).ConfigureAwait(false)
+            : await service.GetDescriptionAsync(syntheticDoc, match, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<CompletionList?> GetDelegatedCompletionsAsync(Document document, string synthetic, int syntheticPosition, CancellationToken cancellationToken)
+    {
+        var syntheticDoc = document.WithText(SourceText.From(synthetic));
+        var service = CompletionService.GetService(syntheticDoc);
+        if (service is null)
+        {
+            return null;
+        }
+        return await service.GetCompletionsAsync(syntheticDoc, syntheticPosition, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static CompletionItem Reemit(CompletionItem item, string synthetic, int syntheticPosition)
+    {
+        var properties = item.Properties
+            .SetItem(SyntheticTextProperty, synthetic)
+            .SetItem(SyntheticPositionProperty, syntheticPosition.ToString(CultureInfo.InvariantCulture));
+
+        return CompletionItem.Create(
+            displayText: item.DisplayText,
+            filterText: item.FilterText,
+            sortText: item.SortText,
+            properties: properties,
+            tags: item.Tags,
+            rules: item.Rules,
+            displayTextPrefix: item.DisplayTextPrefix,
+            displayTextSuffix: item.DisplayTextSuffix,
+            inlineDescription: item.InlineDescription);
+    }
+
+    /// <summary>
+    /// If the caret sits in the argument of a <c>#replace</c>/<c>#wrap</c> command, produces the synthetic
+    /// snippet (and caret within it) to complete against. Returns false for any other line.
+    /// </summary>
+    private static bool TryRewrite(SourceText text, int caretPosition, out string synthetic, out int syntheticPosition)
+    {
+        synthetic = "";
+        syntheticPosition = 0;
+
+        var line = text.Lines.GetLineFromPosition(caretPosition);
+        var lineToCaret = text.ToString(TextSpan.FromBounds(line.Start, caretPosition));
+        var leadingWhitespace = lineToCaret.Length - lineToCaret.AsSpan().TrimStart().Length;
+        var afterWhitespace = lineToCaret[leadingWhitespace..];
+
+        var command = Commands.FirstOrDefault(c => afterWhitespace.StartsWith(c, StringComparison.OrdinalIgnoreCase));
+        if (command is null)
+        {
+            return false;
+        }
+
+        var argument = afterWhitespace[command.Length..];
+        var withIndex = argument.IndexOf(WithSeparator, StringComparison.OrdinalIgnoreCase);
+        synthetic = withIndex >= 0
+            ? argument[(withIndex + WithSeparator.Length)..]   // expression: complete as ordinary script code
+            : "_ = nameof(" + argument;                        // target: nameof so static+instance members show
+        syntheticPosition = synthetic.Length;
+        return true;
+    }
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+}

--- a/CSharpRepl.Services/Remote/Commands/InspectorCommandProcessor.cs
+++ b/CSharpRepl.Services/Remote/Commands/InspectorCommandProcessor.cs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CSharpRepl.InjectedHook.Contracts;
+
+namespace CSharpRepl.Services.Remote.Commands;
+
+/// <summary>
+/// Parses inspect-mode command lines (<c>#replace</c>/<c>#wrap</c>/<c>#patches</c>/<c>#revert</c>) and runs them
+/// against the <see cref="RemoteSession"/>, returning the raw engine response for the REPL to render. Commands
+/// are recognized case-insensitively while the casing of method names and replacement expressions is preserved.
+/// </summary>
+public sealed class InspectorCommandProcessor
+{
+    private readonly RemoteSession session;
+
+    public InspectorCommandProcessor(RemoteSession session) => this.session = session;
+
+    /// <summary>
+    /// Runs <paramref name="commandText"/> if it's an inspect command, returning its result; returns null when
+    /// the text is not one of the commands, so the caller can fall through to normal evaluation. May surface an
+    /// <see cref="IOException"/>/<see cref="OperationCanceledException"/> from the underlying session for the
+    /// caller to handle.
+    /// </summary>
+    public async Task<InspectorCommandResult?> TryExecuteAsync(string commandText, CancellationToken cancellationToken)
+    {
+        if (TryMatchArgument(commandText, InspectorCommands.Replace, out var replaceArgs))
+        {
+            return await ReplaceAsync(replaceArgs, PatchMode.Replace, cancellationToken).ConfigureAwait(false);
+        }
+        if (TryMatchArgument(commandText, InspectorCommands.Wrap, out var wrapArgs))
+        {
+            return await ReplaceAsync(wrapArgs, PatchMode.Wrap, cancellationToken).ConfigureAwait(false);
+        }
+        if (commandText.Equals(InspectorCommands.Patches.Token, StringComparison.OrdinalIgnoreCase))
+        {
+            return new InspectorCommandResult.Listed(await session.ListPatchesAsync(cancellationToken).ConfigureAwait(false));
+        }
+        if (commandText.Equals(InspectorCommands.Revert.Token, StringComparison.OrdinalIgnoreCase) ||
+            commandText.StartsWith(InspectorCommands.Revert.Token + " ", StringComparison.OrdinalIgnoreCase))
+        {
+            return await RevertAsync(commandText[InspectorCommands.Revert.Token.Length..].Trim(), cancellationToken).ConfigureAwait(false);
+        }
+        return null;
+    }
+
+    private async Task<InspectorCommandResult> ReplaceAsync(string arguments, PatchMode mode, CancellationToken cancellationToken)
+    {
+        var info = mode == PatchMode.Wrap ? InspectorCommands.Wrap : InspectorCommands.Replace;
+        var separator = arguments.IndexOf(InspectorCommands.WithSeparator, StringComparison.OrdinalIgnoreCase);
+        if (separator < 0)
+        {
+            return new InspectorCommandResult.UsageError(info);
+        }
+
+        var target = arguments[..separator].Trim();
+        var replacement = arguments[(separator + InspectorCommands.WithSeparator.Length)..].Trim();
+        if (target.Length == 0 || replacement.Length == 0)
+        {
+            return new InspectorCommandResult.UsageError(info);
+        }
+
+        var response = await session.ReplaceAsync(target, replacement, mode, cancellationToken).ConfigureAwait(false);
+        return new InspectorCommandResult.Replaced(mode, target, replacement, response);
+    }
+
+    private async Task<InspectorCommandResult> RevertAsync(string argument, CancellationToken cancellationToken)
+    {
+        if (argument.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            return new InspectorCommandResult.Reverted(All: true, RequestedId: 0, await session.RevertAsync(0, all: true, cancellationToken).ConfigureAwait(false));
+        }
+        if (int.TryParse(argument, out var id))
+        {
+            return new InspectorCommandResult.Reverted(All: false, RequestedId: id, await session.RevertAsync(id, all: false, cancellationToken).ConfigureAwait(false));
+        }
+        return new InspectorCommandResult.UsageError(InspectorCommands.Revert);
+    }
+
+    /// <summary>
+    /// Matches an argument-taking command, requiring the trailing space before the argument (so a bare
+    /// <c>#replace</c> with no argument falls through to evaluation, preserving the original dispatch behavior).
+    /// </summary>
+    private static bool TryMatchArgument(string commandText, InspectorCommandInfo info, out string arguments)
+    {
+        var prefix = info.Token + " ";
+        if (commandText.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            arguments = commandText[prefix.Length..];
+            return true;
+        }
+        arguments = "";
+        return false;
+    }
+}

--- a/CSharpRepl.Services/Remote/Commands/InspectorCommandResult.cs
+++ b/CSharpRepl.Services/Remote/Commands/InspectorCommandResult.cs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using CSharpRepl.InjectedHook.Contracts;
+
+namespace CSharpRepl.Services.Remote.Commands;
+
+/// <summary>
+/// The outcome of running an inspect-mode command. A closed hierarchy carrying the raw engine responses so the
+/// REPL — not this service — decides how to render them.
+/// </summary>
+public abstract record InspectorCommandResult
+{
+    private InspectorCommandResult() { }
+
+    /// <summary>The argument was missing or malformed; the REPL should show <see cref="Command"/>'s usage.</summary>
+    public sealed record UsageError(InspectorCommandInfo Command) : InspectorCommandResult;
+
+    /// <summary>A <c>#replace</c>/<c>#wrap</c> completed; inspect <see cref="Response"/>.Ok for success vs failure.</summary>
+    public sealed record Replaced(PatchMode Mode, string Target, string Replacement, ReplaceResponse Response) : InspectorCommandResult;
+
+    /// <summary>A <c>#patches</c> listing.</summary>
+    public sealed record Listed(PatchListResponse Response) : InspectorCommandResult;
+
+    /// <summary>A <c>#revert</c> result. <see cref="RequestedId"/> is meaningful only when not <see cref="All"/>.</summary>
+    public sealed record Reverted(bool All, int RequestedId, RevertResponse Response) : InspectorCommandResult;
+}

--- a/CSharpRepl.Services/Remote/Commands/InspectorCommands.cs
+++ b/CSharpRepl.Services/Remote/Commands/InspectorCommands.cs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+
+namespace CSharpRepl.Services.Remote.Commands;
+
+/// <summary>
+/// Static metadata for one inspect-mode REPL command. The single source of truth for its token, whether it
+/// takes an argument, its usage line, and its help/completion description — consumed by the command processor,
+/// the completion provider, and the prompt's completion items.
+/// </summary>
+public sealed record InspectorCommandInfo(string Token, bool RequiresArgument, string Usage, string Description);
+
+/// <summary>The inspect-mode commands (<c>#replace</c>/<c>#wrap</c>/<c>#patches</c>/<c>#revert</c>) and their canonical text.</summary>
+public static class InspectorCommands
+{
+    /// <summary>Separates the target method from the replacement expression in <c>#replace</c>/<c>#wrap</c>.</summary>
+    public const string WithSeparator = " with ";
+
+    public static readonly InspectorCommandInfo Replace = new(
+        Token: "#replace",
+        RequiresArgument: true,
+        Usage: "#replace <Namespace.Type.Method> with <expression>",
+        Description: "Replace a live method in the target with a method you define in the REPL. Signature must match. Usage: #replace <Namespace.Type.Method> with <yourMethod>");
+
+    public static readonly InspectorCommandInfo Wrap = new(
+        Token: "#wrap",
+        RequiresArgument: true,
+        Usage: "#wrap <Namespace.Type.Method> with <expression>",
+        Description: "Wrap a live method: the replacement's first parameter is an 'orig' delegate (Func/Action) that invokes the original. Usage: #wrap <Namespace.Type.Method> with <yourMethod>");
+
+    public static readonly InspectorCommandInfo Patches = new(
+        Token: "#patches",
+        RequiresArgument: false,
+        Usage: "#patches",
+        Description: "List the method replacements currently applied to the target.");
+
+    public static readonly InspectorCommandInfo Revert = new(
+        Token: "#revert",
+        RequiresArgument: false,
+        Usage: "#revert <id> | #revert all",
+        Description: "Undo a method replacement, restoring the original. Usage: #revert <id> or #revert all");
+
+    public static readonly IReadOnlyList<InspectorCommandInfo> All = [Replace, Wrap, Patches, Revert];
+}

--- a/CSharpRepl.Services/Remote/InspectorClient.cs
+++ b/CSharpRepl.Services/Remote/InspectorClient.cs
@@ -68,22 +68,47 @@ public sealed class InspectorClient : IAsyncDisposable
             catch { /* peer may be gone; the read below will surface it */ }
         }, channel);
 
-        var response = await channel.ReadAsync(CancellationToken.None).ConfigureAwait(false)
-            ?? throw new IOException("The inspector closed the connection without responding to the evaluation.");
-        return response is not EvalResponse evalResponse
-            ? throw new IOException($"Expected an evaluation result from the inspector but received {response.GetType().Name}.")
-            : evalResponse;
+        return await ReadResponseAsync<EvalResponse>("evaluation", "an evaluation result", CancellationToken.None).ConfigureAwait(false);
     }
 
     internal async Task<IReadOnlyList<string>> GetReferencePathsAsync(CancellationToken cancellationToken)
     {
         await channel.WriteAsync(new ReferencesRequest(), cancellationToken).ConfigureAwait(false);
+        var response = await ReadResponseAsync<ReferencesResponse>("references request", "a references response", cancellationToken).ConfigureAwait(false);
+        return response.Paths;
+    }
 
+    internal async Task<ReplaceResponse> ReplaceAsync(string targetMethod, string replacement, PatchMode mode, CancellationToken cancellationToken)
+    {
+        await channel.WriteAsync(new ReplaceRequest { TargetMethod = targetMethod, Replacement = replacement, Mode = mode }, cancellationToken).ConfigureAwait(false);
+        return await ReadResponseAsync<ReplaceResponse>("replace request", "a replace response", cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async Task<PatchListResponse> ListPatchesAsync(CancellationToken cancellationToken)
+    {
+        await channel.WriteAsync(new PatchListRequest(), cancellationToken).ConfigureAwait(false);
+        return await ReadResponseAsync<PatchListResponse>("patch-list request", "a patch-list response", cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async Task<RevertResponse> RevertAsync(int patchId, bool all, CancellationToken cancellationToken)
+    {
+        await channel.WriteAsync(new RevertRequest { PatchId = patchId, All = all }, cancellationToken).ConfigureAwait(false);
+        return await ReadResponseAsync<RevertResponse>("revert request", "a revert response", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the next frame and asserts it's the expected response type, turning a closed connection or an
+    /// unexpected message into a clear <see cref="IOException"/>. <paramref name="requestNoun"/> names the request
+    /// in the connection-closed message; <paramref name="responseNoun"/> names the expected reply in the
+    /// type-mismatch message (e.g. <c>"a revert response"</c>).
+    /// </summary>
+    private async Task<TResponse> ReadResponseAsync<TResponse>(string requestNoun, string responseNoun, CancellationToken cancellationToken)
+        where TResponse : WireMessage
+    {
         var response = await channel.ReadAsync(cancellationToken).ConfigureAwait(false)
-            ?? throw new IOException("The inspector closed the connection without responding to the references request.");
-        return response is not ReferencesResponse referencesResponse
-            ? throw new IOException($"Expected a references response from the inspector but received {response.GetType().Name}.")
-            : referencesResponse.Paths;
+            ?? throw new IOException($"The inspector closed the connection without responding to the {requestNoun}.");
+        return response as TResponse
+            ?? throw new IOException($"Expected {responseNoun} from the inspector but received {response.GetType().Name}.");
     }
 
     internal async Task SendDisconnectAsync(CancellationToken cancellationToken)

--- a/CSharpRepl.Services/Remote/RemoteEditorContext.cs
+++ b/CSharpRepl.Services/Remote/RemoteEditorContext.cs
@@ -5,6 +5,9 @@
 using System;
 using System.Collections.Generic;
 using CSharpRepl.InjectedHook.Contracts;
+using CSharpRepl.Services.Completion;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace CSharpRepl.Services.Remote;
 
@@ -27,8 +30,22 @@ public sealed class RemoteEditorContext
         GlobalsType = globalsType;
     }
 
+    // The default Roslyn MEF host plus this assembly, so the inspect-only completion provider
+    // (ReplaceMethodCompletionProvider, which powers #replace/#wrap autocomplete) is discovered. A process-wide
+    // singleton built on first use: reconnects don't recompose the MEF catalog, and the local REPL (which uses the
+    // cached MefHostServices.DefaultHost) never pays for it.
+    private static readonly Lazy<HostServices> editorHostServices = new(() =>
+        MefHostServices.Create(MefHostServices.DefaultAssemblies.Add(typeof(ReplaceMethodCompletionProvider).Assembly)));
+
     /// <summary>The target's loaded-assembly file paths, as reported by the inspector engine.</summary>
     public IReadOnlyList<string> ReferencePaths { get; }
+
+    /// <summary>
+    /// The Roslyn workspace host the editor services should use in inspect mode: the default providers plus the
+    /// inspect-only command-completion provider. Supplied to the <c>WorkspaceManager</c>; local sessions pass no
+    /// host and fall back to <see cref="MefHostServices.DefaultHost"/>.
+    /// </summary>
+    internal HostServices EditorHostServices => editorHostServices.Value;
 
     /// <summary>
     /// The globals type whose members (e.g. <c>services</c>, <c>Get&lt;T&gt;()</c>) are in scope for every

--- a/CSharpRepl.Services/Remote/RemoteSession.cs
+++ b/CSharpRepl.Services/Remote/RemoteSession.cs
@@ -42,6 +42,22 @@ public sealed class RemoteSession : IAsyncDisposable
     public Task<IReadOnlyList<string>> GetReferencePathsAsync(CancellationToken cancellationToken)
         => client.GetReferencePathsAsync(cancellationToken);
 
+    /// <summary>
+    /// Detours a live method in the target to a REPL-defined replacement. <paramref name="targetMethod"/> is a
+    /// fully-qualified Type.Method; <paramref name="replacement"/> is an expression (usually a delegate the user
+    /// defined) the engine evaluates against the shared state chain.
+    /// </summary>
+    public Task<ReplaceResponse> ReplaceAsync(string targetMethod, string replacement, PatchMode mode, CancellationToken cancellationToken)
+        => client.ReplaceAsync(targetMethod, replacement, mode, cancellationToken);
+
+    /// <summary>Lists the patches currently applied in the target by this session's engine.</summary>
+    public Task<PatchListResponse> ListPatchesAsync(CancellationToken cancellationToken)
+        => client.ListPatchesAsync(cancellationToken);
+
+    /// <summary>Undoes a patch by id, or every patch when <paramref name="all"/> is true.</summary>
+    public Task<RevertResponse> RevertAsync(int patchId, bool all, CancellationToken cancellationToken)
+        => client.RevertAsync(patchId, all, cancellationToken);
+
     /// <summary>Asks the inspector to end the session. The target process keeps running.</summary>
     public async Task DisconnectAsync(CancellationToken cancellationToken)
     {

--- a/CSharpRepl.Services/Roslyn/RoslynServices.cs
+++ b/CSharpRepl.Services/Roslyn/RoslynServices.cs
@@ -85,6 +85,12 @@ public sealed partial class RoslynServices
     // completion/highlighting are target-aware. Null for a normal local REPL session.
     private readonly RemoteEditorContext? remoteEditor;
 
+    /// <summary>
+    /// True when this is an inspect-mode session (editor services target a remote process). Used to offer the
+    /// inspect-only commands (#replace/#wrap/#patches/#revert) in completion only when they're applicable.
+    /// </summary>
+    public bool IsInspectMode => remoteEditor is not null;
+
     public RoslynServices(IConsoleService console, Configuration config, ITraceLogger logger, RemoteEditorContext? remoteEditor = null)
     {
         DebugAssertHandler.Install(); // Prevent a failed Debug.Assert in evaluated code from killing the whole REPL.
@@ -131,7 +137,7 @@ public sealed partial class RoslynServices
             // syntax highlighting, autocompletion, and roslyn symbol queries. In inspect mode the host object
             // type is the inspector globals, so `services`/`Get<T>()` resolve in the editor (the engine in the
             // target — not this ScriptRunner — performs the actual evaluation).
-            this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger, hostObjectType: remoteGlobalsType);
+            this.workspaceManager = new WorkspaceManager(compilationOptions, referenceService, logger, hostObjectType: remoteGlobalsType, hostServices: remoteEditor?.EditorHostServices);
             this.scriptRunner = new ScriptRunner(workspaceManager, parseOptions, compilationOptions, referenceService, console, config, globalsType: remoteGlobalsType);
 
             this.codeTransformer = new CodeTransformer(parseOptions, compilationOptions, referenceService, scriptRunner);

--- a/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
+++ b/CSharpRepl.Services/Roslyn/WorkspaceManager.cs
@@ -13,6 +13,7 @@ using CSharpRepl.Services.Roslyn.References;
 using CSharpRepl.Services.Roslyn.Scripting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
@@ -44,13 +45,13 @@ internal sealed class WorkspaceManager
 
     public Document CurrentDocument { get; private set; }
 
-    public WorkspaceManager(CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, ITraceLogger logger, Type? hostObjectType = null)
+    public WorkspaceManager(CSharpCompilationOptions compilationOptions, AssemblyReferenceService referenceAssemblyService, ITraceLogger logger, Type? hostObjectType = null, HostServices? hostServices = null)
     {
         this.compilationOptions = compilationOptions;
         this.referenceAssemblyService = referenceAssemblyService;
         this.logger = logger;
         this.hostObjectType = hostObjectType;
-        this.workspace = new AdhocWorkspace(MefHostServices.DefaultHost);
+        this.workspace = new AdhocWorkspace(hostServices ?? MefHostServices.DefaultHost);
 
         logger.Log(() => "MEF Default Assemblies: " + string.Join(", ", MefHostServices.DefaultAssemblies.Select(a => a.Location)));
 

--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using CSharpRepl.Repls;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Completion;
+using CSharpRepl.Services.Remote.Commands;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Scripting;
 using CSharpRepl.Services.SymbolExploration;
@@ -87,10 +88,14 @@ internal class CSharpReplPromptCallbacks(IConsoleService console, RoslynServices
     }
 
     protected override Task<TextSpan> GetSpanToReplaceByCompletionAsync(string text, int caret, CancellationToken cancellationToken)
-        => roslyn.GetSpanToReplaceByCompletionAsync(text, caret, cancellationToken);
+        => roslyn.IsInspectMode && TryGetInspectorCommandSpan(text, caret, out var commandSpan)
+            ? Task.FromResult(commandSpan)
+            : roslyn.GetSpanToReplaceByCompletionAsync(text, caret, cancellationToken);
 
     protected override Task<bool> ShouldOpenCompletionWindowAsync(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
-        => roslyn.ShouldOpenCompletionWindowAsync(text, caret, keyPress, cancellationToken);
+        => roslyn.IsInspectMode && TryGetInspectorCommandSpan(text, caret, out _)
+            ? Task.FromResult(true)
+            : roslyn.ShouldOpenCompletionWindowAsync(text, caret, keyPress, cancellationToken);
 
     protected override async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
     {
@@ -100,6 +105,14 @@ internal class CSharpReplPromptCallbacks(IConsoleService console, RoslynServices
     // Made internal for testing
     internal async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsCoreAsync(string text, int caret, CancellationToken cancellationToken = default)
     {
+        // In inspect mode, when the user is typing a #replace/#wrap/#patches/#revert command name, offer those
+        // commands (with help text) exclusively: the bad-directive line has no useful Roslyn completions, and #r
+        // file-path completion isn't meaningful in a remote session.
+        if (roslyn.IsInspectMode && TryGetInspectorCommandSpan(text, caret, out _))
+        {
+            return InspectorCommandCompletionItems.AllItems;
+        }
+
         var replKeywordCompletions = GetReplKeywordCompletions();
 
         var completions = await roslyn.CompleteAsync(text, caret, cancellationToken).ConfigureAwait(false);
@@ -391,6 +404,69 @@ internal class CSharpReplPromptCallbacks(IConsoleService console, RoslynServices
     private static FormattedString EntireWordFormatString(ReadEvalPrintLoop.Keywords.KeywordInfo keywordInfo)
     {
         return EntireWordFormatString(keywordInfo.Text, keywordInfo.Color);
+    }
+
+    /// <summary>
+    /// True when the caret is within a leading <c>#command-name</c> token (no space yet) — i.e. the user is typing
+    /// an inspect command such as <c>#replace</c>. <paramref name="span"/> covers the whole <c>#word</c> token so a
+    /// committed completion replaces it cleanly, including the leading <c>#</c> (which Roslyn's default word span
+    /// excludes). Returns false once a space is typed (that's the argument position, handled by the completion
+    /// provider) or for any non-command line.
+    /// </summary>
+    internal static bool TryGetInspectorCommandSpan(string text, int caret, out TextSpan span)
+    {
+        span = default;
+        if (caret < 0 || caret > text.Length)
+        {
+            return false;
+        }
+
+        var lineStart = caret;
+        while (lineStart > 0 && text[lineStart - 1] is not '\n' and not '\r')
+        {
+            lineStart--;
+        }
+
+        var hash = lineStart;
+        while (hash < caret && char.IsWhiteSpace(text[hash]))
+        {
+            hash++;
+        }
+
+        if (hash >= caret || text[hash] != '#')
+        {
+            return false;
+        }
+
+        // Everything between '#' and the caret must be the command name: letters only, no space.
+        for (var i = hash + 1; i < caret; i++)
+        {
+            if (!char.IsLetter(text[i]))
+            {
+                return false;
+            }
+        }
+
+        // Extend to the end of the word so committing replaces the entire token, not just up to the caret.
+        var end = caret;
+        while (end < text.Length && char.IsLetter(text[end]))
+        {
+            end++;
+        }
+
+        span = new TextSpan(hash, end - hash);
+        return true;
+    }
+
+    private static class InspectorCommandCompletionItems
+    {
+        // Built from the shared command registry; only the color/formatting is added here.
+        public static IReadOnlyList<CompletionItem> AllItems { get; } = [.. InspectorCommands.All.Select(ToCompletionItem)];
+
+        private static CompletionItem ToCompletionItem(InspectorCommandInfo info) => new(
+            info.Token,
+            displayText: EntireWordFormatString(info.Token, AnsiColor.BrightMagenta),
+            getExtendedDescription: _ => Task.FromResult(new FormattedString(info.Description)));
     }
 
     private static class ReplKeywordCompletionItems

--- a/CSharpRepl/Commands/CommandLine.cs
+++ b/CSharpRepl/Commands/CommandLine.cs
@@ -386,18 +386,22 @@ internal static class CommandLine
         {
             "cmd" => string.Join(NewLine,
                 ":: Run in the shell that launches your app, then start it and note its process id:",
+                ":: Do NOT set them as system-wide or user-wide environment variables; only set them in the shell.",
                 $@"set ""DOTNET_STARTUP_HOOKS={bootstrap}""",
                 $@"set ""ASPNETCORE_HOSTINGSTARTUPASSEMBLIES={HostingStartupAssembly}"""),
             "bash" or "sh" or "zsh" => string.Join(NewLine,
                 "# Run in the shell that launches your app, then start it and note its process id:",
+                "# Do NOT set them as system-wide or user-wide environment variables; only set them in the shell.",
                 $@"export DOTNET_STARTUP_HOOKS=""{bootstrap}""",
                 $@"export ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=""{HostingStartupAssembly}"""),
             "fish" => string.Join(NewLine,
                 "# Run in the shell that launches your app, then start it and note its process id:",
+                "# Do NOT set them as system-wide or user-wide environment variables; only set them in the shell.",
                 $@"set -gx DOTNET_STARTUP_HOOKS ""{bootstrap}""",
                 $@"set -gx ASPNETCORE_HOSTINGSTARTUPASSEMBLIES ""{HostingStartupAssembly}"""),
             _ => string.Join(NewLine, // pwsh / powershell (default on Windows)
                 "# Run in the shell that launches your app, then start it and note its process id:",
+                "# Do NOT set them as system-wide or user-wide environment variables; only set them in the shell.",
                 $@"$env:DOTNET_STARTUP_HOOKS = ""{bootstrap}""",
                 $@"$env:ASPNETCORE_HOSTINGSTARTUPASSEMBLIES = ""{HostingStartupAssembly}"""),
         };

--- a/CSharpRepl/Repls/RemoteReadEvalPrintLoop.cs
+++ b/CSharpRepl/Repls/RemoteReadEvalPrintLoop.cs
@@ -9,6 +9,7 @@ using CSharpRepl.InjectedHook.Contracts;
 using CSharpRepl.PrettyPromptConfig;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Remote;
+using CSharpRepl.Services.Remote.Commands;
 using CSharpRepl.Services.Roslyn;
 using CSharpRepl.Services.Roslyn.Formatting;
 using PrettyPrompt;
@@ -28,6 +29,7 @@ internal sealed class RemoteReadEvalPrintLoop
     private readonly RemoteSession session;
     private readonly RoslynServices roslyn;
     private readonly IPrompt prompt;
+    private readonly InspectorCommandProcessor commands;
 
     public RemoteReadEvalPrintLoop(IConsoleService console, RemoteSession session, RoslynServices roslyn, IPrompt prompt)
     {
@@ -35,6 +37,7 @@ internal sealed class RemoteReadEvalPrintLoop
         this.session = session;
         this.roslyn = roslyn;
         this.prompt = prompt;
+        this.commands = new InspectorCommandProcessor(session);
     }
 
     public async Task RunAsync(Configuration config)
@@ -62,6 +65,29 @@ internal sealed class RemoteReadEvalPrintLoop
             if (command == "clear") { console.Clear(); continue; }
             if (command is "help" or "#help" or "?") { PrintHelp(); continue; }
 
+            // Live method replacement commands (#replace / #wrap / #patches / #revert), handled before eval. The
+            // processor parses and runs them against the session; this loop renders the raw result. A lost
+            // connection here is reported but, unlike eval, does not end the session.
+            InspectorCommandResult? commandResult;
+            try
+            {
+                commandResult = await commands.TryExecuteAsync(commandText, response.CancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                continue;
+            }
+            catch (IOException ex)
+            {
+                console.WriteErrorLine($"Lost the connection to the target process: {ex.Message}");
+                continue;
+            }
+            if (commandResult is not null)
+            {
+                PrintCommandResult(commandResult);
+                continue;
+            }
+
             // Local key-binding callbacks (e.g. lowering/IL) still operate on the local Roslyn services; they're
             // advisory in remote mode but harmless, so surface their output the same way the local loop does.
             if (response is KeyPressCallbackResult callbackOutput)
@@ -70,9 +96,8 @@ internal sealed class RemoteReadEvalPrintLoop
                 continue;
             }
 
-            // Ctrl+C cancels the in-flight evaluation cooperatively: EvalAsync sends a cancel to the engine and
-            // still awaits the (cancelled or completed) result, so the channel stays in sync and the session
-            // survives — no longer tearing down the controller process. Cancellation is cooperative, so it can't
+            // Ctrl+C cancels the in-flight evaluation cooperatively: EvalAsync sends a cancel to the engine and still
+            // awaits the result, so the channel stays in sync and the session survives. Being cooperative, it can't
             // interrupt arbitrary running user code in the target (same limitation as the local REPL).
             var detailed = config.SubmitPromptDetailedKeys.Matches(response.SubmitKeyInfo);
             var level = detailed ? Level.FirstDetailed : Level.FirstSimple;
@@ -104,6 +129,49 @@ internal sealed class RemoteReadEvalPrintLoop
             }
 
             Print(result, level);
+        } // loop!
+    }
+
+    /// <summary>Renders a command result. All wording lives here; the processor only returns the raw responses.</summary>
+    private void PrintCommandResult(InspectorCommandResult result)
+    {
+        switch (result)
+        {
+            case InspectorCommandResult.UsageError usage:
+                console.WriteErrorLine($"Usage: {usage.Command.Usage}");
+                break;
+
+            case InspectorCommandResult.Replaced { Response: var response } replaced when response.Ok:
+                var arrow = replaced.Mode == PatchMode.Wrap ? "wrapped" : "patched";
+                console.WriteLine($"{arrow} {response.ResolvedMethod ?? replaced.Target}  ←  {replaced.Replacement}  (patch #{response.PatchId})");
+                break;
+
+            case InspectorCommandResult.Replaced replaced:
+                console.WriteErrorLine($"{(replaced.Mode == PatchMode.Wrap ? InspectorCommands.Wrap.Token : InspectorCommands.Replace.Token)} failed: {replaced.Response.Error}");
+                break;
+
+            case InspectorCommandResult.Listed { Response.Patches: { Count: 0 } }:
+                console.WriteLine("No active patches.");
+                break;
+
+            case InspectorCommandResult.Listed listed:
+                foreach (var patch in listed.Response.Patches)
+                {
+                    console.WriteLine($"  #{patch.Id}  [{patch.Mode}]  {patch.Method}  ←  {patch.Replacement}");
+                }
+                break;
+
+            case InspectorCommandResult.Reverted { All: true } reverted:
+                console.WriteLine($"reverted {reverted.Response.RevertedCount} patch(es).");
+                break;
+
+            case InspectorCommandResult.Reverted { Response.Ok: true } reverted:
+                console.WriteLine($"reverted patch #{reverted.RequestedId}.");
+                break;
+
+            case InspectorCommandResult.Reverted reverted:
+                console.WriteErrorLine(reverted.Response.Error ?? "revert failed.");
+                break;
         }
     }
 
@@ -134,9 +202,12 @@ internal sealed class RemoteReadEvalPrintLoop
         console.WriteLine($"Connected to {handshake.ProcessName} (pid {handshake.ProcessId})");
         console.WriteLine($"  Runtime:   {handshake.RuntimeVersion}");
         console.WriteLine($"  Inspector: v{handshake.InspectorVersion} (protocol v{handshake.ProtocolVersion})");
-        console.WriteLine(handshake.DiProviderCaptured
-            ? "  DI provider captured: yes — `services` and `Get<T>()` are available."
-            : "  DI provider captured: no — only statics and framework code are reachable.");
+        console.Write(new Markup(handshake.DiProviderCaptured
+            ? "  DI provider captured: yes, [green]services[/] and [green]Get<T>()[/] are available."
+            : "  DI provider captured: [red]no[/], only statics and framework code are reachable."
+            )
+        );
+        console.WriteLine();
 
         if (handshake.AssemblyAvailability == TargetAssemblyAvailability.FrameworkDependentSingleFile)
         {
@@ -156,7 +227,7 @@ internal sealed class RemoteReadEvalPrintLoop
 
         console.WriteLine(string.Empty);
         console.Write(new Markup(
-            "[yellow] Development/diagnostics tool: code you evaluate runs inside the target process with its full privileges. Never inspect a production process.[/]"));
+            "[yellow]Development/diagnostics tool: code you evaluate runs inside the target process with its full privileges. Never inspect a production process.[/]"));
         console.WriteLine();
         console.WriteLine("Type C# to evaluate it in the target. Type exit (or press Ctrl+D) to detach; the target keeps running and you can reconnect later.");
         console.WriteLine(string.Empty);
@@ -168,15 +239,33 @@ internal sealed class RemoteReadEvalPrintLoop
             """
             [underline]Inspect mode[/]
             Submissions are evaluated inside the target process and share a persistent state chain, so a
-            [green]var[/] or a declared method on one line is reusable on the next — exactly like the local REPL.
+            [green]var[/] or a declared method on one line is reusable on the next, exactly like the local REPL.
 
             Reachable state:
               - Statics: reference them by their fully-qualified name, e.g. [green]MyApp.Program.SomeStatic[/].
               - DI services (when captured): [green]services.GetRequiredService<T>()[/] or [green]Get<T>()[/].
 
+            Live method replacement (the target running app changes immediately, generics not supported):
+              1. Define a method in the REPL whose parameters match the target. Instance methods take the
+                 instance as the first parameter; a static method omits it. For example:
+                 [green]decimal Half(MyApp.OrderService svc, int qty, decimal unit) => qty * unit * 0.5m;[/]
+                 [green]#replace MyApp.OrderService.CalculatePrice with Half[/]
+              2. To wrap instead, give the method an [green]orig[/] delegate as its first parameter (then the
+                 instance, then the original parameters) and call it to invoke the original. For example:
+                 [green]decimal Logged(Func<MyApp.OrderService, int, decimal, decimal> orig, MyApp.OrderService svc, int qty, decimal unit)
+                 {
+                     var result = orig(svc, qty, unit);
+                     Console.WriteLine($"price = {result}");
+                     return result;
+                 }
+                 #wrap MyApp.OrderService.CalculatePrice with Logged[/].
+              3. [green]#patches[/] lists active patches; [green]#revert <id>[/] or [green]#revert all[/] undoes them.
+            Patches persist in the target after you detach until reverted (or the process exits).
+
             Commands:
               - [green]exit[/]: detach and quit the REPL; the target keeps running and you can reconnect later.
               - [green]clear[/]: clear the terminal.
+              - [green]#replace[/] / [green]#wrap[/] / [green]#patches[/] / [green]#revert[/]: live method replacement (above).
             """));
         console.WriteLine();
     }

--- a/InjectedHook/CSharpRepl.InjectedHook.Contracts/IInspectorEngine.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.Contracts/IInspectorEngine.cs
@@ -36,4 +36,16 @@ public interface IInspectorEngine
     /// - Single-file/in-memory assemblies are omitted.
     /// </summary>
     Task<IReadOnlyList<string>> GetReferencePathsAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Detours a live method in the target to a REPL-defined replacement (see <see cref="ReplaceRequest"/>).
+    /// Never throws for resolution/compile failures; those return as <c>Ok == false</c> with an Error.
+    /// </summary>
+    Task<ReplaceResponse> ReplaceMethodAsync(string targetMethod, string replacement, PatchMode mode, CancellationToken cancellationToken);
+
+    /// <summary>Lists the patches currently applied by this engine.</summary>
+    Task<PatchListResponse> ListPatchesAsync(CancellationToken cancellationToken);
+
+    /// <summary>Undoes a patch by id, or every patch when <paramref name="all"/> is true.</summary>
+    Task<RevertResponse> RevertAsync(int patchId, bool all, CancellationToken cancellationToken);
 }

--- a/InjectedHook/CSharpRepl.InjectedHook.Contracts/InspectorTransport.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.Contracts/InspectorTransport.cs
@@ -26,7 +26,8 @@ namespace CSharpRepl.InjectedHook.Contracts;
 /// </summary>
 public static class InspectorTransport
 {
-    public const int ProtocolVersion = 1;
+    // v2: added live method replacement (ReplaceRequest/PatchListRequest/RevertRequest).
+    public const int ProtocolVersion = 2;
 
     // The endpoint name embeds the target's process id. These are the single source of truth for that
     // convention: PipeName/SocketPath build it, and TryParseProcessId/EnumerateListeningProcessIds reverse it

--- a/InjectedHook/CSharpRepl.InjectedHook.Contracts/WireMessages.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.Contracts/WireMessages.cs
@@ -19,6 +19,12 @@ namespace CSharpRepl.InjectedHook.Contracts;
 [JsonDerivedType(typeof(ReferencesResponse), "references-response")]
 [JsonDerivedType(typeof(CancelMessage), "cancel")]
 [JsonDerivedType(typeof(DisconnectMessage), "disconnect")]
+[JsonDerivedType(typeof(ReplaceRequest), "replace-request")]
+[JsonDerivedType(typeof(ReplaceResponse), "replace-response")]
+[JsonDerivedType(typeof(PatchListRequest), "patch-list-request")]
+[JsonDerivedType(typeof(PatchListResponse), "patch-list-response")]
+[JsonDerivedType(typeof(RevertRequest), "revert-request")]
+[JsonDerivedType(typeof(RevertResponse), "revert-response")]
 public abstract class WireMessage
 {
 }
@@ -163,4 +169,91 @@ public enum ResultKind
 
     /// <summary>Compilation or execution failed (detail in EvalResponse.Exception).</summary>
     Exception,
+}
+
+// ---------------------------------------------------------------------------------------------------------
+// Live method replacement. The controller names a target method in the running app and supplies a
+// REPL-defined replacement (a delegate value, or a method/expression the engine can coerce to one); the engine
+// detours the live method to it via MonoMod.RuntimeDetour. Patches are reversible and tracked by id.
+// ---------------------------------------------------------------------------------------------------------
+
+/// <summary>How a replacement relates to the original method.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PatchMode>))]
+public enum PatchMode
+{
+    /// <summary>The replacement fully replaces the original (the original never runs).</summary>
+    Replace,
+
+    /// <summary>
+    /// The replacement wraps the original: its first parameter is an "orig" delegate (same signature as the
+    /// original, instance-first for instance methods) that the body may call to delegate to the original.
+    /// </summary>
+    Wrap,
+}
+
+/// <summary>Controller → engine: detour <see cref="TargetMethod"/> to <see cref="Replacement"/>.</summary>
+public sealed class ReplaceRequest : WireMessage
+{
+    /// <summary>Fully-qualified target, e.g. <c>MyApp.Ordering.OrderService.CalculatePrice</c>.</summary>
+    public string TargetMethod { get; init; } = "";
+
+    /// <summary>
+    /// A C# expression, evaluated against the engine's persisted state, that yields the replacement. Typically
+    /// the name of a delegate the user defined (e.g. <c>cheaper</c>) or an explicit cast of a method group
+    /// (<c>(Func&lt;...&gt;)MyMethod</c>). For instance methods the delegate takes the instance as its first
+    /// parameter; in Wrap mode an "orig" delegate precedes that.
+    /// </summary>
+    public string Replacement { get; init; } = "";
+
+    public PatchMode Mode { get; init; }
+}
+
+/// <summary>Engine → controller: the outcome of a <see cref="ReplaceRequest"/>.</summary>
+public sealed class ReplaceResponse : WireMessage
+{
+    public bool Ok { get; init; }
+
+    /// <summary>The id under which the patch is tracked (for #patches / #revert). Valid only when Ok.</summary>
+    public int PatchId { get; init; }
+
+    /// <summary>A friendly rendering of the resolved target method when Ok (e.g. for overload confirmation).</summary>
+    public string? ResolvedMethod { get; init; }
+
+    /// <summary>The failure reason when not Ok.</summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>Controller → engine: list the active patches.</summary>
+public sealed class PatchListRequest : WireMessage
+{
+}
+
+/// <summary>Engine → controller: the currently tracked patches.</summary>
+public sealed class PatchListResponse : WireMessage
+{
+    public IReadOnlyList<PatchInfo> Patches { get; init; } = [];
+}
+
+/// <summary>One tracked patch.</summary>
+public sealed class PatchInfo
+{
+    public int Id { get; init; }
+    public string Method { get; init; } = "";
+    public string Replacement { get; init; } = "";
+    public PatchMode Mode { get; init; }
+}
+
+/// <summary>Controller → engine: undo one patch (by id) or every patch.</summary>
+public sealed class RevertRequest : WireMessage
+{
+    public int PatchId { get; init; }
+    public bool All { get; init; }
+}
+
+/// <summary>Engine → controller: the outcome of a <see cref="RevertRequest"/>.</summary>
+public sealed class RevertResponse : WireMessage
+{
+    public bool Ok { get; init; }
+    public int RevertedCount { get; init; }
+    public string? Error { get; init; }
 }

--- a/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/CSharpRepl.InjectedHook.ScriptEngine.csproj
+++ b/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/CSharpRepl.InjectedHook.ScriptEngine.csproj
@@ -16,6 +16,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <!--
+      Live method replacement (#replace). Detours target methods to REPL-defined delegates. Loaded into the
+      isolated EngineALC; its closure (MonoMod.Core/Utils/Backports/ILHelpers) is staged with the engine and
+      resolved by EngineLoadContext. Detours redirect native code, so they cross the engine-ALC/target-ALC
+      boundary — the detour rewrites native code, not managed references.
+    -->
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/InspectorEngine.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/InspectorEngine.cs
@@ -54,11 +54,13 @@ public sealed class InspectorEngine : IInspectorEngine
     private const int MaxScalarTextLength = 10_000;
 
     private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly InspectorPatcher patcher = new();
     private InteractiveAssemblyLoader assemblyLoader = null!;
     private ScriptOptions scriptOptions = null!;
     private string[] referencePaths = [];
     private ScriptState<object>? state;
     private bool initialized;
+    private int castSalt; // monotonic suffix for the temporary delegate types emitted during method-group coercion
 
     public async Task<EvalResponse> EvalAsync(string code, bool detailed, CancellationToken cancellationToken)
     {
@@ -135,6 +137,145 @@ public sealed class InspectorEngine : IInspectorEngine
         }
     }
 
+    public async Task<ReplaceResponse> ReplaceMethodAsync(string targetMethod, string replacement, PatchMode mode, CancellationToken cancellationToken)
+    {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+
+            var candidates = patcher.ResolveCandidates(targetMethod, out var resolveError);
+            if (candidates.Count == 0)
+            {
+                return new ReplaceResponse { Ok = false, Error = resolveError ?? $"Could not resolve '{targetMethod}'." };
+            }
+
+            // Path 1: the replacement is already a delegate value (a Func/Action variable the user defined, or an
+            // explicit cast). Evaluate it once and disambiguate the overload from its signature.
+            var (del, evalError) = await EvalToDelegateAsync(replacement, cancellationToken).ConfigureAwait(false);
+            MethodInfo? target = null;
+            if (del is not null)
+            {
+                target = patcher.MatchOverload(candidates, del, mode);
+                if (target is null)
+                {
+                    return new ReplaceResponse
+                    {
+                        Ok = false,
+                        Error = $"The replacement's signature doesn't match any overload of '{targetMethod}' " +
+                                $"(for an instance method the delegate's first parameter must be the declaring type).",
+                    };
+                }
+            }
+            else
+            {
+                // Path 2: a bare method group can't be evaluated as a value. Coerce it per candidate by casting to
+                // the delegate type that candidate expects; the first that compiles selects the overload too. For
+                // ref/out/in targets the cast needs a delegate TYPE declaration (Func can't carry by-ref), which we
+                // prepend to the probe submission; the unique salt keeps the temporary type name collision-free.
+                foreach (var candidate in candidates)
+                {
+                    var cast = patcher.BuildCastDelegate(candidate, mode, ++castSalt);
+                    if (cast is null)
+                    {
+                        continue; // this candidate's shape isn't expressible (e.g. Wrap + by-ref, or a ref-return)
+                    }
+
+                    var (declaration, typeName) = cast.Value;
+                    var castExpression = $"{declaration}\n({typeName})({replacement})";
+                    var (coerced, _) = await EvalToDelegateAsync(castExpression, cancellationToken).ConfigureAwait(false);
+                    if (coerced is not null)
+                    {
+                        del = coerced;
+                        target = candidate;
+                        break;
+                    }
+                }
+
+                if (del is null || target is null)
+                {
+                    return new ReplaceResponse
+                    {
+                        Ok = false,
+                        Error = evalError ?? $"Could not turn '{replacement}' into a delegate compatible with '{targetMethod}'.",
+                    };
+                }
+            }
+
+            try
+            {
+                var id = patcher.Apply(target, del, replacement, mode);
+                return new ReplaceResponse { Ok = true, PatchId = id, ResolvedMethod = patcher.List().Single(p => p.Id == id).Method };
+            }
+            catch (Exception ex)
+            {
+                return new ReplaceResponse { Ok = false, Error = $"Detour failed: {ex.Message}" };
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task<PatchListResponse> ListPatchesAsync(CancellationToken cancellationToken)
+    {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return new PatchListResponse { Patches = patcher.List() };
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task<RevertResponse> RevertAsync(int patchId, bool all, CancellationToken cancellationToken)
+    {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (all)
+            {
+                return new RevertResponse { Ok = true, RevertedCount = patcher.RevertAll() };
+            }
+            return patcher.Revert(patchId)
+                ? new RevertResponse { Ok = true, RevertedCount = 1 }
+                : new RevertResponse { Ok = false, Error = $"No active patch with id {patchId}." };
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an expression against the current state to obtain a delegate, WITHOUT committing it to the
+    /// persisted chain (the probe state is discarded; the returned delegate keeps its submission alive). Returns
+    /// a null delegate plus a message on compile failure (e.g. a bare method group, which isn't a value).
+    /// </summary>
+    private async Task<(Delegate? Delegate, string? Error)> EvalToDelegateAsync(string expression, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var probe = state is null
+                ? await CSharpScript
+                    .Create(expression, scriptOptions, globalsType: typeof(InspectorGlobals), assemblyLoader: assemblyLoader)
+                    .RunAsync(globals: new InspectorGlobals(), cancellationToken).ConfigureAwait(false)
+                : await state.ContinueWithAsync(expression, scriptOptions, cancellationToken).ConfigureAwait(false);
+            return (probe.ReturnValue as Delegate, null);
+        }
+        catch (CompilationErrorException compileError)
+        {
+            return (null, string.Join("; ", compileError.Diagnostics.Select(d => d.ToString())));
+        }
+        catch (Exception ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
     private void EnsureInitialized()
     {
         if (initialized)
@@ -146,9 +287,9 @@ public sealed class InspectorEngine : IInspectorEngine
         var references = new List<MetadataReference>();
         var paths = new List<string>();
 
-        // Snapshot the target's live, loaded assemblies once (re-enumerating the default ALC each round would picksup accumulating submission
-        // assemblies). Late-loaded target assemblies/#r are best-effort refreshed later. By the time a controller connects, the target's Main
-        // is running, so its own assemblies are loaded and reachable here.
+        // Snapshot the target's live, loaded assemblies once; re-enumerating the default ALC each round would pick up
+        // the accumulating per-submission assemblies. By the time a controller connects the target's Main is running, so
+        // its own assemblies are loaded and reachable. (Late-loaded assemblies / #r are best-effort refreshed later.)
         foreach (var assembly in AssemblyLoadContext.Default.Assemblies)
         {
             if (assembly.IsDynamic)

--- a/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/InspectorPatcher.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/InspectorPatcher.cs
@@ -1,0 +1,317 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using CSharpRepl.InjectedHook.Contracts;
+using MonoMod.RuntimeDetour;
+
+namespace CSharpRepl.InjectedHook.ScriptEngine;
+
+/// <summary>
+/// Owns live method-replacement state for the engine: resolves a named target method in the running app,
+/// detours it to a REPL-produced delegate via MonoMod.RuntimeDetour, and tracks the resulting <see cref="Hook"/>
+/// so it can be listed and undone. Pure reflection + detour mechanics; the engine supplies the evaluated
+/// replacement delegate (it owns the script state). Not thread-safe on its own; the engine serializes calls
+/// under its eval gate.
+/// </summary>
+internal sealed class InspectorPatcher
+{
+    private sealed class Entry
+    {
+        public required int Id { get; init; }
+        public required Hook Hook { get; init; }
+        public required string Method { get; init; }
+        public required string Replacement { get; init; }
+        public required PatchMode Mode { get; init; }
+    }
+
+    private const BindingFlags MethodFlags =
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+    private readonly Dictionary<int, Entry> patches = new();
+    private int nextId;
+
+    /// <summary>
+    /// Splits "Namespace.Type.Method" and finds candidate overloads on the resolved type from the target's
+    /// loaded assemblies. Returns an empty list (and a reason) when the type or method can't be found.
+    /// </summary>
+    public IReadOnlyList<MethodInfo> ResolveCandidates(string targetMethod, out string? error)
+    {
+        error = null;
+        var lastDot = targetMethod.LastIndexOf('.');
+        if (lastDot <= 0 || lastDot == targetMethod.Length - 1)
+        {
+            error = $"'{targetMethod}' is not a fully-qualified Type.Method reference.";
+            return [];
+        }
+
+        var typeName = targetMethod[..lastDot];
+        var methodName = targetMethod[(lastDot + 1)..];
+
+        var type = FindType(typeName);
+        if (type is null)
+        {
+            error = $"Could not find type '{typeName}' among the target's loaded assemblies.";
+            return [];
+        }
+
+        // Skip open generic methods — each instantiation is a distinct native method, so there's nothing single to detour.
+        var candidates = type
+            .GetMethods(MethodFlags)
+            .Where(m => m.Name == methodName && !m.IsGenericMethodDefinition && !m.IsAbstract)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            error = $"Type '{typeName}' has no patchable method named '{methodName}'.";
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Picks the overload whose required replacement signature matches <paramref name="replacement"/>'s delegate
+    /// shape (instance-first for instance methods; an extra leading "orig" delegate in Wrap mode).
+    /// </summary>
+    public MethodInfo? MatchOverload(IReadOnlyList<MethodInfo> candidates, Delegate replacement, PatchMode mode)
+    {
+        var invoke = replacement.GetType().GetMethod("Invoke")!;
+        var actualParams = invoke.GetParameters().Select(p => p.ParameterType).ToArray();
+        var actualReturn = invoke.ReturnType;
+
+        return candidates.FirstOrDefault(m =>
+        {
+            try
+            {
+                var (expectedParams, expectedReturn) = ExpectedSignature(m, mode);
+                return expectedReturn == actualReturn && expectedParams.SequenceEqual(actualParams);
+            }
+            catch
+            {
+                // ExpectedSignature throws for shapes Func/Action can't model (e.g. Wrap + by-ref);
+                // such a candidate just isn't matchable on the delegate-value path.
+                return false;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Builds the cast that coerces a method group (a named replacement) to the delegate a candidate expects.
+    ///
+    /// - Replace: emits a delegate TYPE declaration, so by-ref (ref/out/in) parameters are expressible — Func/Action
+    ///   can't carry them. The engine prepends the declaration to the probe submission, then casts to its name.
+    /// - Wrap (no by-ref): reuses a Func/Action cast, so the user's `orig` parameter (a shared Func type) still
+    ///   matches what they wrote.
+    /// - Returns null when the shape isn't expressible (Wrap + by-ref, or a ref-return), so the caller reports a
+    ///   clean failure rather than emitting code that won't compile.
+    /// </summary>
+    public (string Declaration, string TypeName)? BuildCastDelegate(MethodInfo target, PatchMode mode, int salt)
+    {
+        if (target.ReturnType.IsByRef)
+        {
+            return null; // ref-returning methods aren't expressible as a Func/Action or a simple delegate parameter
+        }
+
+        if (mode == PatchMode.Wrap)
+        {
+            // Wrap needs a shared `orig` delegate type. Func works for by-value params; by-ref can't use Func and a
+            // generated nominal type wouldn't match the type the user named, so by-ref wrap is unsupported here.
+            if (target.GetParameters().Any(p => p.ParameterType.IsByRef))
+            {
+                return null;
+            }
+            var (paramTypes, returnType) = ExpectedSignature(target, mode);
+            return ("", DelegateTypeText(paramTypes, returnType));
+        }
+
+        // Replace: emit a delegate type so ref/out/in are expressible.
+        var name = $"__Repl_{salt}";
+        var declaration = $"delegate {CompilableReturnName(target.ReturnType)} {name}({BuildParameterList(target)});";
+        return (declaration, name);
+    }
+
+    /// <summary>The instance-first (for instance methods) parameter list for an emitted delegate, with ref/out/in modifiers.</summary>
+    private static string BuildParameterList(MethodInfo target)
+    {
+        var parts = target.GetParameters().Select((p, i) => $"{ParameterText(p)} __p{i}");
+        if (!target.IsStatic)
+        {
+            parts = parts.Prepend($"{CompilableTypeName(target.DeclaringType!)} __self");
+        }
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>A by-ref-aware parameter type rendering: <c>out X</c> / <c>ref X</c> / <c>in X</c>, or just <c>X</c>.</summary>
+    private static string ParameterText(ParameterInfo parameter)
+    {
+        // CompilableTypeName already strips IsByRef to the element type, so this works for both cases.
+        var type = CompilableTypeName(parameter.ParameterType);
+        if (!parameter.ParameterType.IsByRef)
+        {
+            return type;
+        }
+        var modifier = parameter.IsOut ? "out" : parameter.IsIn ? "in" : "ref";
+        return $"{modifier} {type}";
+    }
+
+    /// <summary>A delegate return type must use the <c>void</c> keyword, not <c>System.Void</c>.</summary>
+    private static string CompilableReturnName(Type returnType) =>
+        returnType == typeof(void) ? "void" : CompilableTypeName(returnType);
+
+    /// <summary>Applies the detour and records it, returning the patch id.</summary>
+    public int Apply(MethodInfo target, Delegate replacement, string replacementText, PatchMode mode)
+    {
+        var hook = new Hook(target, replacement);
+        var id = ++nextId;
+        patches[id] = new Entry
+        {
+            Id = id,
+            Hook = hook,
+            Method = DisplaySignature(target),
+            Replacement = replacementText,
+            Mode = mode,
+        };
+        return id;
+    }
+
+    public PatchInfo[] List() => patches.Values
+        .OrderBy(e => e.Id)
+        .Select(e => new PatchInfo { Id = e.Id, Method = e.Method, Replacement = e.Replacement, Mode = e.Mode })
+        .ToArray();
+
+    public bool Revert(int id)
+    {
+        if (!patches.Remove(id, out var entry))
+        {
+            return false;
+        }
+        entry.Hook.Dispose();
+        return true;
+    }
+
+    public int RevertAll()
+    {
+        var count = patches.Count;
+        foreach (var entry in patches.Values)
+        {
+            try { entry.Hook.Dispose(); } catch { /* best effort */ }
+        }
+        patches.Clear();
+        return count;
+    }
+
+    /// <summary>
+    /// The delegate signature a replacement must have for <paramref name="method"/>: the method's own parameters,
+    /// prefixed by the declaring type for an instance method, and (in Wrap mode) by an "orig" delegate of that
+    /// same shape so the replacement can call the original.
+    /// </summary>
+    private static (Type[] Parameters, Type ReturnType) ExpectedSignature(MethodInfo method, PatchMode mode)
+    {
+        var methodParams = method.GetParameters().Select(p => p.ParameterType);
+        Type[] baseParams = method.IsStatic ? [.. methodParams] : [method.DeclaringType!, .. methodParams];
+        var returnType = method.ReturnType;
+
+        if (mode == PatchMode.Replace)
+        {
+            return (baseParams, returnType);
+        }
+
+        // Wrap: the "orig" delegate has the original's (instance-first) signature.
+        var origDelegateType = Expression.GetDelegateType([.. baseParams, returnType]);
+        return ([origDelegateType, .. baseParams], returnType);
+    }
+
+    private static string DelegateTypeText(Type[] paramTypes, Type returnType)
+    {
+        if (returnType == typeof(void))
+        {
+            return paramTypes.Length == 0
+                ? "global::System.Action"
+                : $"global::System.Action<{string.Join(", ", paramTypes.Select(CompilableTypeName))}>";
+        }
+
+        var args = paramTypes.Append(returnType).Select(CompilableTypeName);
+        return $"global::System.Func<{string.Join(", ", args)}>";
+    }
+
+    /// <summary>A fully-qualified, compilable C# name for a type (handles generics, arrays, nested types).</summary>
+    private static string CompilableTypeName(Type type)
+    {
+        if (type.IsByRef)
+        {
+            // ref/out can't be expressed by Func/Action; surface as the element type so the cast fails clearly.
+            return CompilableTypeName(type.GetElementType()!);
+        }
+
+        if (type.IsArray)
+        {
+            return CompilableTypeName(type.GetElementType()!) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+        }
+
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            var name = StripArity("global::" + (definition.FullName ?? definition.Name));
+            var args = type.GetGenericArguments().Select(CompilableTypeName);
+            return $"{name.Replace('+', '.')}<{string.Join(", ", args)}>";
+        }
+
+        return "global::" + (type.FullName ?? type.Name).Replace('+', '.');
+    }
+
+    /// <summary>A readable rendering of a method for the patch list / confirmations.</summary>
+    private static string DisplaySignature(MethodInfo method)
+    {
+        var prefix = method.IsStatic ? "static " : "";
+        var declaring = method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "";
+        var parameters = string.Join(", ", method.GetParameters().Select(p => $"{ShortName(p.ParameterType)} {p.Name}"));
+        return $"{prefix}{ShortName(method.ReturnType)} {declaring}.{method.Name}({parameters})";
+    }
+
+    private static string ShortName(Type type)
+    {
+        if (type.IsGenericType)
+        {
+            var name = StripArity(type.Name);
+            return $"{name}<{string.Join(", ", type.GetGenericArguments().Select(ShortName))}>";
+        }
+        return type.Name;
+    }
+
+    /// <summary>Strips the CLR arity suffix (<c>`1</c>) from a generic type name.</summary>
+    private static string StripArity(string name)
+    {
+        var tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    private static Type? FindType(string fullName)
+    {
+        foreach (var assembly in AssemblyLoadContext.Default.Assemblies)
+        {
+            if (assembly.IsDynamic)
+            {
+                continue;
+            }
+            try
+            {
+                var type = assembly.GetType(fullName, throwOnError: false);
+                if (type is not null)
+                {
+                    return type;
+                }
+            }
+            catch
+            {
+                // Unreadable assembly metadata — skip and keep searching.
+            }
+        }
+        return Type.GetType(fullName, throwOnError: false);
+    }
+}

--- a/InjectedHook/CSharpRepl.InjectedHook/InspectorServer.cs
+++ b/InjectedHook/CSharpRepl.InjectedHook/InspectorServer.cs
@@ -30,7 +30,7 @@ internal static class InspectorServer
 
     public static void StartInBackground(IInspectorEngine engine)
     {
-        // use a background thread so the inspector loop never keeps the target alive. Don't use a task because we don't want to consume the target's thread pool with a long-running loop.
+        // Dedicated background thread, not a pool Task: the loop is long-lived, and IsBackground keeps it from holding the target alive.
         var thread = new Thread(() => RunLoop(engine))
         {
             IsBackground = true,
@@ -95,6 +95,21 @@ internal static class InspectorServer
                 case ReferencesRequest:
                     var references = await GetReferencePathsAsync(engine).ConfigureAwait(false);
                     await channel.WriteAsync(new ReferencesResponse { Paths = references }, CancellationToken.None).ConfigureAwait(false);
+                    message = await channel.ReadAsync(CancellationToken.None).ConfigureAwait(false);
+                    break;
+
+                case ReplaceRequest replace:
+                    await channel.WriteAsync(await ReplaceAsync(engine, replace).ConfigureAwait(false), CancellationToken.None).ConfigureAwait(false);
+                    message = await channel.ReadAsync(CancellationToken.None).ConfigureAwait(false);
+                    break;
+
+                case PatchListRequest:
+                    await channel.WriteAsync(await ListPatchesAsync(engine).ConfigureAwait(false), CancellationToken.None).ConfigureAwait(false);
+                    message = await channel.ReadAsync(CancellationToken.None).ConfigureAwait(false);
+                    break;
+
+                case RevertRequest revert:
+                    await channel.WriteAsync(await RevertAsync(engine, revert).ConfigureAwait(false), CancellationToken.None).ConfigureAwait(false);
                     message = await channel.ReadAsync(CancellationToken.None).ConfigureAwait(false);
                     break;
 
@@ -200,6 +215,43 @@ internal static class InspectorServer
         {
             // The controller degrades to a reference-less editor workspace if this fails; never tear down the session.
             return [];
+        }
+    }
+
+    private static async Task<ReplaceResponse> ReplaceAsync(IInspectorEngine engine, ReplaceRequest request)
+    {
+        try
+        {
+            return await engine.ReplaceMethodAsync(request.TargetMethod, request.Replacement, request.Mode, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            // The engine reports expected failures as Ok=false; this catches only unexpected engine faults.
+            return new ReplaceResponse { Ok = false, Error = exception.Message };
+        }
+    }
+
+    private static async Task<PatchListResponse> ListPatchesAsync(IInspectorEngine engine)
+    {
+        try
+        {
+            return await engine.ListPatchesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            return new PatchListResponse();
+        }
+    }
+
+    private static async Task<RevertResponse> RevertAsync(IInspectorEngine engine, RevertRequest request)
+    {
+        try
+        {
+            return await engine.RevertAsync(request.PatchId, request.All, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            return new RevertResponse { Ok = false, Error = exception.Message };
         }
     }
 

--- a/InjectedHook/InjectedHookReadme.md
+++ b/InjectedHook/InjectedHookReadme.md
@@ -11,7 +11,7 @@ Three projects under `InjectedHook/` are staged (together with their own private
 | Project | Loaded into | Role |
 |---|---|---|
 | `CSharpRepl.InjectedHook` | target's default AssemblyLoadContext | The bootstrap. `StartupHook.Initialize()` runs before the target's `Main` (via `DOTNET_STARTUP_HOOKS`), must never throw, and references no Roslyn. It installs an assembly-resolving handler, subscribes to the hosting `DiagnosticListener` to capture the root `IServiceProvider` (`HostCapture`), creates the isolated engine ALC (`EngineHost`), and runs the transport server (`InspectorServer`) on a background thread. |
-| `CSharpRepl.InjectedHook.ScriptEngine` | dedicated isolated ALC | The engine (`InspectorEngine`). Hosts `CSharpScript` and the persisted `ScriptState` submission chain. Its Roslyn lives entirely inside the isolated ALC, so it cannot collide with any Roslyn version the target itself uses. |
+| `CSharpRepl.InjectedHook.ScriptEngine` | dedicated isolated ALC | The engine (`InspectorEngine`). Hosts `CSharpScript` and the persisted `ScriptState` submission chain. Its Roslyn lives entirely inside the isolated ALC, so it cannot collide with any Roslyn version the target itself uses. Also hosts `InspectorPatcher`, which detours live target methods to REPL-defined delegates via `MonoMod.RuntimeDetour`. |
 | `CSharpRepl.InjectedHook.Contracts` | default ALC, shared into the isolated ALC | The boundary types: `IInspectorEngine`, `InspectorGlobals`/`InspectorRoots`, `RemoteValue`, the `WireMessage` hierarchy, and the transport/framing (`InspectorTransport`, `MessageChannel`). Loaded once and resolved to that same instance from the engine ALC, so these types are *type-identical* on both sides. References no Roslyn. |
 
 On first evaluation the engine snapshots the target's own loaded assemblies and builds its compilation references from them, so submissions compile against the target's real types and bind, at runtime, to the already-loaded live instances.
@@ -32,9 +32,19 @@ One duplex connection per session (named pipe on Windows, Unix domain socket els
 1. → connect; ← `HandshakeMessage` (pid, runtime, inspector/protocol version, DI-captured flag, assembly availability).
 2. → `ReferencesRequest`; ← `ReferencesResponse` (assembly paths for the controller's editor workspace).
 3. Per submission: → `EvalRequest { Code, Detailed }`; ← `EvalResponse { Kind, Value/Exception, Committed }`. A `CancelMessage` may be sent mid-flight (Ctrl+C); the controller still waits for the response so framing stays in lock-step.
-4. → `DisconnectMessage`; the target keeps running and the server loops to accept a future reconnect.
+4. Optional, any time after step 2: → `ReplaceRequest` / `PatchListRequest` / `RevertRequest`; ← the matching response (protocol v2, live method replacement).
+5. → `DisconnectMessage`; the target keeps running and the server loops to accept a future reconnect.
 
 Inbound data is treated as untrusted: frame lengths are bounded (64 MB) and malformed frames surface as catchable exceptions, never a crash of the target.
+
+## Live method replacement
+
+The controller can detour a live method in the target to a REPL-defined delegate. Commands, handled in `RemoteReadEvalPrintLoop`: `#replace`, `#wrap`, `#patches`, `#revert`.
+
+- Engine: `InspectorPatcher` (ScriptEngine project) over `MonoMod.RuntimeDetour`. It resolves the named target, matches the overload from the replacement delegate's signature, coerces a bare method group via a generated cast (an emitted delegate type when the target has `ref`/`out`/`in` parameters, which `Func` can't express), applies a `Hook`, and tracks it by id for revert.
+- Replacement shape: the delegate matches the target's parameters. Instance methods take the instance as the first parameter. `#wrap` prepends an `orig` delegate the body can call to invoke the original.
+- Cross-ALC: detours repoint native code, so the replacement (compiled in the engine ALC) patches a method that lives in the target's default ALC.
+- Lifecycle: patches persist in the target until reverted with `#revert` (or the process exits), so they survive a controller detach.
 
 ## What doesn't work
 
@@ -42,3 +52,5 @@ Inbound data is treated as untrusted: frame lengths are bounded (64 MB) and malf
 - Framework-dependent single-file targets: framework types work, but the app's *own* assemblies have no on-disk metadata, so typed access to its types fails to compile (CS0103). You can still reach its state via reflection (`Type.GetType("MyApp.Program, MyApp")`). The banner warns about this mode.
 - Ctrl+C is cooperative: it cancels at points Roslyn observes (same as the local REPL). It cannot interrupt arbitrary running code — a submission stuck in a tight loop inside the target cannot be aborted (see "Known limitations").
 - `#r` (NuGet/assembly references) inside a remote session is not supported.
+- `#replace` supports `ref`/`out`/`in` parameters (via an emitted delegate type). Not supported: generic methods, pointer parameters, and `#wrap` on a method with by-ref parameters.
+- A method already inlined by the JIT at a call site keeps its old behavior at that site.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ C# REPL provides the following features:
 - Nuget package installation
 - Reference local assemblies, solutions, and projects
 - Dump and explore objects with syntax highlighting and rich Spectre.Console formatting
-- Inspect a running .NET application and run the REPL inside that application, with access to application state
+- Inspect a running .NET application and run the REPL inside that application, with access to application state and the ability to replace live methods
 - Navigate to source via Source Link
 - IL disassembly and "lowered" C# decompilation (both Debug and Release mode, using ILSpy)
 - OpenAI integration (bring your own API key)
@@ -156,6 +156,16 @@ This will start the REPL in the target application. Some things you can try:
 - Statics: reference them by their fully-qualified name, e.g. `MyApp.Program.SomeStatic` (read and write).
 - DI services (ASP.NET Core or Generic Host apps): `services.GetRequiredService<T>()` or the shorthand `Get<T>()`. The inspector captures the application's root service provider via .NET's hosting hooks.
 
+You can also replace live methods in the target. Define a delegate, then patch a method with it:
+
+- Define a delegate matching the target. Instance methods take the instance as the first parameter:
+	- `Func<MyApp.OrderService, int, decimal, decimal> half = (svc, qty, unit) => qty * unit * 0.5m;`
+- `#replace MyApp.OrderService.CalculatePrice with half`: supplant the original.
+- `#wrap MyApp.OrderService.CalculatePrice with logged`: wrap it. The replacement's first parameter is an `orig` delegate that calls the original.
+- `#patches`: list active patches. `#revert <id>` or `#revert all`: undo them.
+
+Patches take effect immediately and persist in the target until reverted or the process exits.
+
 Type `exit` (or press <kbd>Ctrl+D</kbd>) to detach. The target application will keep running, and you can reconnect to it later.
 
 **Requirements and limitations:**
@@ -164,6 +174,7 @@ Type `exit` (or press <kbd>Ctrl+D</kbd>) to detach. The target application will 
 - Apps published as single-files have very limited functionality:
 	- A framework-dependent single-file app's assemblies are bundled with no metadata, so strongly-typed access to the app's own types is unavailable. You need to use reflection to access the app's types.
   - A self-contained single-file app is unsupported (even the runtime is bundled, so nothing can be compiled). The inspector will refuse to start.
+- Method replacement supports `ref`/`out`/`in` parameters with `#replace` (define a matching named method). Not supported: generic methods, pointer parameters, `#wrap` on a method with by-ref parameters, and a method the JIT already inlined at a call site (which keeps its old behavior there).
 
 See the [Injected Hook documentation](https://github.com/waf/CSharpRepl/blob/main/InjectedHook/InjectedHookReadme.md) for information on how this works under the hood.
 

--- a/Tests/CSharpRepl.Tests/CompletionTests.cs
+++ b/Tests/CSharpRepl.Tests/CompletionTests.cs
@@ -46,6 +46,44 @@ public class CompletionTests : IAsyncLifetime, IClassFixture<RoslynServicesFixtu
     }
 
     [Fact]
+    public async Task Complete_ReplaceCommand_IsInspectModeOnly()
+    {
+        // #replace is an inspect-mode command. Its completion provider is registered only in the remote
+        // workspace, so a #replace line in the local REPL yields no type/member completions.
+        const string text = "#replace System.Console.";
+        var completions = await this.services.CompleteAsync(text, text.Length, TestContext.Current.CancellationToken);
+        Assert.DoesNotContain("WriteLine", completions.Select(c => c.Item.DisplayText));
+    }
+
+    [Fact]
+    public async Task Complete_InspectCommandNames_AreInspectModeOnly()
+    {
+        // The local REPL isn't inspect mode, so #replace/#wrap/etc. aren't offered as command-name completions.
+        var completions = await promptCallbacks.GetCompletionItemsCoreAsync("#re", 3, TestContext.Current.CancellationToken);
+        Assert.DoesNotContain(completions, c => c.DisplayText == "#replace");
+    }
+
+    [Theory]
+    [InlineData("#re", 3, 0, 3)]
+    [InlineData("  #rep", 6, 2, 4)]
+    [InlineData("#replace", 8, 0, 8)]
+    public void InspectorCommandSpan_CoversTheHashToken(string text, int caret, int expectedStart, int expectedLength)
+    {
+        Assert.True(CSharpReplPromptCallbacks.TryGetInspectorCommandSpan(text, caret, out var span));
+        Assert.Equal(expectedStart, span.Start);
+        Assert.Equal(expectedLength, span.Length);
+    }
+
+    [Theory]
+    [InlineData("#replace Foo.", 13)] // a space → argument position, handled by the completion provider, not the command list
+    [InlineData("hello", 5)]          // no leading '#'
+    [InlineData("   ", 3)]            // whitespace only
+    public void InspectorCommandSpan_RejectsNonCommandLines(string text, int caret)
+    {
+        Assert.False(CSharpReplPromptCallbacks.TryGetInspectorCommandSpan(text, caret, out _));
+    }
+
+    [Fact]
     public async Task Complete_GivenLinq_ReturnsCompletions()
     {
         // LINQ tends to be a good canary for whether or not our reference / implementation assemblies are correct.

--- a/Tests/CSharpRepl.Tests/Data/CSharpRepl.InjectedHook.TestTarget/Program.cs
+++ b/Tests/CSharpRepl.Tests/Data/CSharpRepl.InjectedHook.TestTarget/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -55,4 +56,9 @@ public sealed class Service
     public int Value { get; set; } = 41;
 
     public int Next() => ++Value;
+
+    // A patchable method for the live method-replacement end-to-end test. NoInlining so a fresh REPL submission
+    // calling it goes through a real call site the detour can repoint (an inlined copy wouldn't see the patch).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Compute(int input) => input * 2;
 }

--- a/Tests/CSharpRepl.Tests/InspectorEngineTests.cs
+++ b/Tests/CSharpRepl.Tests/InspectorEngineTests.cs
@@ -342,6 +342,112 @@ public class InspectorEngineTests : IClassFixture<InspectorEngineTests.EngineFix
     }
 
     [Fact]
+    public async Task ReplaceMethod_CoercesOverloadedMethodGroups_ViaGeneratedDelegateCast()
+    {
+        // A *single* named method has a natural delegate type (C# 10+), so it evaluates as a value and takes the
+        // delegate-value path. An *overloaded* method group has no natural type, so it can only be coerced by
+        // casting it to the delegate each candidate expects — the engine's method-group path, which builds the
+        // cast (InspectorPatcher.BuildCastDelegate / BuildParameterList / ParameterText / DelegateTypeText).
+        var ct = TestContext.Current.CancellationToken;
+        try
+        {
+            // Static, by value → Replace-mode cast emits a delegate TYPE, BuildParameterList renders a static
+            // (no instance) parameter list.
+            Assert.True((await EvalAsync("int Septuple(int v) => v * 7; int Septuple(int v, int w) => v + w;")).Committed);
+            var staticReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "Septuple", PatchMode.Replace, ct);
+            Assert.True(staticReplace.Ok, staticReplace.Error);
+            Assert.Equal(35, EngineTestProbe.Triple(5)); // 5 * 7
+
+            // Instance, by value → BuildParameterList prepends the declaring type as the first (__self) parameter.
+            var sample = new PatchSample { Factor = 10 };
+            Assert.True((await EvalAsync(
+                "int ScaleC(CSharpRepl.Tests.PatchSample self, int v) => v * self.Factor + 2; int ScaleC(CSharpRepl.Tests.PatchSample self, int v, int w) => 0;")).Committed);
+            var instanceReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.PatchSample.Scale", "ScaleC", PatchMode.Replace, ct);
+            Assert.True(instanceReplace.Ok, instanceReplace.Error);
+            Assert.Equal(52, sample.Scale(5)); // 5 * 10 + 2
+
+            // out parameter → ParameterText renders the "out" modifier on the emitted delegate type.
+            Assert.True((await EvalAsync(
+                "bool TryC(int input, out int result) { result = 777; return false; } bool TryC(int input, out int result, int extra) { result = 0; return false; }")).Committed);
+            var outReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.TryDouble", "TryC", PatchMode.Replace, ct);
+            Assert.True(outReplace.Ok, outReplace.Error);
+            Assert.False(RefProbe.TryDouble(5, out var outValue));
+            Assert.Equal(777, outValue);
+
+            // ref parameter → ParameterText renders the "ref" modifier.
+            Assert.True((await EvalAsync(
+                "void BumpC(ref int value) { value += 100; } void BumpC(ref int value, int extra) { }")).Committed);
+            var refReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.Bump", "BumpC", PatchMode.Replace, ct);
+            Assert.True(refReplace.Ok, refReplace.Error);
+            var bumped = 1;
+            RefProbe.Bump(ref bumped);
+            Assert.Equal(101, bumped); // += 100 instead of += 1
+        }
+        finally
+        {
+            await engine.RevertAsync(0, all: true, ct);
+        }
+    }
+
+    [Fact]
+    public async Task ReplaceMethod_OverloadedMethodGroups_WrapAndRejectUnsupportedShapes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        try
+        {
+            // Wrap with an overloaded (non-value) method group → the cast builds the shared "orig" delegate
+            // type (DelegateTypeText): a Func for a value-returning target...
+            Assert.True((await EvalAsync(
+                "int WrapC(System.Func<int, int> orig, int v) => orig(v) + 5; int WrapC(System.Func<int, int> orig, int v, int w) => 0;")).Committed);
+            var wrapFunc = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "WrapC", PatchMode.Wrap, ct);
+            Assert.True(wrapFunc.Ok, wrapFunc.Error);
+            Assert.Equal(20, EngineTestProbe.Triple(5)); // original 15, + 5
+            await engine.RevertAsync(wrapFunc.PatchId, all: false, ct);
+
+            // ...and an Action for a void target.
+            Assert.True((await EvalAsync(
+                "void PokeC(System.Action<int> orig, int n) => orig(n + 1000); void PokeC(System.Action<int> orig, int n, int x) { }")).Committed);
+            var wrapAction = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.CoercionProbe.Poke", "PokeC", PatchMode.Wrap, ct);
+            Assert.True(wrapAction.Ok, wrapAction.Error);
+            CoercionProbe.Poke(9);
+            Assert.Equal(1009, CoercionProbe.LastPoke); // wrapper added 1000 before calling the original
+            await engine.RevertAsync(wrapAction.PatchId, all: false, ct);
+
+            // Array and generic parameter types render through the cast's compilable type-name builder.
+            Assert.True((await EvalAsync(
+                "int MixedC(int[] xs, System.Collections.Generic.List<int> ys) => 42; int MixedC(int[] xs, System.Collections.Generic.List<int> ys, int z) => 0;")).Committed);
+            var mixed = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.CoercionProbe.Mixed", "MixedC", PatchMode.Replace, ct);
+            Assert.True(mixed.Ok, mixed.Error);
+            Assert.Equal(42, CoercionProbe.Mixed([1, 2], [3]));
+            await engine.RevertAsync(mixed.PatchId, all: false, ct);
+
+            // Shapes the cast can't express are declined cleanly (it returns null, so no overload matches and the
+            // engine reports a failure instead of throwing): a by-ref return can't be a delegate...
+            Assert.True((await EvalAsync("int AnyC(int a) => a; int AnyC(int a, int b) => a + b;")).Committed);
+            var byRefReturn = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.CoercionProbe.RefReturn", "AnyC", PatchMode.Replace, ct);
+            Assert.False(byRefReturn.Ok);
+
+            // ...and a wrap over a by-ref parameter can't share a Func/Action "orig" type.
+            Assert.True((await EvalAsync("void WrapRefC(int a) { } void WrapRefC(int a, int b) { }")).Committed);
+            var wrapByRef = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.Bump", "WrapRefC", PatchMode.Wrap, ct);
+            Assert.False(wrapByRef.Ok);
+        }
+        finally
+        {
+            await engine.RevertAsync(0, all: true, ct);
+        }
+    }
+
+    [Fact]
     public async Task GetReferencePaths_ReportsTheHostProcessesLoadedAssemblies()
     {
         var paths = await engine.GetReferencePathsAsync(TestContext.Current.CancellationToken);
@@ -397,4 +503,23 @@ public sealed class RefSample
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public bool TryScale(int input, out int result) { result = input * Factor; return true; }
+}
+
+/// <summary>
+/// Targets for the method-group coercion path: array/generic parameter rendering, a void target (so a wrap
+/// produces an Action orig delegate), and a by-ref return (a shape the cast can't express).
+/// </summary>
+public static class CoercionProbe
+{
+    public static int LastPoke;
+    private static int refCell = 7;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Mixed(int[] xs, System.Collections.Generic.List<int> ys) => xs.Length + ys.Count;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Poke(int n) => LastPoke = n;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ref int RefReturn() => ref refCell;
 }

--- a/Tests/CSharpRepl.Tests/InspectorEngineTests.cs
+++ b/Tests/CSharpRepl.Tests/InspectorEngineTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using CSharpRepl.InjectedHook.Contracts;
 using CSharpRepl.InjectedHook.ScriptEngine;
@@ -210,6 +211,137 @@ public class InspectorEngineTests : IClassFixture<InspectorEngineTests.EngineFix
     }
 
     [Fact]
+    public async Task ReplaceMethod_DetoursLiveMethods_AndRevertsThem()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        try
+        {
+            // 1. Static method, replaced via a delegate value the user defined in the REPL.
+            Assert.Equal(15, EngineTestProbe.Triple(5)); // original behavior
+            Assert.True((await EvalAsync("System.Func<int, int> tripler100 = x => x * 100;")).Committed);
+            var staticReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "tripler100", PatchMode.Replace, ct);
+            Assert.True(staticReplace.Ok, staticReplace.Error);
+            Assert.Equal(500, EngineTestProbe.Triple(5)); // now detoured to the REPL delegate
+
+            // 2. Instance method, whose replacement reads live instance state (self.Factor).
+            var sample = new PatchSample { Factor = 10 };
+            Assert.Equal(50, sample.Scale(5)); // original: value * Factor
+            Assert.True((await EvalAsync(
+                "System.Func<CSharpRepl.Tests.PatchSample, int, int> scaler = (self, v) => v * self.Factor + 1;")).Committed);
+            var instanceReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.PatchSample.Scale", "scaler", PatchMode.Replace, ct);
+            Assert.True(instanceReplace.Ok, instanceReplace.Error);
+            Assert.Equal(51, sample.Scale(5)); // detoured: 5 * 10 + 1
+
+            // 3. Both patches are tracked.
+            var list = await engine.ListPatchesAsync(ct);
+            Assert.Equal(2, list.Patches.Count);
+
+            // 4. Restoring one returns its original behavior; the other stays patched.
+            Assert.True((await engine.RevertAsync(staticReplace.PatchId, all: false, ct)).Ok);
+            Assert.Equal(15, EngineTestProbe.Triple(5));
+            Assert.Equal(51, sample.Scale(5));
+
+            // 5. A bare named method (a method group, not a value) is coerced via the generated delegate cast.
+            Assert.True((await EvalAsync("int Quad(int v) => v * 4;")).Committed);
+            var namedReplace = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "Quad", PatchMode.Replace, ct);
+            Assert.True(namedReplace.Ok, namedReplace.Error);
+            Assert.Equal(20, EngineTestProbe.Triple(5));
+            await engine.RevertAsync(namedReplace.PatchId, all: false, ct);
+
+            // 6. Wrap mode: the replacement calls the original through the leading "orig" delegate.
+            Assert.True((await EvalAsync(
+                "System.Func<System.Func<int, int>, int, int> plusOne = (orig, v) => orig(v) + 1;")).Committed);
+            var wrap = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "plusOne", PatchMode.Wrap, ct);
+            Assert.True(wrap.Ok, wrap.Error);
+            Assert.Equal(16, EngineTestProbe.Triple(5)); // original 15, + 1
+
+            // 7. A signature that matches no overload is reported, not thrown.
+            Assert.True((await EvalAsync("System.Func<string, string> wrongSig = s => s;")).Committed);
+            var mismatch = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.Triple", "wrongSig", PatchMode.Replace, ct);
+            Assert.False(mismatch.Ok);
+            Assert.NotNull(mismatch.Error);
+
+            // An unknown target is also a clean failure.
+            var unknown = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.EngineTestProbe.NoSuchMethod", "tripler100", PatchMode.Replace, ct);
+            Assert.False(unknown.Ok);
+        }
+        finally
+        {
+            // Detours are process-global, so never leak one into another test in this process.
+            await engine.RevertAsync(0, all: true, ct);
+        }
+
+        Assert.Empty((await engine.ListPatchesAsync(ct)).Patches);
+        Assert.Equal(15, EngineTestProbe.Triple(5)); // fully reverted
+    }
+
+    [Fact]
+    public async Task ReplaceMethod_SupportsRefAndOutParameters_ViaNamedMethods()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        try
+        {
+            // out, static — defined as a named method (the realistic UX, which Func can't express).
+            Assert.True(RefProbe.TryDouble(5, out var d0));
+            Assert.Equal(10, d0);
+            Assert.True((await EvalAsync(
+                "bool MyTryDouble(int input, out int result) { result = 999; return false; }")).Committed);
+            var outStatic = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.TryDouble", "MyTryDouble", PatchMode.Replace, ct);
+            Assert.True(outStatic.Ok, outStatic.Error);
+            Assert.False(RefProbe.TryDouble(5, out var d1)); // detoured: returns false, out = 999
+            Assert.Equal(999, d1);
+
+            // ref, static.
+            Assert.True((await EvalAsync("void MyBump(ref int value) { value += 100; }")).Committed);
+            var refStatic = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.Bump", "MyBump", PatchMode.Replace, ct);
+            Assert.True(refStatic.Ok, refStatic.Error);
+            var bumped = 1;
+            RefProbe.Bump(ref bumped);
+            Assert.Equal(101, bumped); // detoured: += 100 instead of += 1
+
+            // out, instance — the replacement reads live instance state (self.Factor).
+            var sample = new RefSample { Factor = 10 };
+            Assert.True(sample.TryScale(5, out var s0));
+            Assert.Equal(50, s0);
+            Assert.True((await EvalAsync(
+                "bool MyTryScale(CSharpRepl.Tests.RefSample self, int input, out int result) { result = input * self.Factor + 1; return false; }")).Committed);
+            var outInstance = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefSample.TryScale", "MyTryScale", PatchMode.Replace, ct);
+            Assert.True(outInstance.Ok, outInstance.Error);
+            Assert.False(sample.TryScale(5, out var s1)); // detoured: 5 * 10 + 1
+            Assert.Equal(51, s1);
+
+            // A generic-method target is still excluded cleanly (out of scope, no crash).
+            Assert.True((await EvalAsync("int Identity(int v) => v;")).Committed);
+            var generic = await engine.ReplaceMethodAsync(
+                "CSharpRepl.Tests.RefProbe.Echo", "Identity", PatchMode.Replace, ct);
+            Assert.False(generic.Ok);
+
+            // Revert everything; the originals come back, by-ref behavior included.
+            await engine.RevertAsync(0, all: true, ct);
+            Assert.True(RefProbe.TryDouble(5, out var d2));
+            Assert.Equal(10, d2);
+            var bumped2 = 1;
+            RefProbe.Bump(ref bumped2);
+            Assert.Equal(2, bumped2);
+            Assert.True(sample.TryScale(5, out var s2));
+            Assert.Equal(50, s2);
+        }
+        finally
+        {
+            await engine.RevertAsync(0, all: true, ct);
+        }
+    }
+
+    [Fact]
     public async Task GetReferencePaths_ReportsTheHostProcessesLoadedAssemblies()
     {
         var paths = await engine.GetReferencePathsAsync(TestContext.Current.CancellationToken);
@@ -229,4 +361,40 @@ public static class EngineTestProbe
 {
     public static int WriteProbe;
     public static readonly int[] Numbers = [1, 2, 3];
+
+    // A patchable static method for the method-replacement tests. NoInlining so the JIT keeps a real call site
+    // for the detour to repoint (an inlined copy wouldn't see the patch).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Triple(int value) => value * 3;
+}
+
+/// <summary>An instance type with patchable behavior that depends on live instance state.</summary>
+public sealed class PatchSample
+{
+    public int Factor = 10;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Scale(int value) => value * Factor;
+}
+
+/// <summary>Static targets with by-ref parameters (out/ref) plus a generic method (excluded from patching).</summary>
+public static class RefProbe
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool TryDouble(int input, out int result) { result = input * 2; return true; }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Bump(ref int value) => value += 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static T Echo<T>(T value) => value;
+}
+
+/// <summary>An instance type with an out-parameter method that reads live instance state.</summary>
+public sealed class RefSample
+{
+    public int Factor = 10;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TryScale(int input, out int result) { result = input * Factor; return true; }
 }

--- a/Tests/CSharpRepl.Tests/RemoteEditorServicesTests.cs
+++ b/Tests/CSharpRepl.Tests/RemoteEditorServicesTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpRepl.InjectedHook.Contracts;
+using CSharpRepl.PrettyPromptConfig;
 using CSharpRepl.Services;
 using CSharpRepl.Services.Remote;
 using CSharpRepl.Services.Roslyn;
@@ -67,6 +68,38 @@ public class RemoteEditorServicesTests
             var memberCompletions = await CompletionDisplayTextsAsync(services, "s.");
             Assert.Contains("Value", memberCompletions); // Service.Value
             Assert.Contains("Next", memberCompletions);  // Service.Next()
+
+            // --- #replace completion: the target's types complete in the type-path segment ---
+            var replaceTypes = await CompletionDisplayTextsAsync(services, $"#replace {TargetNamespace}.");
+            Assert.Contains("Service", replaceTypes);
+            Assert.Contains("Program", replaceTypes);
+
+            // --- #replace completion: a type's INSTANCE members complete (nameof rewrite, not static-only) ---
+            var replaceMembers = await CompletionDisplayTextsAsync(services, $"#replace {TargetNamespace}.Service.");
+            Assert.Contains("Compute", replaceMembers); // instance method
+            Assert.Contains("Next", replaceMembers);    // instance method
+
+            // --- The span committed for a #replace target is the identifier under the caret, not the whole line ---
+            var partial = $"#replace {TargetNamespace}.Servi";
+            var span = await services.GetSpanToReplaceByCompletionAsync(partial, partial.Length, TestContext.Current.CancellationToken);
+            Assert.Equal("Servi", partial.Substring(span.Start, span.Length));
+
+            // --- The replacement-expression position completes ordinary script code against the chain (s.) ---
+            var replaceExpr = await CompletionDisplayTextsAsync(services, $"#replace {TargetNamespace}.Service.Compute with s.");
+            Assert.Contains("Value", replaceExpr);
+            Assert.Contains("Compute", replaceExpr);
+
+            // --- The inspect commands themselves complete (with help text), via the prompt callbacks ---
+            var promptCallbacks = new CSharpReplPromptCallbacks(console, services, new Configuration(theme: "Data/theme.json"));
+            var commandItems = await promptCallbacks.GetCompletionItemsCoreAsync("#re", 3, TestContext.Current.CancellationToken);
+            var commandTexts = commandItems.Select(c => c.ReplacementText).ToList();
+            Assert.Contains("#replace", commandTexts);
+            Assert.Contains("#wrap", commandTexts);
+            Assert.Contains("#patches", commandTexts);
+            Assert.Contains("#revert", commandTexts);
+            var replaceDescription = await commandItems.First(c => c.ReplacementText == "#replace")
+                .GetExtendedDescriptionAsync(TestContext.Current.CancellationToken);
+            Assert.Contains("Replace a live method", replaceDescription.Text);
 
             // --- Semantic highlighting resolves the target type as a class (not an unresolved identifier) ---
             var classNameColor = services.ToColor(ClassificationTypeNames.ClassName);

--- a/Tests/CSharpRepl.Tests/RemoteEditorServicesTests.cs
+++ b/Tests/CSharpRepl.Tests/RemoteEditorServicesTests.cs
@@ -14,6 +14,8 @@ using CSharpRepl.Services.Remote;
 using CSharpRepl.Services.Roslyn;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
+using PrettyPrompt;
+using PrettyPrompt.Consoles;
 using Xunit;
 
 namespace CSharpRepl.Tests;
@@ -88,6 +90,28 @@ public class RemoteEditorServicesTests
             var replaceExpr = await CompletionDisplayTextsAsync(services, $"#replace {TargetNamespace}.Service.Compute with s.");
             Assert.Contains("Value", replaceExpr);
             Assert.Contains("Compute", replaceExpr);
+
+            // --- Typing into a #replace argument opens the completion window (ReplaceMethodCompletionProvider
+            //     .ShouldTriggerCompletion): built-in providers don't engage on the bad-directive line, so ours does ---
+            var dotKey = new KeyPress(new ConsoleKeyInfo('.', ConsoleKey.OemPeriod, shift: false, alt: false, control: false));
+            var afterDot = $"#replace {TargetNamespace}.Service.";
+            Assert.True(await services.ShouldOpenCompletionWindowAsync(afterDot, afterDot.Length, dotKey, TestContext.Current.CancellationToken));
+
+            var letterKey = new KeyPress(new ConsoleKeyInfo('i', ConsoleKey.I, shift: false, alt: false, control: false));
+            var afterLetter = $"#replace {TargetNamespace}.Servi";
+            Assert.True(await services.ShouldOpenCompletionWindowAsync(afterLetter, afterLetter.Length, letterKey, TestContext.Current.CancellationToken));
+
+            // A non-command line: the inspect provider declines (TryRewrite false), leaving the decision to others.
+            var ordinaryLine = $"{TargetNamespace}.Servi";
+            await services.ShouldOpenCompletionWindowAsync(ordinaryLine, ordinaryLine.Length, letterKey, TestContext.Current.CancellationToken);
+
+            // --- A #replace member completion produces a tooltip (ReplaceMethodCompletionProvider.GetDescriptionAsync,
+            //     which rebuilds the synthetic document and forwards to the real member's description) ---
+            var describeLine = $"#replace {TargetNamespace}.Service.";
+            var memberItems = await services.CompleteAsync(describeLine, describeLine.Length, TestContext.Current.CancellationToken);
+            var computeItem = memberItems.First(c => c.Item.DisplayText == "Compute");
+            var description = await computeItem.GetDescriptionAsync(TestContext.Current.CancellationToken);
+            Assert.Contains("Compute", description.Text);
 
             // --- The inspect commands themselves complete (with help text), via the prompt callbacks ---
             var promptCallbacks = new CSharpReplPromptCallbacks(console, services, new Configuration(theme: "Data/theme.json"));

--- a/Tests/CSharpRepl.Tests/RemoteReadEvalPrintLoopTests.cs
+++ b/Tests/CSharpRepl.Tests/RemoteReadEvalPrintLoopTests.cs
@@ -27,6 +27,7 @@ namespace CSharpRepl.Tests;
 public class RemoteReadEvalPrintLoopTests
 {
     private const string TargetType = "CSharpRepl.InjectedHook.TestTarget.Program";
+    private const string ServiceType = "CSharpRepl.InjectedHook.TestTarget.Service";
 
     [Fact(Timeout = 180_000)]
     public async Task RunAsync_DrivesAFullInspectSession_AgainstAHookedProcess()
@@ -61,6 +62,24 @@ public class RemoteReadEvalPrintLoopTests
                 new PromptResult(true, "definitelyNotDefined", default),                  // compile error, loop survives
                 new PromptResult(true, """throw new System.InvalidOperationException("bang!");""", default),
                 new KeyPressCallbackResult("", "callback output marker"),                 // local key-binding output
+                // --- live method replacement: define a delegate, replace a live method, observe the change,
+                //     list it, then revert it — the running target's behavior changes and reverts mid-session ---
+                new PromptResult(true, $"System.Func<{ServiceType}, int, int> stub = (self, n) => 888;", default),
+                new PromptResult(true, $"#replace {ServiceType}.Compute with stub", default),
+                new PromptResult(true, "svc.Compute(111)", default),                      // detoured → 888
+                new PromptResult(true, "#patches", default),
+                new PromptResult(true, "#revert 1", default),
+                new PromptResult(true, "svc.Compute(111)", default),                      // reverted → 222
+                // --- command edge cases: usage error, engine failures, wrap, revert-all, empty listing ---
+                new PromptResult(true, "#replace BadInput", default),                     // no " with " → usage error
+                new PromptResult(true, $"#replace {ServiceType}.NoSuchMethod with stub", default), // engine Ok=false → "failed:"
+                new PromptResult(true, "#revert 999", default),                           // no such patch → revert error
+                new PromptResult(true, $"System.Func<System.Func<{ServiceType}, int, int>, {ServiceType}, int, int> wrapper = (orig, self, n) => orig(self, n) + 1000;", default),
+                new PromptResult(true, $"#wrap {ServiceType}.Compute with wrapper", default),
+                new PromptResult(true, "svc.Compute(111)", default),                      // wrapped → 222 + 1000 = 1222
+                new PromptResult(true, "#patches", default),                              // lists the wrap (patch #2)
+                new PromptResult(true, "#revert all", default),                           // → "reverted 1 patch(es)."
+                new PromptResult(true, "#patches", default),                              // → "No active patches."
                 new PromptResult(true, "exit", default));
 
             await repl.RunAsync(new Configuration());
@@ -82,6 +101,21 @@ public class RemoteReadEvalPrintLoopTests
 
             // Key-binding callback output is surfaced via standard output, like the local loop.
             Assert.Contains("callback output marker", capturedStdout.ToString());
+
+            // Live method replacement: the detour took effect (888), was listed, then reverted (222 = 111 * 2).
+            Assert.Contains("patched", output);
+            Assert.Contains("888", output);
+            Assert.Contains("#1", output);              // #patches listing / revert confirmation
+            Assert.Contains("222", output);             // original behavior after #revert
+
+            // Command edge cases, each a distinct PrintCommandResult arm rendered through the real loop:
+            Assert.Contains("Usage:", output);                  // "#replace BadInput" → usage error
+            Assert.Contains("failed", output);                  // "#replace …NoSuchMethod" → engine Ok=false
+            Assert.Contains("No active patch with id", output); // "#revert 999" → revert error
+            Assert.Contains("wrapped", output);                 // "#wrap" success
+            Assert.Contains("1222", output);                    // wrapped result (orig 222 + 1000)
+            Assert.Contains("patch(es)", output);               // "#revert all" → "reverted N patch(es)."
+            Assert.Contains("No active patches.", output);      // empty "#patches" after revert-all
 
             // The committed `var` advanced the controller's remote workspace: the editor sees it afterwards.
             var completions = await roslyn.CompleteAsync("svc.", 4, cancellationToken);


### PR DESCRIPTION
Use MonoMod.RuntimeDetour allow live patching of methods in inspected processes.

Adds a few new commands (only in `inspect` mode), like `#replace` and `#wrap` for replacing methods and wrapping them, as well as supporting commands `#patches` to list replaced/wrapped methods and `#revert` to undo previous patches.

Also includes a `ReplaceMethodCompletionProvider` so we can get autocompletion on the above commands.