### PR TITLE
Switch to Centralized Package Management (and also a minor Spectre.Console upgrade)

### DIFF
--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
     <PackageReference Include="PrettyPrompt" Version="6.0.3" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-    <PackageReference Include="Spectre.Console.Ansi" Version="0.57.0" />
+    <PackageReference Include="Spectre.Console.Ansi" Version="0.57.1" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
   </ItemGroup>

--- a/CSharpRepl.Services/CSharpRepl.Services.csproj
+++ b/CSharpRepl.Services/CSharpRepl.Services.csproj
@@ -1,20 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="10.1.0.8386" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
+    <PackageReference Include="Ben.Demystifier" />
+    <PackageReference Include="ICSharpCode.Decompiler" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <PackageReference Include="Microsoft.Build.Locator" />
     <!--
       Microsoft.Build.Framework arrives transitively via Microsoft.CodeAnalysis.Workspaces.MSBuild.
       We use MSBuildLocator (RegisterDefaults) to load MSBuild from the installed .NET SDK at
@@ -24,28 +24,28 @@
       The same is required for Microsoft.NET.StringTools, a dependency of Microsoft.Build.Framework.
       See https://aka.ms/msbuild/locator/diagnostics/MSBL001
     -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.StringTools" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <!--
       Microsoft.CodeAnalysis.Workspaces.MSBuild depends on Microsoft.Extensions.{Logging, DependencyInjection} at 9.0. When a user references a shared framework
       (e.g. `-f Microsoft.AspNetCore.App`) their code requests 10.0, our copies are found it throws a FileLoadException. Set these at 10.0 to fix that. See issue #414.
     -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.SymbolStore" Version="1.0.731901" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageReference Include="PrettyPrompt" Version="6.0.3" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-    <PackageReference Include="Spectre.Console.Ansi" Version="0.57.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.SymbolStore" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="PrettyPrompt" />
+    <PackageReference Include="Spectre.Console.Cli" />
+    <PackageReference Include="Spectre.Console.Ansi" />
+    <PackageReference Include="System.IO.Abstractions" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
 
   <!--
@@ -55,17 +55,17 @@
 	https://github.com/OmniSharp/omnisharp-roslyn/commit/efeafeca33abe1d19659ed8c7ebab1d7c3481188
 	-->
   <ItemGroup>
-    <PackageReference Include="NuGet.Common" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Commands" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Credentials" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Configuration" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.DependencyResolver.Core" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Frameworks" Version="7.6.0" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.LibraryModel" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.ProjectModel" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" PrivateAssets="all" />
-    <PackageReference Include="NuGet.Versioning" Version="7.6.0" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Common" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Commands" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Credentials" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Configuration" PrivateAssets="all" />
+    <PackageReference Include="NuGet.DependencyResolver.Core" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Frameworks" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.LibraryModel" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Packaging" PrivateAssets="all" />
+    <PackageReference Include="NuGet.ProjectModel" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Protocol" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpRepl.slnx
+++ b/CSharpRepl.slnx
@@ -6,6 +6,10 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Solution Items/.github/">
+    <File Path=".github/codecov.yml" />
+    <File Path=".github/dependabot.yml" />
+  </Folder>
+  <Folder Name="/Solution Items/.github/workflows/">
     <File Path=".github/workflows/main.yml" />
     <File Path=".github/workflows/release.yml" />
   </Folder>

--- a/CSharpRepl/CSharpRepl.csproj
+++ b/CSharpRepl/CSharpRepl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>0.9.0</Version>
@@ -25,16 +25,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrettyPrompt" Version="6.0.3" />
-    <PackageReference Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.9" />
+    <PackageReference Include="PrettyPrompt" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir; they're loaded from the SDK via
          MSBuildLocator at runtime. Required transitively through CSharpRepl.Services.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.StringTools" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,52 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="10.1.0.8386" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.7.1" />
+    <PackageVersion Include="Microsoft.SymbolStore" Version="1.0.731901" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageVersion Include="MonoMod.RuntimeDetour" Version="25.3.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Common" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Configuration" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Credentials" Version="7.6.0" />
+    <PackageVersion Include="NuGet.DependencyResolver.Core" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="7.6.0" />
+    <PackageVersion Include="NuGet.LibraryModel" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
+    <PackageVersion Include="PrettyPrompt" Version="6.0.3" />
+    <PackageVersion Include="Spectre.Console.Ansi" Version="0.57.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.57.1" />
+    <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
+    <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
+    <PackageVersion Include="System.Management" Version="10.0.0" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.9" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0-pre.128" />
+  </ItemGroup>
+</Project>

--- a/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/CSharpRepl.InjectedHook.ScriptEngine.csproj
+++ b/InjectedHook/CSharpRepl.InjectedHook.ScriptEngine/CSharpRepl.InjectedHook.ScriptEngine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!--
     The Roslyn scripting engine. Loaded into the isolated EngineALC (never the target's default ALC), so
@@ -15,14 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
     <!--
       Live method replacement (#replace). Detours target methods to REPL-defined delegates. Loaded into the
       isolated EngineALC; its closure (MonoMod.Core/Utils/Backports/ILHelpers) is staged with the engine and
       resolved by EngineLoadContext. Detours redirect native code, so they cross the engine-ALC/target-ALC
       boundary — the detour rewrites native code, not managed references.
     -->
-    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.4" />
+    <PackageReference Include="MonoMod.RuntimeDetour" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
+++ b/Tests/CSharpRepl.Benchmarks/CSharpRepl.Benchmarks.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="BenchmarkDotNet" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
          arrives transitively through the CSharpRepl.Services project reference.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.StringTools" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/Tests/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/Tests/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,19 +15,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PrettyPrompt" Version="6.0.3" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.57.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.128" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="PrettyPrompt" />
+    <PackageReference Include="Spectre.Console.Testing" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <!-- Keep MSBuild/StringTools assemblies out of the output dir (loaded from the SDK via MSBuildLocator);
          arrives transitively through the CSharpRepl.Services project reference.
          See https://aka.ms/msbuild/locator/diagnostics/MSBL001 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.StringTools" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/Tests/CSharpRepl.Tests/CSharpRepl.Tests.csproj
+++ b/Tests/CSharpRepl.Tests/CSharpRepl.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="PrettyPrompt" Version="6.0.3" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.57.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.57.1" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.128" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />

--- a/Tests/CSharpRepl.Tests/Data/Directory.Packages.props
+++ b/Tests/CSharpRepl.Tests/Data/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+  <!--
+    These are throwaway test-fixture/demo projects (sln/slnx/csproj inputs that the unit/integration
+    tests build on demand), NOT part of the shipped solution. They pin their own PackageReference
+    versions inline, so opt this whole subtree out of Central Package Management. NuGet uses the nearest
+    Directory.Packages.props walking up (it does not merge), so this shadows the repo-root one and stops
+    it from forcing CPM (and the resulting NU1008) onto the fixtures.
+
+    This file is copied alongside the fixtures into bin\...\Data\ via the test project's
+    Content Include="Data\**", so it also covers the copies built in-place at test time
+    (e.g. InspectorTestSupport.BuildTestTarget against the TestTarget under bin\...\Data\).
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Switch to Centralized Package Management. Solutions and projects that are "test data" for our integration tests are excluded via a Directory.Packages.props inside the test data folder.
- Other minor updates:
    - Update Spectre Console dependency (minor update)
    - Sync Solution Items in slnx file.