### PR TITLE
Fix double-enter required for `exit` command

### DIFF
--- a/CSharpRepl/CSharpReplPromptCallbacks.cs
+++ b/CSharpRepl/CSharpReplPromptCallbacks.cs
@@ -283,7 +283,19 @@ internal class CSharpReplPromptCallbacks(IConsoleService console, RoslynServices
     }
 
     protected override Task<bool> ConfirmCompletionCommit(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
-        => roslyn.ConfirmCompletionCommit(text, caret, keyPress, cancellationToken);
+    {
+        // When a REPL command (exit/clear/help) is already fully typed and the user presses the submit key,
+        // committing the open completion would just re-insert the identical text — a no-op that swallows the
+        // Enter and forces a second press to actually run the command. Decline the commit so a single Enter
+        // submits straight away. Partially-typed input (e.g. "exi") still commits, completing it to the keyword.
+        if (configuration.KeyBindings.SubmitPrompt.Matches(keyPress.ConsoleKeyInfo) &&
+            ReplKeywordCompletionItems.IsFullyTypedKeyword(text))
+        {
+            return Task.FromResult(false);
+        }
+
+        return roslyn.ConfirmCompletionCommit(text, caret, keyPress, cancellationToken);
+    }
 
     protected override async Task<(string Text, int Caret)> FormatInput(string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
     {
@@ -490,7 +502,12 @@ internal class CSharpReplPromptCallbacks(IConsoleService console, RoslynServices
             displayText: clearFormattedString,
             getExtendedDescription: _ => Task.FromResult(new FormattedString("Clear the terminal screen.")));
 
-        public static IReadOnlyList<CompletionItem> AllItems = [Help, Exit, Clear];
+        public static IReadOnlyCollection<CompletionItem> AllItems = [Help, Exit, Clear];
+
+        private static readonly HashSet<string> replacementTexts =
+            AllItems.Select(i => i.ReplacementText).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        public static bool IsFullyTypedKeyword(string text) => replacementTexts.Contains(text.Trim());
     }
 }
 

--- a/Tests/CSharpRepl.Tests/PromptConfigurationTests.cs
+++ b/Tests/CSharpRepl.Tests/PromptConfigurationTests.cs
@@ -121,6 +121,49 @@ public class PromptConfigurationTests : IAsyncLifetime
         Assert.False(string.IsNullOrEmpty(result!.Output));
     }
 
+    [Theory]
+    [InlineData("exit")]
+    [InlineData("clear")]
+    [InlineData("help")]
+    [InlineData("EXIT")]    // dispatch is case-insensitive, so the menu offers (and we decline committing) "exit" here too
+    [InlineData("  exit  ")] // surrounding whitespace is trimmed before the command is dispatched
+    public async Task ConfirmCompletionCommit_FullyTypedReplKeyword_DeclinesSoEnterSubmits(string text)
+    {
+        // Pressing Enter on a fully-typed REPL command must NOT commit the (identical) completion — otherwise the
+        // Enter is swallowed and the user has to press it twice. Declining the commit lets the single Enter submit.
+        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
+        var enterKey = new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.Enter, shift: false, alt: false, control: false));
+
+        var shouldCommit = await configuration.ConfirmCompletionCommit(text, text.Length, enterKey, CancellationToken.None);
+
+        Assert.False(shouldCommit);
+    }
+
+    [Theory]
+    [InlineData("exi")]      // partially typed: Enter should still complete it to "exit"
+    [InlineData("Console")]  // ordinary code: not a REPL command
+    public async Task ConfirmCompletionCommit_NonFullyTypedKeyword_CommitsAsUsual(string text)
+    {
+        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
+        var enterKey = new KeyPress(new ConsoleKeyInfo('\0', ConsoleKey.Enter, shift: false, alt: false, control: false));
+
+        var shouldCommit = await configuration.ConfirmCompletionCommit(text, text.Length, enterKey, CancellationToken.None);
+
+        Assert.True(shouldCommit);
+    }
+
+    [Fact]
+    public async Task ConfirmCompletionCommit_FullyTypedReplKeyword_NonSubmitKey_CommitsAsUsual()
+    {
+        // Tab isn't the submit key, so committing "exit" via Tab has no double-press downside — keep default behavior.
+        IPromptCallbacks configuration = new CSharpReplPromptCallbacks(console, services, new Configuration());
+        var tabKey = new KeyPress(new ConsoleKeyInfo('\t', ConsoleKey.Tab, shift: false, alt: false, control: false));
+
+        var shouldCommit = await configuration.ConfirmCompletionCommit("exit", 4, tabKey, CancellationToken.None);
+
+        Assert.True(shouldCommit);
+    }
+
     public static IEnumerable<object[]> KeyPresses()
     {
         yield return new object[] { new ConsoleKeyInfo('\0', ConsoleKey.F1, shift: false, alt: false, control: false) };


### PR DESCRIPTION
Fix an annoyance around the `exit` command: we have "exit" as a completion menu item, but this means that when we type exit, we need to press enter twice to actually exit. Once to accept the completion, and once to actually submit the exit command and exit.

Fix this by auto-committing the exit when the word "exit" is fully typed. Also works for `clear` and `help`.